### PR TITLE
Add timestamp offset setting

### DIFF
--- a/src/API/API.ts
+++ b/src/API/API.ts
@@ -38,14 +38,20 @@ export class API implements IAPI {
 	 * Gets the current time in the given moment format.
 	 * @param format Moment format.
 	 * @param linkify Linking to the podcast so PodNotes can open it at this time later.
+	 * @param offsetSeconds Optional offset to subtract from the current playback time.
 	 * @returns
 	 */
-	getPodcastTimeFormatted(format: string, linkify = false): string {
+	getPodcastTimeFormatted(
+		format: string,
+		linkify = false,
+		offsetSeconds = 0,
+	): string {
 		if (!this.podcast) {
 			throw new Error("No podcast loaded");
 		}
 
-		const time = formatSeconds(this.currentTime, format);
+		const adjustedTime = Math.max(0, this.currentTime - offsetSeconds);
+		const time = formatSeconds(adjustedTime, format);
 
 		if (!linkify) return time;
 
@@ -63,7 +69,7 @@ export class API implements IAPI {
 		const url = encodePodnotesURI(
 			this.podcast.title,
 			feedUrl,
-			this.currentTime
+			adjustedTime,
 		);
 
 		return `[${time}](${url.href})`;

--- a/src/API/IAPI.ts
+++ b/src/API/IAPI.ts
@@ -6,7 +6,11 @@ export interface IAPI {
 	readonly length: number;
 	currentTime: number;
 
-	getPodcastTimeFormatted(format: string, linkify?: boolean): string;
+	getPodcastTimeFormatted(
+		format: string,
+		linkify?: boolean,
+		offsetSeconds?: number,
+	): string;
 	
 	start(): void;
 	stop(): void;

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -117,12 +117,14 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 
 export function TimestampTemplateEngine(template: string) {
 	const [replacer, addTag] = useTemplateEngine();
+	const { api, settings } = get(plugin);
+	const timestampOffset = settings.timestamp.offset ?? 0;
 
 	addTag("time", (format?: string) =>
-		get(plugin).api.getPodcastTimeFormatted(format ?? "HH:mm:ss"),
+		api.getPodcastTimeFormatted(format ?? "HH:mm:ss", false, timestampOffset),
 	);
 	addTag("linktime", (format?: string) =>
-		get(plugin).api.getPodcastTimeFormatted(format ?? "HH:mm:ss", true),
+		api.getPodcastTimeFormatted(format ?? "HH:mm:ss", true, timestampOffset),
 	);
 
 	return replacer(template);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,7 @@ export const DEFAULT_SETTINGS: IPodNotesSettings = {
 
 	timestamp: {
 		template: "- {{time}} ",
+		offset: 0,
 	},
 
 	note: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -340,7 +340,13 @@ export default class PodNotes extends Plugin implements IPodNotes {
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		const loadedData = await this.loadData();
+
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedData);
+		this.settings.timestamp = {
+			...DEFAULT_SETTINGS.timestamp,
+			...(loadedData?.timestamp ?? {}),
+		};
 	}
 
 	async saveSettings() {

--- a/src/types/IPodNotesSettings.ts
+++ b/src/types/IPodNotesSettings.ts
@@ -20,6 +20,7 @@ export interface IPodNotesSettings {
 
 	timestamp: {
 		template: string;
+		offset: number;
 	};
 
 	note: {

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -160,6 +160,26 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 			);
 		};
 
+		new Setting(container)
+			.setName("Timestamp offset (s)")
+			.setDesc(
+				"Subtract this many seconds when capturing a timestamp to compensate for reaction time.",
+			)
+			.addText((textComponent) => {
+				textComponent.inputEl.type = "number";
+				textComponent
+					.setValue(`${this.plugin.settings.timestamp.offset}`)
+					.onChange((value) => {
+						const parsedValue = Number.parseInt(value, 10);
+						this.plugin.settings.timestamp.offset = Number.isNaN(parsedValue)
+							? 0
+							: Math.max(0, parsedValue);
+						this.plugin.saveSettings();
+						updateTimestampDemo(this.plugin.settings.timestamp.template);
+					})
+					.setPlaceholder("e.g. 5");
+			});
+
 		updateTimestampDemo(this.plugin.settings.timestamp.template);
 
 		const randomEpisode = getRandomEpisode();


### PR DESCRIPTION
Adds a timestamp offset setting applied to captured timestamps and links. Settings UI now exposes the offset with defaults to keep existing configs working. Tests not run (not requested).