### PR TITLE
Fix download extension detection

### DIFF
--- a/src/utility/getExtensionFromContentType.test.ts
+++ b/src/utility/getExtensionFromContentType.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import getExtensionFromContentType from "./getExtensionFromContentType";
+
+describe("getExtensionFromContentType", () => {
+	test("detects mp3 from standard mime type", () => {
+		expect(getExtensionFromContentType("audio/mpeg")).toBe("mp3");
+	});
+
+	test("handles mixed case mime types", () => {
+		expect(getExtensionFromContentType("Audio/X-M4A")).toBe("m4a");
+	});
+
+	test("returns null when mime type is not audio", () => {
+		expect(getExtensionFromContentType("text/html")).toBeNull();
+	});
+});

--- a/src/utility/getExtensionFromContentType.ts
+++ b/src/utility/getExtensionFromContentType.ts
@@ -1,0 +1,34 @@
+const CONTENT_TYPE_EXTENSION_MAP: Array<{
+	pattern: RegExp;
+	extension: string;
+}> = [
+	{ pattern: /audio\/mpeg/i, extension: "mp3" },
+	{ pattern: /audio\/mp3/i, extension: "mp3" },
+	{ pattern: /audio\/mp4/i, extension: "m4a" },
+	{ pattern: /audio\/x-m4a/i, extension: "m4a" },
+	{ pattern: /audio\/aac/i, extension: "aac" },
+	{ pattern: /audio\/ogg/i, extension: "ogg" },
+	{ pattern: /audio\/wav/i, extension: "wav" },
+	{ pattern: /audio\/x-wav/i, extension: "wav" },
+	{ pattern: /audio\/flac/i, extension: "flac" },
+	{ pattern: /audio\/x-flac/i, extension: "flac" },
+	{ pattern: /audio\/x-ms-wma/i, extension: "wma" },
+	{ pattern: /audio\/wma/i, extension: "wma" },
+	{ pattern: /audio\/amr/i, extension: "amr" },
+];
+
+export default function getExtensionFromContentType(
+	contentType?: string | null,
+): string | null {
+	if (!contentType) {
+		return null;
+	}
+
+	for (const { pattern, extension } of CONTENT_TYPE_EXTENSION_MAP) {
+		if (pattern.test(contentType)) {
+			return extension;
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary
- ensure the notice download path falls back to URL and MIME detection before erroring out
- share a content-type to extension helper with the legacy path and add tests