### PR TITLE
Fix: undefined with unplayed episode when mark as play

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -73,7 +73,7 @@ export const playedEpisodes = (function () {
 		},
 		markAsPlayed: (episode: Episode) => {
 			update((playedEpisodes) => {
-				const playedEpisode = playedEpisodes[episode.title];
+				const playedEpisode = playedEpisodes[episode.title] || episode;
 
 				if (playedEpisode) {
 					playedEpisode.time = playedEpisode.duration;
@@ -86,7 +86,7 @@ export const playedEpisodes = (function () {
 		},
 		markAsUnplayed: (episode: Episode) => {
 			update((playedEpisodes) => {
-				const playedEpisode = playedEpisodes[episode.title];
+				const playedEpisode = playedEpisodes[episode.title] || episode;
 
 				if (playedEpisode) {
 					playedEpisode.time = 0;
@@ -241,13 +241,13 @@ export const localFiles = function () {
 		set,
 		getLocalEpisode: (title: string): LocalEpisode | undefined => {
 			const ep =  get(store).episodes.find(ep => ep.title === title);
-			
+
 			return ep as LocalEpisode;
 		},
 		updateStreamUrl: (title: string, newUrl: string): void => {
 			store.update((playlist) => {
 				const idx = playlist.episodes.findIndex(ep => ep.title === title);
-				
+
 				if (idx !== -1) playlist.episodes[idx].streamUrl = newUrl;
 
 				return playlist;


### PR DESCRIPTION
The bug happens when I tried to mark an episode which I did not play with PodNotes but Spotify. So the data in the store was undefined at the markAsUnplayed, markAsPlayed functions then result the plugin can not perform open context menu again until next reload.