### PR TITLE
Add content field to episode

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -23,6 +23,7 @@ export interface Episode {
 	streamUrl: string
 	url: string,
 	description: string,
+	content: string,
 	podcastName: string,
 	feedUrl?: string,
 	artworkUrl?: string;

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -19,6 +19,9 @@ This template will be used to create the note text. You can use the following sy
 - `{{safeTitle}}`: The title of the podcast episode, but with all special characters removed (like `{{title}}` in file path templates).
 - `{{description}}`: The description of the podcast episode.
 	-  You can use `{{description:> }}` to prepend each new line with a `>` (to put the entire description in a blockquote).
+- `{{content}}`: The content of the podcast episode from `<content:encoded>`. Show notes will sometimes land here.
+	-  You can use `{{content:> }}` to prepend each new line with a `>` (to put the entire content in a blockquote).
+
 - `{{podcast}}`: The name of the podcast.
 - `{{url}}`: The URL of the podcast episode.
 - `{{date}}`: The publish date of the podcast episode.

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -70,6 +70,16 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 
 			return htmlToMarkdown(episode.description)
 		});
+	addTag('content', (prependToLines?: string) => {
+			if (prependToLines) {
+				return htmlToMarkdown(episode.content)
+					.split("\n")
+					.map((str) => `${prependToLines}${str}`)
+					.join("\n")
+			}
+
+			return htmlToMarkdown(episode.content)
+	});
 	addTag('safetitle', replaceIllegalFileNameCharactersInString(episode.title));
 	addTag('url', episode.url);
 	addTag('date', (format?: string) => episode.episodeDate ?

--- a/src/main.ts
+++ b/src/main.ts
@@ -290,6 +290,7 @@ export default class PodNotes extends Plugin implements IPodNotes {
 							const localEpisode: Episode = {
 								title: file.basename,
 								description: "",
+								content: "",
 								podcastName: "local file",
 								url: app.fileManager.generateMarkdownLink(
 									file,

--- a/src/parser/feedParser.ts
+++ b/src/parser/feedParser.ts
@@ -82,6 +82,7 @@ export default class FeedParser {
 		const streamUrlEl = item.querySelector("enclosure");
 		const linkEl = item.querySelector("link");
 		const descriptionEl = item.querySelector("description");
+		const contentEl = item.querySelector("*|encoded")
 		const pubDateEl = item.querySelector("pubDate");
 		const itunesImageEl = item.querySelector("image");
 
@@ -94,6 +95,7 @@ export default class FeedParser {
 		const streamUrl = streamUrlEl.getAttribute("url") || "";
 		const url = linkEl?.textContent || "";
 		const description = descriptionEl?.textContent || "";
+		const content = contentEl?.textContent || "";
 		const pubDate = new Date(pubDateEl.textContent as string);
 		const artworkUrl = itunesImageEl?.getAttribute("href") || this.feed?.artworkUrl;
 
@@ -102,6 +104,7 @@ export default class FeedParser {
 			streamUrl,
 			url: url || this.feed?.url || "",
 			description,
+			content,
 			podcastName: this.feed?.title || "",
 			artworkUrl,
 			episodeDate: pubDate,

--- a/src/parser/pcastParser.ts
+++ b/src/parser/pcastParser.ts
@@ -19,6 +19,7 @@ export class PocketCastsParser extends Parser {
         const {title, podcastName} = this.parseTitleAndPodcastName(headingEl.innerText, titleEl.getAttribute('content') || "");
 		const url = urlEl?.getAttribute('content') || "";
 		const description = descriptionEl?.getAttribute('content') || "";
+		const content = "";
 		const streamUrl = audioPlayerEl?.getAttribute('src');
 		const episodeDate = episodeDateEl?.textContent;
 		const artwork = artworkEl?.item(0)?.getAttribute('src') || undefined;
@@ -36,6 +37,7 @@ export class PocketCastsParser extends Parser {
 			episodeDate: (episodeDate && new Date(episodeDate)) || undefined,
 			artworkUrl: artwork,
 			description,
+			content,
 			feedUrl: rssLink?.getAttribute('href') || undefined,
 		};
 	}

--- a/src/types/Episode.ts
+++ b/src/types/Episode.ts
@@ -3,6 +3,7 @@ export interface Episode {
 	streamUrl: string
 	url: string,
 	description: string,
+	content: string,
 	podcastName: string,
 	feedUrl?: string,
 	artworkUrl?: string;

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -233,6 +233,7 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 function getRandomEpisode(): Episode {
 	const fallbackDemoObj = {
 		description: "demo",
+		content: "demo",
 		podcastName: "demo",
 		title: "demo",
 		url: "demo",


### PR DESCRIPTION
    Extract and expose <content:encoded> as {{content}}

    Shows will often put the show notes in the <content:encoded> field.