### PR TITLE
Add stable keys to podcast lists

### DIFF
--- a/src/ui/PodcastView/EpisodeList.svelte
+++ b/src/ui/PodcastView/EpisodeList.svelte
@@ -67,7 +67,7 @@
 		{#if episodes.length === 0}
 			<p>No episodes found.</p>
 		{/if}
-		{#each episodes as episode}
+		{#each episodes as episode (episode.url || episode.streamUrl || `${episode.title}-${episode.episodeDate ?? ""}`)}
 			{@const episodePlayed = $playedEpisodes[episode.title]?.finished}
 			{#if !hidePlayedEpisodes || !episodePlayed}
 				<EpisodeListItem

--- a/src/ui/PodcastView/PodcastGrid.svelte
+++ b/src/ui/PodcastView/PodcastGrid.svelte
@@ -17,13 +17,13 @@
 
 <div class="podcast-grid">
 	{#if playlists.length > 0}
-		{#each playlists as playlist}
+		{#each playlists as playlist (playlist.name)}
 			<PlaylistCard playlist={playlist} on:clickPlaylist={forwardClickPlaylist} />
 		{/each}
 	{/if}
 
 	{#if feeds.length > 0}
-		{#each feeds as feed}
+		{#each feeds as feed (feed.url)}
 			<PodcastGridCard
 				feed={feed}
 				on:clickPodcast


### PR DESCRIPTION
Add keyed #each blocks for episodes, playlists, and feeds so DOM nodes stay aligned when lists reorder. No tests were run (not requested).