### PR TITLE
fix: make images undraggable

### DIFF
--- a/src/ui/common/Image.svelte
+++ b/src/ui/common/Image.svelte
@@ -23,6 +23,7 @@
 <div class="pn_image_container">
 	<img 
 		on:click={e => onClick(e)} 
+		draggable="false"
 		{src} 
 		{alt} 
 		class={_class}


### PR DESCRIPTION
fixes 3d press not showing context menu, but starting drag action on mobile devices

fix #70
