### PR TITLE
Reuse Fuse instance for episode search

### DIFF
--- a/src/utility/searchEpisodes.ts
+++ b/src/utility/searchEpisodes.ts
@@ -1,21 +1,37 @@
 import Fuse from "fuse.js";
 import type { Episode } from "src/types/Episode";
 
+const fuseOptions = {
+    shouldSort: true,
+    findAllMatches: true,
+    threshold: 0.4,
+    isCaseSensitive: false,
+    keys: ["title"],
+};
+
+const fuseCache = new WeakMap<Episode[], { fuse: Fuse<Episode>; size: number }>();
+
+function getFuse(episodes: Episode[]): Fuse<Episode> {
+    const cached = fuseCache.get(episodes);
+
+    if (cached && cached.size === episodes.length) {
+        return cached.fuse;
+    }
+
+    const newFuse = new Fuse(episodes, fuseOptions);
+    fuseCache.set(episodes, { fuse: newFuse, size: episodes.length });
+
+    return newFuse;
+}
+
 export default function searchEpisodes(query: string, episodes: Episode[]): Episode[] {
-	if (episodes.length === 0) return [];
+    if (episodes.length === 0) return [];
 
     if (query.length === 0) {
         return episodes;
-    } 
+    }
 
-    const fuse = new Fuse(episodes, {
-        shouldSort: true,
-        findAllMatches: true,
-        threshold: 0.4,
-        isCaseSensitive: false,
-        keys: ['title'],
-    });
-    
+    const fuse = getFuse(episodes);
     const searchResults = fuse.search(query);
     return searchResults.map(resItem => resItem.item);
 }


### PR DESCRIPTION
Summary:\n- memoize Fuse instances per episode list to avoid rebuilding on each query\n- refresh cached index when the list size changes