### PR TITLE
Bugfix: Handle periods in podcastName and multiple newline issues in YAML format

### DIFF
--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -77,14 +77,15 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 
 	addTag("title", episode.title);
 	addTag("description", (prependToLines?: string) => {
+		const sanitizeDescription = reduceMultipleNewlines(episode.description);
 		if (prependToLines) {
-			return htmlToMarkdown(episode.description)
+			return htmlToMarkdown(sanitizeDescription)
 				.split("\n")
 				.map((str) => `${prependToLines}${str}`)
 				.join("\n");
 		}
 
-		return htmlToMarkdown(episode.description);
+		return htmlToMarkdown(sanitizeDescription);
 	});
 	addTag("content", (prependToLines?: string) => {
 		if (prependToLines) {
@@ -203,4 +204,8 @@ function replaceIllegalFileNameCharactersInString(string: string) {
 		.replace(/[\\,#%&{}/*<>$'":@\u2023|\\.]*/g, "") // Replace illegal file name characters with empty string
 		.replace(/\n/, " ") // replace newlines with spaces
 		.replace("  ", " "); // replace multiple spaces with single space to make sure we don't have double spaces in the file name
+}
+
+function reduceMultipleNewlines(description: string) {
+	return description.replace(/\n{3,}/g, "\n\n");
 }

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -197,7 +197,7 @@ export function DownloadPathTemplateEngine(template: string, episode: Episode) {
 
 function replaceIllegalFileNameCharactersInString(string: string) {
 	return string
-		.replace(/[\\,#%&{}/*<>$'":@\u2023|?]*/g, "") // Replace illegal file name characters with empty string
+		.replace(/[\\,#%&{}/*<>$'":@\u2023|\\.]*/g, "") // Replace illegal file name characters with empty string
 		.replace(/\n/, " ") // replace newlines with spaces
 		.replace("  ", " "); // replace multiple spaces with single space to make sure we don't have double spaces in the file name
 }

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -106,7 +106,10 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 			? window.moment(episode.episodeDate).format(format ?? "YYYY-MM-DD")
 			: ""
 	);
-	addTag("podcast", episode.podcastName);
+	addTag(
+		"podcast",
+		replaceIllegalFileNameCharactersInString(episode.podcastName)
+	);
 	addTag("artwork", episode.artworkUrl ?? "");
 
 	return replacer(template);


### PR DESCRIPTION
some podcast has "." in their name as [Hieu.tv](https://open.spotify.com/show/4wHBViHYk6eG53SAuvU7vr?si=684ce3da050e4731) and it should be sanitize.
also with description usually has multiple line like
```
Trong tập ngày hôm nay tôi sẽ cùng các anh chị phân tích chi tiết về tính bảo mật và ẩn danh của Bitcoin - khía cạnh quan trọng mà những người ủng hộ Bitcoin thường sử dụng để làm nền tảng tranh luận rằng bitcoin vượt trội hơn với các công cụ tài chính truyền thống khác.

  

KHOÁ HỌC ĐẦU TƯ 2023 ĐÃ KHAI GIẢNG...
``` 
and it just broken yaml when people using {{description}} => I reduce it. All tested and it works! Please merge it❤️!