### PR TITLE
Fix spaces in a url and local file name

### DIFF
--- a/src/URIHandler.ts
+++ b/src/URIHandler.ts
@@ -29,7 +29,7 @@ export default async function podNotesURIHandler(
 	}
 	
 	const decodedUrl = url.replace(/\+/g, " ");
-  const localFile = app.vault.getAbstractFileByPath(decodedUrl);
+	const localFile = app.vault.getAbstractFileByPath(decodedUrl);
 
 	let episode: Episode | undefined;
 

--- a/src/URIHandler.ts
+++ b/src/URIHandler.ts
@@ -27,8 +27,9 @@ export default async function podNotesURIHandler(
 
 		return;
 	}
-
-	const localFile = app.vault.getAbstractFileByPath(url);
+	
+	const decodedUrl = url.replace(/\+/g, " ");
+  const localFile = app.vault.getAbstractFileByPath(decodedUrl);
 
 	let episode: Episode | undefined;
 


### PR DESCRIPTION
If url contained spaces they were changed to a plus sign. so such a file could not be found in a storage. So, we need to change plus sign before looking for a file.