### PR TITLE
docs(TemplateEngine): Add documentation for added {{stream}} tag to template

### DIFF
--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -29,3 +29,4 @@ This template will be used to create the note text. You can use the following sy
 - `{{date}}`: The publish date of the podcast episode.
 	- You can use `{{date:format}}` to specify a custom [Moment.js](https://momentjs.com) format. E.g. `{{date:YYYY-MM-DD}}`.
 - `{{artwork}}`: The URL of the podcast artwork. If no artwork is found, an empty string will be used.
+- `{{stream}}`: The URL of the podcast audio file for the episode.

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -100,7 +100,7 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 		return htmlToMarkdown(episode.content);
 	});
 	addTag("safetitle", replaceIllegalFileNameCharactersInString(episode.title));
-	addTag("stream", episode.streamUrl);
+	addTag("stream", episode.streamUrl ?? "");
 	addTag("url", episode.url);
 	addTag("date", (format?: string) =>
 		episode.episodeDate

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -215,6 +215,8 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 						"\nPublishDate:: {{date:YYYY-MM-DD}}" +
 						"\n### Description" +
 						"\n> {{description}}",
+					    "\n### Audio File URL" +
+						"\n> {{stream}}",
 				);
 			});
 


### PR DESCRIPTION
Added documentation both on the settings and in the documentation. 

I **did not verify** if I made any syntax typo on my end. 
Also changed the previous change for the off-chance that a podcast has an empty stream? Can this ever happen?

TODO:
- [ ] Check if the audio file is parsable and include that