### PR TITLE
getUrlExtension method slightly modified

### DIFF
--- a/src/utility/getUrlExtension.ts
+++ b/src/utility/getUrlExtension.ts
@@ -1,10 +1,10 @@
 export default function getUrlExtension(url: string): string {
-	const extension = url.split('.').pop()?.split(/[#?]/).pop();
+  	const extension = url.split(/[#?]/)[0]?.split('.').pop()?.trim();
 
-	if (extension?.contains(url)) {
+	if (extension == undefined) {
 		// Extraction failed
-		return "";
+		return '';
 	}
 
-	return extension ?? "";
+	return extension;
 }


### PR DESCRIPTION
The URL of my Cortex Podcast has a url from which the file extension is not cleanly readable. For this reason a file path is generated which can not be created.

The URL of the podcast episode is the following:

https://content.libsyn.com/p/2/9/7/2976089b68a44701/Cortex_131.mp3? c_id=132998295&cs_id=132998295&response-content-type=audio%2Fmpeg&Expires=1661533184&Signature=f0yT1HUuQf3mmD25H7Z2EDegXNDGcYIgQK4KH2z- jWe4uqd7i~ZpCY~ygbKqRbVT4LHnsw48ok7sGASwizpS3N~wTWecd4NN2T3jlYFrj6o8Fa511acIOEraWc0zARFoj9pmxSZOvJZUpwD0Is4oAoNmMkCyMpz9aC0Y5W3QgHWxUfVMon58st0uEpLMJy3RGSLwnJaeNZhU1l1IvXfIFEwRTcU3t3dLk2- WLfV1fgS0hhXNH0DXNk37nyrvE5m5Tm9DM15oFsNQlujB24mMGxZcEeD~8ELdxGIzZMgb3Jm0nnNkV~RbInyrLfqMgGy9vtU6DUC1UtlLYLhI~9BmQ__&Key-Pair-Id=K1YS7LZGUP96OI

The current implementation cannot read the file extension cleanly from this URL