### PR TITLE
Polish PodNotes player and episode row state

### DIFF
--- a/src/parser/feedParser.test.ts
+++ b/src/parser/feedParser.test.ts
@@ -25,6 +25,7 @@ const sampleRssFeed = `<?xml version="1.0" encoding="UTF-8"?>
       <description>First episode description</description>
       <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
       <itunes:title>Episode 1 iTunes Title</itunes:title>
+      <itunes:duration>01:02:03</itunes:duration>
     </item>
     <item>
       <title>Episode 2</title>
@@ -202,6 +203,7 @@ describe("FeedParser", () => {
 			expect(episode.description).toBe("First episode description");
 			expect(episode.episodeDate).toEqual(new Date("Mon, 01 Jan 2024 00:00:00 GMT"));
 			expect(episode.itunesTitle).toBe("Episode 1 iTunes Title");
+			expect(episode.duration).toBe(3723);
 			// Feed metadata should now be populated
 			expect(episode.podcastName).toBe("Test Podcast");
 			expect(episode.feedUrl).toBe("https://example.com/feed.xml");

--- a/src/parser/feedParser.ts
+++ b/src/parser/feedParser.ts
@@ -114,6 +114,7 @@ export default class FeedParser {
 		const pubDateEl = item.querySelector("pubDate");
 		const itunesImageEl = this.findImageElement(item);
 		const itunesTitleEl = item.getElementsByTagName("itunes:title")[0];
+		const durationEl = item.getElementsByTagName("itunes:duration")[0];
 		const chaptersEl = item.getElementsByTagName("podcast:chapters")[0];
 
 		if (!titleEl || !streamUrlEl || !pubDateEl) {
@@ -140,6 +141,7 @@ export default class FeedParser {
 			podcastName: this.feed?.title || "",
 			artworkUrl,
 			episodeDate: pubDate,
+			duration: parseDuration(durationEl?.textContent),
 			feedUrl: this.feed?.url || "",
 			itunesTitle: itunesTitle || "",
 			chaptersUrl,
@@ -154,4 +156,29 @@ export default class FeedParser {
 
 		return body;
 	}
+}
+
+function parseDuration(rawDuration: string | null | undefined): number | undefined {
+	if (!rawDuration) return undefined;
+
+	const trimmedDuration = rawDuration.trim();
+	if (!trimmedDuration) return undefined;
+
+	if (/^\d+$/.test(trimmedDuration)) {
+		return Number.parseInt(trimmedDuration, 10);
+	}
+
+	const segments = trimmedDuration
+		.split(":")
+		.map((segment) => Number.parseInt(segment, 10));
+
+	if (
+		segments.length < 2 ||
+		segments.length > 3 ||
+		segments.some((segment) => Number.isNaN(segment))
+	) {
+		return undefined;
+	}
+
+	return segments.reduce((total, segment) => total * 60 + segment, 0);
 }

--- a/src/types/Episode.ts
+++ b/src/types/Episode.ts
@@ -8,6 +8,7 @@ export interface Episode {
 	feedUrl?: string,
 	artworkUrl?: string;
 	episodeDate?: Date;
+	duration?: number;
 	itunesTitle?: string;
 	/** URL to the podcast:chapters JSON file */
 	chaptersUrl?: string;

--- a/src/ui/PodcastView/EpisodeList.svelte
+++ b/src/ui/PodcastView/EpisodeList.svelte
@@ -2,16 +2,35 @@
 	import type { Episode } from "src/types/Episode";
 	import { createEventDispatcher } from "svelte";
 	import EpisodeListItem from "./EpisodeListItem.svelte";
-	import { hidePlayedEpisodes, playedEpisodes } from "src/store";
+	import {
+		downloadedEpisodes,
+		favorites,
+		hidePlayedEpisodes,
+		playedEpisodes,
+		plugin,
+		queue,
+	} from "src/store";
 	import Icon from "../obsidian/Icon.svelte";
 	import Text from "../obsidian/Text.svelte";
 	import Loading from "./Loading.svelte";
 	import { getEpisodeKey } from "src/utility/episodeKey";
-	import { isEpisodeFinished } from "src/utility/episodeStatus";
+	import { getPlayedEpisode, isEpisodeFinished } from "src/utility/episodeStatus";
 	import {
 		createEpisodeListEntries,
 		type EpisodeListEntry,
 	} from "src/utility/episodeListEntry";
+	import type DownloadedEpisode from "src/types/DownloadedEpisode";
+	import type { Playlist } from "src/types/Playlist";
+	import type { PlayedEpisode } from "src/types/PlayedEpisode";
+	import { getPodcastNote } from "src/createPodcastNote";
+
+	type EpisodeQuickAction =
+		| "play"
+		| "togglePlayed"
+		| "download"
+		| "note"
+		| "favorite"
+		| "queue";
 
 	export let episodes: Episode[] = [];
 	export let episodeEntries: EpisodeListEntry[] | null = null;
@@ -20,6 +39,7 @@
 	export let showPlayedToggle: boolean = true;
 	export let alwaysShowPlayedEpisodes: boolean = false;
 	export let isLoading: boolean = false;
+	export let noteRefreshToken: number = 0;
 	let searchInputQuery: string = "";
 	$: listEntries = episodeEntries ?? createEpisodeListEntries(episodes);
 	$: shouldHidePlayedEpisodes = $hidePlayedEpisodes && !alwaysShowPlayedEpisodes;
@@ -52,8 +72,68 @@
 		});
 	}
 
+	function forwardQuickAction(
+		entry: EpisodeListEntry,
+		event: CustomEvent<{ episode: Episode; action: EpisodeQuickAction }>,
+	) {
+		dispatch("quickActionEpisode", {
+			episode: event.detail.episode,
+			action: event.detail.action,
+			entry,
+		});
+	}
+
 	function forwardSearchInput(event: CustomEvent<{ value: string }>) {
 		dispatch("search", { query: event.detail.value });
+	}
+
+	function hasEpisode(episodes: Episode[], episode: Episode): boolean {
+		const episodeKey = getEpisodeKey(episode);
+
+		return episodes.some((candidate) => {
+			const candidateKey = getEpisodeKey(candidate);
+			return candidateKey && episodeKey
+				? candidateKey === episodeKey
+				: candidate.title === episode.title;
+		});
+	}
+
+	function isEpisodeDownloaded(
+		episode: Episode,
+		downloaded: Record<string, DownloadedEpisode[]>,
+	): boolean {
+		return Boolean(downloaded[episode.podcastName]?.some(
+			(candidate) => candidate.title === episode.title,
+		));
+	}
+
+	function isEpisodeQueued(episode: Episode, currentQueue: Playlist): boolean {
+		return hasEpisode(currentQueue.episodes, episode);
+	}
+
+	function isEpisodeFavorite(
+		episode: Episode,
+		currentFavorites: Playlist,
+	): boolean {
+		return hasEpisode(currentFavorites.episodes, episode);
+	}
+
+	function findPlayedEpisode(episode: Episode): PlayedEpisode | undefined {
+		return getPlayedEpisode($playedEpisodes, episode);
+	}
+
+	function noteExists(episode: Episode): boolean {
+		noteRefreshToken;
+
+		const pluginInstance = $plugin;
+		if (!pluginInstance?.settings?.note?.path) return false;
+		if (!("app" in globalThis)) return false;
+
+		try {
+			return Boolean(getPodcastNote(episode));
+		} catch {
+			return false;
+		}
 	}
 </script>
 
@@ -104,10 +184,16 @@
 			<EpisodeListItem
 				episode={entry.episode}
 				episodeFinished={isEpisodeFinished(entry.episode, $playedEpisodes)}
+				playedEpisode={findPlayedEpisode(entry.episode)}
 				showEpisodeImage={showThumbnails}
 				unavailableReason={entry.unavailableReason}
+				isDownloaded={isEpisodeDownloaded(entry.episode, $downloadedEpisodes)}
+				isQueued={isEpisodeQueued(entry.episode, $queue)}
+				isFavorite={isEpisodeFavorite(entry.episode, $favorites)}
+				noteExists={noteExists(entry.episode)}
 				on:clickEpisode={forwardClickEpisode.bind(null, entry)}
 				on:contextMenu={forwardContextMenuEpisode.bind(null, entry)}
+				on:quickAction={forwardQuickAction.bind(null, entry)}
 			/>
 		{/each}
 	</div>
@@ -146,16 +232,24 @@
 		flex-direction: row;
 		justify-content: flex-end;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0.375rem;
 		width: 100%;
-		padding: 0.5rem 0.75rem;
+		padding: 0.5rem 0.875rem;
 		border-bottom: 1px solid var(--background-modifier-border);
-		background: var(--background-secondary);
+		background: var(--background-primary);
 	}
 
 	.episode-list-search {
 		flex: 1 1 auto;
 		min-width: 0;
+	}
+
+	:global(.episode-list-menu .icon-button) {
+		width: 2rem;
+		height: 2rem;
+		min-height: 2rem;
+		border-radius: 0.375rem;
+		box-shadow: none !important;
 	}
 
 	.episode-list-loading {

--- a/src/ui/PodcastView/EpisodeListHeader.svelte
+++ b/src/ui/PodcastView/EpisodeListHeader.svelte
@@ -3,7 +3,7 @@
     export let artworkUrl: string = "";
 </script>
 
-<div class="podcast-header">
+<div class="podcast-header" class:podcast-header-with-artwork={artworkUrl}>
     {#if artworkUrl}
         <img id="podcast-artwork" src={artworkUrl} alt={text} />
     {/if}
@@ -13,26 +13,35 @@
 <style>
 	.podcast-header {
 		display: flex;
-		flex-direction: column;
-		justify-content: center;
+		flex-direction: row;
+		justify-content: flex-start;
 		align-items: center;
 		gap: 0.75rem;
-		padding: 1rem;
+		padding: 0.75rem 1rem;
+		border-bottom: 1px solid var(--background-modifier-border);
 	}
 
 	#podcast-artwork {
-		width: 5rem;
-		height: 5rem;
+		flex: 0 0 3.25rem;
+		width: 3.25rem;
+		height: 3.25rem;
 		border-radius: 0.5rem;
 		object-fit: cover;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 	}
 
 	.podcast-heading {
 		margin: 0;
-		font-size: 1.125rem;
+		font-size: 1rem;
 		font-weight: 600;
-		text-align: center;
+		line-height: 1.25;
+		text-align: left;
 		color: var(--text-normal);
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.podcast-header:not(.podcast-header-with-artwork) {
+		justify-content: center;
+		padding: 0.875rem 1rem;
 	}
 </style>

--- a/src/ui/PodcastView/EpisodeListItem.svelte
+++ b/src/ui/PodcastView/EpisodeListItem.svelte
@@ -1,14 +1,34 @@
 <script lang="ts">
 	import type { Episode } from "src/types/Episode";
+	import type { PlayedEpisode } from "src/types/PlayedEpisode";
+	import { formatSeconds } from "src/utility/formatSeconds";
 	import { createEventDispatcher } from "svelte";
 	import ImageLoader from "../common/ImageLoader.svelte";
+	import Icon from "../obsidian/Icon.svelte";
+
+	type EpisodeQuickAction =
+		| "play"
+		| "togglePlayed"
+		| "download"
+		| "note"
+		| "favorite"
+		| "queue";
 
 	export let episode: Episode;
 	export let episodeFinished: boolean = false;
+	export let playedEpisode: PlayedEpisode | undefined = undefined;
 	export let showEpisodeImage: boolean = false;
 	export let unavailableReason: string | undefined = undefined;
+	export let isDownloaded: boolean = false;
+	export let isQueued: boolean = false;
+	export let isFavorite: boolean = false;
+	export let noteExists: boolean = false;
 
-	const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher<{
+		clickEpisode: { episode: Episode };
+		contextMenu: { episode: Episode; event: MouseEvent };
+		quickAction: { episode: Episode; action: EpisodeQuickAction };
+	}>();
 	const dateFormatter = new Intl.DateTimeFormat("en-GB", {
 		day: "2-digit",
 		month: "long",
@@ -22,6 +42,11 @@
 
 	function onContextMenu(event: MouseEvent) {
 		dispatch("contextMenu", { episode, event });
+	}
+
+	function onQuickAction(event: MouseEvent, action: EpisodeQuickAction) {
+		event.stopPropagation();
+		dispatch("quickAction", { episode, action });
 	}
 
 	function parseEpisodeDate(rawDate?: Date | string): Date | null {
@@ -49,83 +74,230 @@
 	}
 
 	let date: string = "";
+	let durationText: string = "";
+	let progressPercent: number = 0;
+	let isPartiallyPlayed: boolean = false;
+	let canUseEpisodeActions: boolean = true;
 
 	$: date = formatEpisodeDate(episode);
+	$: durationText = formatDuration(episode.duration ?? playedEpisode?.duration);
+	$: progressPercent = getProgressPercent(playedEpisode);
+	$: isPartiallyPlayed =
+		!episodeFinished && Boolean(playedEpisode?.time && playedEpisode.time > 0);
+	$: canUseEpisodeActions = !unavailableReason;
+
+	function formatDuration(duration: number | undefined): string {
+		if (!duration || duration <= 0) return "";
+
+		return duration >= 3600
+			? formatSeconds(duration, "H:mm:ss")
+			: formatSeconds(duration, "m:ss");
+	}
+
+	function getProgressPercent(played: PlayedEpisode | undefined): number {
+		if (!played?.time || !played.duration) return 0;
+
+		return Math.min(99, Math.max(1, Math.round((played.time / played.duration) * 100)));
+	}
 </script>
 
-<button
-	type="button"
-	class="podcast-episode-item" 
-	on:click={onClickEpisode} 
+<div
+	class="podcast-episode-item"
+	class:podcast-episode-item-unavailable={unavailableReason}
+	role="group"
+	aria-label={episode.title}
 	on:contextmenu={onContextMenu}
 	title={unavailableReason ?? episode.title}
 >
-	{#if showEpisodeImage && episode?.artworkUrl} 
-		<div class="podcast-episode-thumbnail-container">
-			<ImageLoader
-				src={episode.artworkUrl}
-				alt={episode.title}
-				fadeIn={true}
-				width="100%"
-				height="100%"
-				class="podcast-episode-thumbnail"
-			/>
-		</div>
-	{:else if showEpisodeImage}
-		<div class="podcast-episode-thumbnail-container"></div>
-	{/if}
-	<div class="podcast-episode-information">
-		<span class="episode-item-date">{date}</span>
-		<span class={`episode-item-title ${episodeFinished && "strikeout"}`}>{episode.title}</span>
-		{#if unavailableReason}
-			<span class="episode-item-status">{unavailableReason}</span>
+	<button
+		type="button"
+		class="podcast-episode-main"
+		on:click={onClickEpisode}
+	>
+		{#if showEpisodeImage && episode?.artworkUrl} 
+			<div class="podcast-episode-thumbnail-container">
+				<ImageLoader
+					src={episode.artworkUrl}
+					alt={episode.title}
+					fadeIn={true}
+					width="100%"
+					height="100%"
+					class="podcast-episode-thumbnail"
+				/>
+			</div>
+		{:else if showEpisodeImage}
+			<div class="podcast-episode-thumbnail-container"></div>
 		{/if}
+		<div class="podcast-episode-information">
+			<span class="episode-item-date">{date}</span>
+			<span class="episode-item-title" class:strikeout={episodeFinished}>{episode.title}</span>
+			<div class="episode-item-meta" aria-label="Episode state">
+				{#if durationText}
+					<span class="episode-item-badge">
+						<Icon icon="clock" size={14} clickable={false} />
+						{durationText}
+					</span>
+				{/if}
+				{#if episodeFinished}
+					<span class="episode-item-badge episode-item-badge-strong">
+						<Icon icon="check" size={14} clickable={false} />
+						Played
+					</span>
+				{:else if isPartiallyPlayed}
+					<span class="episode-item-badge">
+						<Icon icon="timer" size={14} clickable={false} />
+						{progressPercent ? `${progressPercent}%` : "In progress"}
+					</span>
+				{/if}
+				{#if isDownloaded}
+					<span class="episode-item-badge" aria-label="Downloaded">
+						<Icon icon="download" size={14} clickable={false} />
+					</span>
+				{/if}
+				{#if isQueued}
+					<span class="episode-item-badge" aria-label="Queued">
+						<Icon icon="list-ordered" size={14} clickable={false} />
+					</span>
+				{/if}
+				{#if isFavorite}
+					<span class="episode-item-badge" aria-label="Favorited">
+						<Icon icon="lucide-star" size={14} clickable={false} />
+					</span>
+				{/if}
+				{#if noteExists}
+					<span class="episode-item-badge" aria-label="Podcast note exists">
+						<Icon icon="file-text" size={14} clickable={false} />
+					</span>
+				{/if}
+				{#if unavailableReason}
+					<span class="episode-item-status">{unavailableReason}</span>
+				{/if}
+			</div>
+		</div>
+	</button>
+
+	<div class="episode-quick-actions" aria-label={`Quick actions for ${episode.title}`}>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label="Play episode"
+			title="Play"
+			disabled={!canUseEpisodeActions}
+			on:click={(event) => onQuickAction(event, "play")}
+		>
+			<Icon icon="play" size={16} clickable={false} />
+		</button>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label={episodeFinished ? "Mark unplayed" : "Mark played"}
+			title={episodeFinished ? "Mark unplayed" : "Mark played"}
+			on:click={(event) => onQuickAction(event, "togglePlayed")}
+		>
+			<Icon icon={episodeFinished ? "x" : "check"} size={16} clickable={false} />
+		</button>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label={isDownloaded ? "Remove downloaded file" : "Download episode"}
+			title={isDownloaded ? "Remove file" : "Download"}
+			disabled={!canUseEpisodeActions}
+			on:click={(event) => onQuickAction(event, "download")}
+		>
+			<Icon icon={isDownloaded ? "x" : "download"} size={16} clickable={false} />
+		</button>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label={noteExists ? "Open podcast note" : "Create podcast note"}
+			title={noteExists ? "Open note" : "Create note"}
+			disabled={!canUseEpisodeActions}
+			on:click={(event) => onQuickAction(event, "note")}
+		>
+			<Icon icon={noteExists ? "file-text" : "file-plus"} size={16} clickable={false} />
+		</button>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
+			title={isFavorite ? "Remove favorite" : "Favorite"}
+			disabled={!canUseEpisodeActions}
+			on:click={(event) => onQuickAction(event, "favorite")}
+		>
+			<Icon icon="lucide-star" size={16} clickable={false} />
+		</button>
+		<button
+			type="button"
+			class="episode-quick-action"
+			aria-label={isQueued ? "Remove from queue" : "Add to queue"}
+			title={isQueued ? "Remove from queue" : "Queue"}
+			disabled={!canUseEpisodeActions}
+			on:click={(event) => onQuickAction(event, "queue")}
+		>
+			<Icon icon={isQueued ? "list-x" : "list-plus"} size={16} clickable={false} />
+		</button>
 	</div>
-</button>
+</div>
 
 <style>
 	.podcast-episode-item {
 		display: flex;
 		flex-direction: row;
-		justify-content: flex-start;
+		justify-content: space-between;
 		align-items: center;
-		padding: 0.625rem 0.75rem;
-		min-height: 4.5rem;
+		padding: 0.375rem 0.625rem 0.375rem 0.875rem;
+		min-height: 3.875rem;
 		width: 100%;
 		border: none;
 		border-bottom: 1px solid var(--background-modifier-border);
-		gap: 0.75rem;
+		gap: 0.625rem;
 		background: transparent;
 		text-align: left;
-		cursor: pointer;
-		transition: background-color 120ms ease;
 	}
 
 	.podcast-episode-item:last-child {
 		border-bottom: none;
 	}
 
-	.podcast-episode-item:focus-visible {
+	.podcast-episode-item:focus-within {
 		outline: 2px solid var(--interactive-accent);
 		outline-offset: -2px;
 		border-radius: 0.25rem;
 	}
 
-	.podcast-episode-item:hover {
+	.podcast-episode-item:hover,
+	.podcast-episode-item:focus-within {
 		background-color: var(--background-secondary-alt);
 	}
 
-	.podcast-episode-item:active {
+	.podcast-episode-item:has(.podcast-episode-main:active),
+	.podcast-episode-item:has(.episode-quick-action:active) {
 		background-color: var(--background-modifier-border);
 	}
 
-	.strikeout {
-		text-decoration: line-through;
-		opacity: 0.6;
+	.podcast-episode-item-unavailable {
+		opacity: 0.75;
 	}
 
-	.podcast-episode-item:has(.episode-item-status) {
-		opacity: 0.75;
+	.podcast-episode-main {
+		appearance: none;
+		display: flex;
+		flex: 1 1 auto;
+		align-items: center;
+		gap: 0.625rem;
+		min-width: 0;
+		width: 100%;
+		min-height: 0;
+		padding: 0;
+		margin: 0;
+		border: none !important;
+		border-radius: 0;
+		background: transparent;
+		box-shadow: none !important;
+		color: inherit;
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
 	}
 
 	.podcast-episode-information {
@@ -133,21 +305,21 @@
 		flex-direction: column;
 		justify-content: center;
 		align-items: flex-start;
-		gap: 0.25rem;
+		gap: 0.1875rem;
 		flex: 1 1 auto;
 		min-width: 0;
 	}
 
 	.episode-item-date {
-		font-size: 0.75rem;
+		font-size: 0.6875rem;
 		font-weight: 500;
-		letter-spacing: 0.025em;
+		letter-spacing: 0.04em;
 		color: var(--text-muted);
 	}
 
 	.episode-item-title {
-		font-size: 0.9rem;
-		line-height: 1.4;
+		font-size: 0.9375rem;
+		line-height: 1.3;
 		color: var(--text-normal);
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -157,10 +329,98 @@
 		-webkit-box-orient: vertical;
 	}
 
+	.strikeout {
+		text-decoration: line-through;
+		opacity: 0.6;
+	}
+
+	.episode-item-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.375rem;
+		min-height: 1rem;
+	}
+
+	.episode-item-badge,
+	.episode-item-status {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.1875rem;
+		min-height: 1rem;
+		padding: 0;
+		border: none;
+		border-radius: 0;
+		font-size: 0.75rem;
+		line-height: 1;
+		color: var(--text-muted);
+		background: transparent;
+	}
+
+	.episode-item-badge-strong {
+		color: var(--text-accent);
+		font-weight: 500;
+	}
+
+	.episode-item-status {
+		padding: 0.125rem 0.375rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 999px;
+		background: var(--background-secondary);
+	}
+
+	.episode-quick-actions {
+		display: flex;
+		flex: 0 0 auto;
+		align-items: center;
+		gap: 0.125rem;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.podcast-episode-item:hover .episode-quick-actions,
+	.podcast-episode-item:focus-within .episode-quick-actions {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	.episode-quick-action {
+		appearance: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		min-height: 1.75rem;
+		padding: 0;
+		border: none !important;
+		border-radius: 0.375rem;
+		color: var(--text-muted);
+		background: transparent;
+		box-shadow: none !important;
+		cursor: pointer;
+	}
+
+	.episode-quick-action:hover,
+	.episode-quick-action:focus-visible {
+		color: var(--text-normal);
+		background: var(--background-modifier-hover);
+	}
+
+	.episode-quick-action:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 1px;
+	}
+
+	.episode-quick-action:disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
+	}
+
 	.podcast-episode-thumbnail-container {
-		flex: 0 0 3.5rem;
-		width: 3.5rem;
-		height: 3.5rem;
+		flex: 0 0 3rem;
+		width: 3rem;
+		height: 3rem;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -171,9 +431,9 @@
 
 	@media (min-width: 400px) {
 		.podcast-episode-thumbnail-container {
-			flex: 0 0 4rem;
-			width: 4rem;
-			height: 4rem;
+			flex: 0 0 3.25rem;
+			width: 3.25rem;
+			height: 3.25rem;
 		}
 	}
 
@@ -184,8 +444,10 @@
 		border-radius: 0.375rem;
 	}
 
-	.episode-item-status {
-		font-size: 0.75rem;
-		color: var(--text-muted);
+	@media (hover: none) {
+		.episode-quick-actions {
+			opacity: 1;
+			pointer-events: auto;
+		}
 	}
 </style>

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -18,7 +18,6 @@
 	import { onDestroy, onMount } from "svelte";
 	import Icon from "../obsidian/Icon.svelte";
 	import Button from "../obsidian/Button.svelte";
-	import Slider from "../obsidian/Slider.svelte";
 	import Loading from "./Loading.svelte";
 	import EpisodeList from "./EpisodeList.svelte";
 	import ChapterList from "./ChapterList.svelte";
@@ -50,9 +49,22 @@
 
 	let isHoveringArtwork: boolean = false;
 	let isLoading: boolean = true;
+	let hasRestoredPlaybackTime: boolean = false;
 	let playerVolume: number = 1;
 	let chapters: Chapter[] = [];
 	let lastChaptersUrl: string | undefined = undefined;
+	let currentTimeText: string = "00:00:00";
+	let remainingTimeText: string = "--:--:--";
+	let progressDuration: number = 1;
+	let progressTime: number = 0;
+
+	$: progressDuration = Number.isFinite($duration) && $duration > 0 ? $duration : 1;
+	$: progressTime = Number.isFinite($currentTime) && $currentTime > 0 ? $currentTime : 0;
+	$: currentTimeText = formatSeconds(progressTime, "HH:mm:ss");
+	$: remainingTimeText =
+		Number.isFinite($duration) && $duration > 0
+			? formatSeconds(Math.max(0, $duration - progressTime), "HH:mm:ss")
+			: "--:--:--";
 
 	function togglePlayback() {
 		isPaused.update((value) => !value);
@@ -61,6 +73,8 @@
 	function onClickProgressbar(
 		{ detail: { event, percent } }: CustomEvent<{ event: MouseEvent | KeyboardEvent; percent?: number }>
 	) {
+		if (!Number.isFinite($duration) || $duration <= 0) return;
+
 		if (typeof percent === "number") {
 			currentTime.set(percent * $duration);
 			return;
@@ -94,13 +108,12 @@
 		queue.playNext();
 	}
 
-	function onPlaybackRateChange(event: CustomEvent<{ value: number }>) {
-		offBinding.playbackRate = event.detail.value;
+	function onPlaybackRateInput(event: Event) {
+		offBinding.playbackRate = Number((event.currentTarget as HTMLInputElement).value);
 	}
 
-	function onVolumeChange(event: CustomEvent<{ value: number }>) {
-		const newVolume = clampVolume(event.detail.value);
-
+	function onVolumeInput(event: Event) {
+		const newVolume = clampVolume(Number((event.currentTarget as HTMLInputElement).value));
 		volume.set(newVolume);
 	}
 
@@ -109,8 +122,23 @@
 	}
 
 	function onMetadataLoaded() {
+		finishAudioLoading(true);
+	}
+
+	function onAudioCanPlay() {
+		finishAudioLoading();
+	}
+
+	function onAudioError() {
+		finishAudioLoading();
+	}
+
+	function finishAudioLoading(shouldRestorePlaybackTime: boolean = false) {
 		isLoading = false;
 
+		if (!shouldRestorePlaybackTime || hasRestoredPlaybackTime) return;
+
+		hasRestoredPlaybackTime = true;
 		restorePlaybackTime();
 	}
 
@@ -168,6 +196,8 @@
 		});
 
 		const unsubCurrentEpisode = currentEpisode.subscribe((episode) => {
+			isLoading = true;
+			hasRestoredPlaybackTime = false;
 			srcPromise = getSrc($currentEpisode);
 
 			// Fetch chapters when episode changes
@@ -195,7 +225,14 @@
 	});
 
 	onDestroy(() => {
-		playedEpisodes.setEpisodeTime($currentEpisode, $currentTime, $duration, ($currentTime === $duration));
+		const safeDuration = Number.isFinite($duration) && $duration > 0 ? $duration : 0;
+		const safeCurrentTime = Number.isFinite($currentTime) && $currentTime > 0 ? $currentTime : 0;
+		playedEpisodes.setEpisodeTime(
+			$currentEpisode,
+			safeCurrentTime,
+			safeDuration,
+			safeDuration > 0 && safeCurrentTime === safeDuration,
+		);
 		isPaused.set(true);
 	});
 
@@ -231,7 +268,8 @@
 	}
 </script>
 
-	<div class="episode-player">
+<div class="episode-player">
+	<div class="now-playing-panel">
 		<div class="episode-image-container">
 			<button
 				type="button"
@@ -269,64 +307,85 @@
 		</button>
 	</div>
 
-	<h2 class="podcast-title">{$currentEpisode.title}</h2>
+		<div class="now-playing-details">
+			<h2 class="podcast-title">{$currentEpisode.title}</h2>
 
-	{#await srcPromise then src}
-		<audio
-			src={src}
-			bind:duration={$duration}
-			bind:currentTime={$currentTime}
-			bind:paused={$isPaused}
-			bind:playbackRate={offBinding._playbackRate}
-			bind:volume={playerVolume}
-			on:ended={onEpisodeEnded}
-			on:loadedmetadata={onMetadataLoaded}
-			on:play|preventDefault
-			autoplay={true}
-		></audio>
-	{/await}
+			{#await srcPromise then src}
+				<audio
+					src={src}
+					bind:duration={$duration}
+					bind:currentTime={$currentTime}
+					bind:paused={$isPaused}
+					bind:playbackRate={offBinding._playbackRate}
+					bind:volume={playerVolume}
+					on:ended={onEpisodeEnded}
+					on:canplay={onAudioCanPlay}
+					on:error={onAudioError}
+					on:loadedmetadata={onMetadataLoaded}
+					on:play|preventDefault
+					autoplay={true}
+				></audio>
+			{/await}
 
-	<div class="status-container">
-		<span>{formatSeconds($currentTime, "HH:mm:ss")}</span>
-		<Progressbar 
-			on:click={onClickProgressbar}
-			value={$currentTime}
-			max={$duration}
-		/>
-		<span>{formatSeconds($duration - $currentTime, "HH:mm:ss")}</span>
-	</div>
+			<div class="status-container">
+				<span>{currentTimeText}</span>
+				<Progressbar 
+					on:click={onClickProgressbar}
+					value={progressTime}
+					max={progressDuration}
+				/>
+				<span>{remainingTimeText}</span>
+			</div>
 
-	<div class="controls-container">
-		<Button
-			icon="skip-back"
-			tooltip="Skip backward"
-			on:click={$plugin.api.skipBackward.bind($plugin.api)}
-			class="player-control-button"
-		/>
-		<Button
-			icon="skip-forward"
-			tooltip="Skip forward"
-			on:click={$plugin.api.skipForward.bind($plugin.api)}
-			class="player-control-button"
-		/>
+			<div class="controls-container">
+				<Button
+					icon="skip-back"
+					tooltip="Skip backward"
+					on:click={$plugin.api.skipBackward.bind($plugin.api)}
+					class="player-control-button"
+				/>
+				<Button
+					icon={$isPaused ? "play" : "pause"}
+					tooltip={$isPaused ? "Play" : "Pause"}
+					on:click={togglePlayback}
+					class="player-control-button player-play-button"
+				/>
+				<Button
+					icon="skip-forward"
+					tooltip="Skip forward"
+					on:click={$plugin.api.skipForward.bind($plugin.api)}
+					class="player-control-button"
+				/>
+			</div>
+		</div>
 	</div>
 
 	<div class="slider-stack">
 		<div class="volume-container">
 			<span>Volume: {Math.round(playerVolume * 100)}%</span>
-			<Slider
-				on:change={onVolumeChange}
+			<input
+				class="native-slider"
+				type="range"
+				min="0"
+				max="1"
+				step="0.05"
 				value={playerVolume}
-				limits={[0, 1, 0.05]}
+				aria-label="Volume"
+				on:input={onVolumeInput}
 			/>
 		</div>
 
 		<div class="playbackrate-container">
 			<span>{offBinding.playbackRate}x</span>
-			<Slider
-				on:change={onPlaybackRateChange}
+			<input
+				class="native-slider"
+				type="range"
+				min="0.5"
+				max="3.5"
+				step="0.1"
 				value={offBinding.playbackRate}
-				limits={[0.5, 3.5, 0.1]}
+				aria-label="Playback rate"
+				on:input={onPlaybackRateInput}
 			/>
 		</div>
 	</div>
@@ -358,35 +417,52 @@
 		flex-direction: column;
 		flex: 1 1 auto;
 		min-height: 0;
-		padding: 0 1rem;
+		padding: 0.75rem 1rem 1rem;
 		overflow-y: auto;
-		gap: 0.35rem;
+		overflow-x: hidden;
+		gap: 0.75rem;
+	}
+
+	.now-playing-panel {
+		display: grid;
+		grid-template-columns: 7rem minmax(0, 1fr);
+		align-items: center;
+		gap: 1rem;
+		padding-bottom: 0.75rem;
+		border-bottom: 1px solid var(--background-modifier-border);
 	}
 
 	.episode-image-container {
-		width: 100%;
-		max-width: 20rem;
-		margin: 0 auto 0.5rem;
-		padding: 1rem 0 0.5rem;
+		width: 7rem;
+		max-width: 7rem;
+		margin: 0;
+		padding: 0;
+	}
+
+	.now-playing-details {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		min-width: 0;
 	}
 
 	.hover-container {
-		width: 100%;
-		height: 0;
-		padding-bottom: 100%;
+		width: 7rem;
+		height: 7rem;
+		padding: 0;
 		display: block;
 		position: relative;
 		border: none;
 		background: transparent;
 		cursor: pointer;
-		border-radius: 0.75rem;
+		border-radius: 0.625rem;
 		overflow: hidden;
-		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
 		transition: box-shadow 200ms ease, transform 200ms ease;
 	}
 
 	.hover-container:hover {
-		box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
 	}
 
 	.hover-container:active {
@@ -447,27 +523,32 @@
 	.podcast-title {
 		font-size: 1.125rem;
 		font-weight: 600;
-		line-height: 1.4;
-		margin: 0 0 0.75rem;
-		text-align: center;
+		line-height: 1.3;
+		margin: 0;
+		text-align: left;
 		color: var(--text-normal);
 		white-space: normal;
 		word-break: break-word;
 	}
 
 	.status-container {
-		display: flex;
+		display: grid;
+		grid-template-columns: 4.25rem minmax(0, 1fr) 4.25rem;
 		align-items: center;
-		gap: 0.75rem;
-		padding: 0 0.25rem;
+		gap: 0.625rem;
+		padding: 0;
+		min-width: 0;
+		overflow: hidden;
 	}
 
 	.status-container span {
 		font-size: 0.8rem;
 		font-variant-numeric: tabular-nums;
 		color: var(--text-muted);
-		min-width: 4rem;
+		min-width: 0;
 		text-align: center;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 
 	.status-container span:first-child {
@@ -480,23 +561,33 @@
 
 	:global(.episode-player .status-container .progress) {
 		height: var(--episode-player-progress-height, 0.5rem);
-		flex: 1 1 auto;
+		width: 100%;
+		min-width: 0;
 	}
 
 	.controls-container {
 		display: flex;
 		align-items: center;
-		justify-content: center;
-		gap: 2rem;
-		margin: 1.25rem 0;
+		justify-content: flex-start;
+		gap: 0.375rem;
+		margin: 0;
 	}
 
 	:global(.player-control-button) {
 		margin: 0;
 		cursor: pointer;
-		padding: 0.5rem;
-		border-radius: 50%;
+		width: 2rem;
+		height: 2rem;
+		min-height: 2rem;
+		padding: 0;
+		border-radius: 0.375rem;
+		box-shadow: none !important;
 		transition: background-color 120ms ease;
+	}
+
+	:global(.player-play-button) {
+		color: var(--text-accent);
+		background-color: var(--background-modifier-hover);
 	}
 
 	:global(.player-control-button:hover) {
@@ -504,26 +595,34 @@
 	}
 
 	.slider-stack {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		padding: 1rem 0 0.75rem;
-		border-top: 1px solid var(--background-modifier-border);
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.75rem 1rem;
+		padding: 0;
 	}
 
 	.playbackrate-container,
 	.volume-container {
-		display: flex;
+		display: grid;
+		grid-template-columns: 5.75rem minmax(0, 1fr);
 		align-items: center;
-		gap: 1rem;
-		padding: 0 0.5rem;
+		gap: 0.75rem;
+		padding: 0;
+		min-width: 0;
 	}
 
 	.playbackrate-container span,
 	.volume-container span {
 		font-size: 0.8rem;
 		color: var(--text-muted);
-		min-width: 5rem;
+		min-width: 0;
+		white-space: nowrap;
+	}
+
+	.native-slider {
+		width: 100%;
+		min-width: 0;
+		accent-color: var(--interactive-accent);
 	}
 
 	:global(.episode-player h3) {
@@ -555,5 +654,38 @@
 
 	:global(.lists-container .episode-list-view-container) {
 		height: auto;
+	}
+
+	@media (max-width: 520px) {
+		.now-playing-panel {
+			grid-template-columns: 1fr;
+			justify-items: center;
+		}
+
+		.episode-image-container {
+			width: 10rem;
+			max-width: 10rem;
+		}
+
+		.hover-container {
+			width: 10rem;
+			height: 10rem;
+		}
+
+		.now-playing-details {
+			width: 100%;
+		}
+
+		.podcast-title {
+			text-align: center;
+		}
+
+		.controls-container {
+			justify-content: center;
+		}
+
+		.slider-stack {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -9,6 +9,7 @@ import {
 	isPaused,
 	playedEpisodes,
 	plugin,
+	queue,
 	requestedPlaybackTime,
 } from "src/store";
 import type { Episode } from "src/types/Episode";
@@ -30,6 +31,13 @@ beforeEach(() => {
 	duration.set(3600);
 	isPaused.set(true);
 	playedEpisodes.set({});
+	queue.set({
+		icon: "list-ordered",
+		name: "Queue",
+		episodes: [],
+		shouldEpisodeRemoveAfterPlay: true,
+		shouldRepeat: false,
+	});
 	requestedPlaybackTime.set(null);
 	HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
 	HTMLMediaElement.prototype.pause = vi.fn();
@@ -83,5 +91,21 @@ describe("EpisodePlayer", () => {
 		expect(get(currentTime)).toBe(1800);
 		expect(get(isPaused)).toBe(false);
 		expect(get(requestedPlaybackTime)).toBeNull();
+	});
+
+	test("clears loading overlay when audio fails to load", async () => {
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+
+		expect(container.querySelector(".podcast-artwork-isloading-overlay")).not.toBeNull();
+
+		await fireEvent.error(audio);
+
+		await waitFor(() => {
+			expect(container.querySelector(".podcast-artwork-isloading-overlay")).toBeNull();
+		});
 	});
 });

--- a/src/ui/PodcastView/PodcastView.integration.test.ts
+++ b/src/ui/PodcastView/PodcastView.integration.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { TFile } from "obsidian";
 import { get } from "svelte/store";
 import {
 	afterEach,
@@ -12,10 +13,13 @@ import {
 import createPodcastNote from "src/createPodcastNote";
 import {
 	currentEpisode,
+	downloadedEpisodes,
 	episodeCache,
+	favorites,
 	hidePlayedEpisodes,
 	playedEpisodes,
 	plugin,
+	queue,
 	savedFeeds,
 	viewState,
 } from "src/store";
@@ -64,6 +68,21 @@ function resetStores() {
 	episodeCache.set({});
 	hidePlayedEpisodes.set(false);
 	playedEpisodes.set({});
+	downloadedEpisodes.set({});
+	queue.set({
+		icon: "list-ordered",
+		name: "Queue",
+		episodes: [],
+		shouldEpisodeRemoveAfterPlay: true,
+		shouldRepeat: false,
+	});
+	favorites.set({
+		icon: "lucide-star",
+		name: "Favorites",
+		episodes: [],
+		shouldEpisodeRemoveAfterPlay: false,
+		shouldRepeat: false,
+	});
 	viewState.set(ViewState.PodcastGrid);
 	currentEpisode.update(() => undefined as unknown as Episode);
 	plugin.set(undefined as never);
@@ -234,6 +253,94 @@ describe("PodcastView integration flow", () => {
 		);
 	});
 
+	test("shows episode state badges and handles row quick actions", async () => {
+		const { appMock } = bootstrapAppMock();
+		const episodeWithDuration: Episode = {
+			...testEpisode,
+			duration: 120,
+		};
+
+		mockGetEpisodes.mockResolvedValue([episodeWithDuration]);
+		playedEpisodes.set({
+			[`${testFeed.title}::${testEpisode.title}`]: {
+				title: testEpisode.title,
+				podcastName: testFeed.title,
+				time: 30,
+				duration: 120,
+				finished: false,
+			},
+		});
+		downloadedEpisodes.set({
+			[testFeed.title]: [
+				{
+					...episodeWithDuration,
+					filePath: "Downloads/episode.mp3",
+					size: 1200,
+				},
+			],
+		});
+		queue.set({
+			icon: "list-ordered",
+			name: "Queue",
+			episodes: [episodeWithDuration],
+			shouldEpisodeRemoveAfterPlay: true,
+			shouldRepeat: false,
+		});
+		favorites.set({
+			icon: "lucide-star",
+			name: "Favorites",
+			episodes: [episodeWithDuration],
+			shouldEpisodeRemoveAfterPlay: false,
+			shouldRepeat: false,
+		});
+		const existingNote = Object.assign(Object.create(TFile.prototype), {
+			path: "Podcasts/Episode 1 Launch.md",
+		}) as TFile;
+		appMock.vault.getAbstractFileByPath.mockImplementationOnce(
+			() => existingNote as never,
+		);
+		plugin.set({
+			settings: {
+				note: {
+					path: "Podcasts/{{title}}",
+					template: "# {{title}}",
+				},
+				download: {
+					path: "Downloads/{{title}}",
+				},
+				feedCache: {
+					enabled: false,
+					ttlHours: 6,
+				},
+			},
+		} as never);
+
+		render(PodcastView);
+
+		await fireEvent.click(await screen.findByAltText(testFeed.title));
+		expect(await screen.findByText(testEpisode.title)).toBeInTheDocument();
+
+		expect(screen.getByText("2:00")).toBeInTheDocument();
+		expect(screen.getByText("25%")).toBeInTheDocument();
+		expect(screen.getByLabelText("Downloaded")).toBeInTheDocument();
+		expect(screen.getByLabelText("Queued")).toBeInTheDocument();
+		expect(screen.getByLabelText("Favorited")).toBeInTheDocument();
+		expect(screen.getByLabelText("Podcast note exists")).toBeInTheDocument();
+
+		await fireEvent.click(
+			screen.getByRole("button", { name: "Remove from favorites" }),
+		);
+		expect(get(favorites).episodes).toHaveLength(0);
+
+		await fireEvent.click(
+			screen.getByRole("button", { name: "Remove from queue" }),
+		);
+		expect(get(queue).episodes).toHaveLength(0);
+
+		await fireEvent.click(screen.getByRole("button", { name: "Mark played" }));
+		expect(playedEpisodes.get(episodeWithDuration)?.finished).toBe(true);
+	});
+
 	test("opens a global played episodes view from the podcast grid", async () => {
 		const playedEpisode: Episode = {
 			title: "Already Finished",
@@ -264,7 +371,9 @@ describe("PodcastView integration flow", () => {
 		await fireEvent.click(playedCard);
 
 		expect(await screen.findByText("Already Finished")).toBeInTheDocument();
-		expect(screen.getByText("Played")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: "Played" }),
+		).toBeInTheDocument();
 	});
 
 	test("does not apply a delayed played feed refresh after leaving the played view", async () => {

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -35,13 +35,30 @@
 	} from "src/services/FeedCacheService";
 	import { get } from "svelte/store";
 	import { PLAYED_SETTINGS } from "src/constants";
-	import { getFinishedPlayedEpisodeRecords } from "src/utility/episodeStatus";
+	import {
+		getFinishedPlayedEpisodeRecords,
+		isEpisodeFinished,
+	} from "src/utility/episodeStatus";
 	import {
 		buildPlayedEpisodeListEntries,
 		createPlayedEpisodePlaceholder,
 		type EpisodeListEntry,
 		type PlayedEpisodeListEntry,
 	} from "src/utility/episodeListEntry";
+	import createPodcastNote, {
+		getPodcastNote,
+		openPodcastNote,
+	} from "src/createPodcastNote";
+	import downloadEpisodeWithProgressNotice from "src/downloadEpisode";
+	import { getEpisodeKey } from "src/utility/episodeKey";
+
+	type EpisodeQuickAction =
+		| "play"
+		| "togglePlayed"
+		| "download"
+		| "note"
+		| "favorite"
+		| "queue";
 
 	let feeds: PodcastFeed[] = [];
 	let selectedFeed: PodcastFeed | null = null;
@@ -57,6 +74,7 @@
 	let loadingFeedNames: string[] = [];
 	let loadingFeedSummary: string = "";
 	let isMounted: boolean = true;
+	let noteRefreshToken: number = 0;
 
 	onDestroy(() => {
 		isMounted = false;
@@ -375,6 +393,130 @@
 		);
 	}
 
+	function hasEpisode(episodes: Episode[], episode: Episode): boolean {
+		return episodes.some((candidate) => episodeMatches(candidate, episode));
+	}
+
+	function episodeMatches(candidate: Episode, episode: Episode): boolean {
+		const episodeKey = getEpisodeKey(episode);
+		const candidateKey = getEpisodeKey(candidate);
+
+		return candidateKey && episodeKey
+			? candidateKey === episodeKey
+			: candidate.title === episode.title;
+	}
+
+	function toggleFavoriteEpisode(episode: Episode) {
+		favorites.update((playlist) => {
+			const episodeIsFavorite = hasEpisode(playlist.episodes, episode);
+			playlist.episodes = episodeIsFavorite
+				? playlist.episodes.filter(
+						(candidate) => !episodeMatches(candidate, episode),
+					)
+				: [...playlist.episodes, episode];
+
+			return playlist;
+		});
+	}
+
+	function toggleQueuedEpisode(episode: Episode) {
+		const episodeIsInQueue = hasEpisode(get(queue).episodes, episode);
+
+		if (episodeIsInQueue) {
+			queue.remove(episode);
+		} else {
+			queue.add(episode);
+		}
+	}
+
+	function togglePlayedEpisode(episode: Episode, entry: EpisodeListEntry) {
+		const playedEpisodeKey = getPlayedEpisodeKey(entry);
+		const playedEpisodeMap = get(playedEpisodes);
+		const episodeIsPlayed = playedEpisodeKey
+			? playedEpisodeMap[playedEpisodeKey]?.finished
+			: isEpisodeFinished(episode, playedEpisodeMap);
+
+		if (episodeIsPlayed) {
+			if (playedEpisodeKey) {
+				playedEpisodes.markKeyAsUnplayed(playedEpisodeKey);
+			} else {
+				playedEpisodes.markAsUnplayed(episode);
+			}
+		} else {
+			playedEpisodes.markAsPlayed(episode);
+		}
+	}
+
+	function toggleDownloadedEpisode(episode: Episode) {
+		if (downloadedEpisodes.isEpisodeDownloaded(episode)) {
+			downloadedEpisodes.removeEpisode(episode, true);
+			return;
+		}
+
+		const downloadPath = get(plugin)?.settings?.download?.path;
+		if (!downloadPath) {
+			new Notice("Please set a download path in the settings.");
+			return;
+		}
+
+		downloadEpisodeWithProgressNotice(episode, downloadPath);
+	}
+
+	async function openOrCreateNote(episode: Episode) {
+		const noteSettings = get(plugin)?.settings?.note;
+		if (!noteSettings?.path || !noteSettings.template) {
+			new Notice("Please set a note path and template in the settings.");
+			return;
+		}
+
+		const episodeNoteExists = Boolean(getPodcastNote(episode));
+
+		if (episodeNoteExists) {
+			openPodcastNote(episode);
+			return;
+		}
+
+		await createPodcastNote(episode);
+		noteRefreshToken += 1;
+	}
+
+	async function handleQuickActionEpisode(
+		event: CustomEvent<{
+			episode: Episode;
+			action: EpisodeQuickAction;
+			entry: EpisodeListEntry;
+		}>,
+	) {
+		const { episode, action, entry } = event.detail;
+
+		if (!entry.isAvailable && action !== "togglePlayed") {
+			new Notice("This played episode is no longer available in current feeds.");
+			return;
+		}
+
+		switch (action) {
+			case "play":
+				currentEpisode.set(episode);
+				viewState.set(ViewState.Player);
+				break;
+			case "togglePlayed":
+				togglePlayedEpisode(episode, entry);
+				break;
+			case "download":
+				toggleDownloadedEpisode(episode);
+				break;
+			case "note":
+				await openOrCreateNote(episode);
+				break;
+			case "favorite":
+				toggleFavoriteEpisode(episode);
+				break;
+			case "queue":
+				toggleQueuedEpisode(episode);
+				break;
+		}
+	}
+
 	async function handleClickRefresh() {
 		if (isShowingPlayedEpisodes) {
 			await fetchEpisodesInAllFeeds(feeds, false);
@@ -499,8 +641,10 @@
 			showPlayedToggle={!isShowingPlayedEpisodes}
 			alwaysShowPlayedEpisodes={isShowingPlayedEpisodes}
 			isLoading={selectedFeed ? loadingFeeds.has(selectedFeed.title) : isFetchingEpisodes}
+			{noteRefreshToken}
 			on:clickEpisode={handleClickEpisode}
 			on:contextMenuEpisode={handleContextMenuEpisode}
+			on:quickActionEpisode={handleQuickActionEpisode}
 			on:clickRefresh={handleClickRefresh}
 			on:search={handleSearch}
 		>
@@ -513,7 +657,7 @@
 					>
 						<Icon
 							icon={"arrow-left"}
-							size={20}
+							size={16}
 							clickable={false}
 						/> Latest Episodes
 					</button>
@@ -529,7 +673,7 @@
 					>
 						<Icon
 							icon={"arrow-left"}
-							size={20}
+							size={16}
 							clickable={false}
 						/> Latest Episodes
 					</button>
@@ -605,17 +749,22 @@
 	}
 
 	.go-back {
+		appearance: none;
 		display: inline-flex;
 		align-items: center;
 		gap: 0.375rem;
-		padding: 0.375rem 0.625rem;
-		margin: 0.5rem 0.5rem 0;
-		font-size: 0.85rem;
+		width: max-content;
+		min-height: 1.75rem;
+		padding: 0.25rem 0.5rem;
+		margin: 0.5rem 0.75rem 0;
+		font-size: 0.8125rem;
+		font-weight: 500;
 		color: var(--text-muted);
 		cursor: pointer;
-		background: none;
-		border: none;
-		border-radius: 0.25rem;
+		background: transparent;
+		border: none !important;
+		border-radius: 0.375rem;
+		box-shadow: none !important;
 		transition: color 120ms ease, background-color 120ms ease;
 	}
 
@@ -634,5 +783,166 @@
 		justify-content: center;
 		padding: 0.5rem;
 		color: var(--text-muted);
+	}
+
+	:global(.podcast-view .episode-list-view-container) {
+		display: flex !important;
+		flex-direction: column !important;
+		align-items: stretch !important;
+		width: 100% !important;
+		overflow: hidden;
+	}
+
+	:global(.podcast-view .podcast-episode-list) {
+		display: flex !important;
+		flex-direction: column !important;
+		align-items: stretch !important;
+		width: 100% !important;
+		overflow-x: hidden;
+	}
+
+	:global(.podcast-view .podcast-episode-item) {
+		display: flex !important;
+		flex-direction: row !important;
+		align-items: center !important;
+		justify-content: space-between !important;
+		gap: 0.625rem !important;
+		width: 100% !important;
+		min-height: 3.5rem !important;
+		padding: 0.375rem 0.5rem !important;
+		border: 0 !important;
+		border-bottom: 1px solid var(--background-modifier-border) !important;
+		background: transparent !important;
+		text-align: left !important;
+		box-sizing: border-box !important;
+	}
+
+	:global(.podcast-view .podcast-episode-item:hover),
+	:global(.podcast-view .podcast-episode-item:focus-within) {
+		background: var(--background-secondary-alt) !important;
+	}
+
+	:global(.podcast-view .podcast-episode-main) {
+		appearance: none !important;
+		display: flex !important;
+		flex: 1 1 auto !important;
+		align-items: center !important;
+		justify-content: flex-start !important;
+		gap: 0.625rem !important;
+		min-width: 0 !important;
+		width: 100% !important;
+		min-height: 0 !important;
+		height: auto !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		border: 0 !important;
+		border-radius: 0 !important;
+		background: transparent !important;
+		box-shadow: none !important;
+		color: inherit !important;
+		font: inherit !important;
+		text-align: left !important;
+		overflow: hidden !important;
+	}
+
+	:global(.podcast-view .podcast-episode-thumbnail-container) {
+		flex: 0 0 2.625rem !important;
+		width: 2.625rem !important;
+		height: 2.625rem !important;
+		border-radius: 0.375rem !important;
+		overflow: hidden !important;
+		background: var(--background-secondary) !important;
+	}
+
+	:global(.podcast-view .podcast-episode-information) {
+		display: flex !important;
+		flex: 1 1 auto !important;
+		flex-direction: column !important;
+		align-items: flex-start !important;
+		justify-content: center !important;
+		gap: 0.1875rem !important;
+		min-width: 0 !important;
+	}
+
+	:global(.podcast-view .episode-item-date) {
+		font-size: 0.6875rem !important;
+		line-height: 1 !important;
+		letter-spacing: 0.04em !important;
+		color: var(--text-muted) !important;
+		white-space: nowrap !important;
+	}
+
+	:global(.podcast-view .episode-item-title) {
+		display: block !important;
+		max-width: 100% !important;
+		overflow: hidden !important;
+		text-overflow: ellipsis !important;
+		white-space: nowrap !important;
+		font-size: 0.875rem !important;
+		line-height: 1.25 !important;
+		color: var(--text-normal) !important;
+		text-align: left !important;
+	}
+
+	:global(.podcast-view .episode-item-meta) {
+		display: flex !important;
+		align-items: center !important;
+		flex-wrap: wrap !important;
+		gap: 0.4375rem !important;
+		min-height: 0.875rem !important;
+	}
+
+	:global(.podcast-view .episode-item-badge) {
+		display: inline-flex !important;
+		align-items: center !important;
+		gap: 0.1875rem !important;
+		padding: 0 !important;
+		border: 0 !important;
+		background: transparent !important;
+		color: var(--text-muted) !important;
+		font-size: 0.75rem !important;
+		line-height: 1 !important;
+	}
+
+	:global(.podcast-view .episode-item-badge-strong) {
+		color: var(--text-accent) !important;
+		font-weight: 500 !important;
+	}
+
+	:global(.podcast-view .episode-quick-actions) {
+		display: flex !important;
+		flex: 0 0 auto !important;
+		align-items: center !important;
+		gap: 0.125rem !important;
+		opacity: 0 !important;
+		pointer-events: none !important;
+	}
+
+	:global(.podcast-view .podcast-episode-item:hover .episode-quick-actions),
+	:global(.podcast-view .podcast-episode-item:focus-within .episode-quick-actions) {
+		opacity: 1 !important;
+		pointer-events: auto !important;
+	}
+
+	:global(.podcast-view .episode-quick-action) {
+		appearance: none !important;
+		display: inline-flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+		width: 1.75rem !important;
+		height: 1.75rem !important;
+		min-height: 1.75rem !important;
+		padding: 0 !important;
+		border: 0 !important;
+		border-radius: 0.375rem !important;
+		background: transparent !important;
+		box-shadow: none !important;
+		color: var(--text-muted) !important;
+	}
+
+	:global(.podcast-view .episode-quick-action:hover),
+	:global(.podcast-view .episode-quick-action:focus-visible) {
+		background: var(--background-modifier-hover) !important;
+		color: var(--text-normal) !important;
 	}
 </style>

--- a/src/ui/PodcastView/TopBar.svelte
+++ b/src/ui/PodcastView/TopBar.svelte
@@ -44,7 +44,7 @@
 		aria-pressed={viewState === ViewState.PodcastGrid}
 		title={gridTooltip}
 	>
-		<Icon icon="grid" size={20} clickable={false} />
+		<Icon icon="grid" size={18} clickable={false} />
 	</button>
 	<button
 		type="button"
@@ -63,7 +63,7 @@
 		disabled={!canShowEpisodeList}
 		title={episodeTooltip}
 	>
-		<Icon icon="list-minus" size={20} clickable={false} />
+		<Icon icon="list-minus" size={18} clickable={false} />
 	</button>
 	<button
 		type="button"
@@ -82,7 +82,7 @@
 		disabled={!canShowPlayer}
 		title={playerTooltip}
 	>
-		<Icon icon="play" size={20} clickable={false} />
+		<Icon icon="play" size={18} clickable={false} />
 	</button>
 </div>
 
@@ -91,25 +91,28 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		justify-content: stretch;
-		gap: 0.375rem;
-		padding: 0.5rem;
-		min-height: 3rem;
+		justify-content: center;
+		gap: 0.25rem;
+		padding: 0.375rem 0.75rem;
+		min-height: 2.5rem;
 		border-bottom: 1px solid var(--background-modifier-border);
-		background: var(--background-secondary);
+		background: var(--background-primary);
 		box-sizing: border-box;
 	}
 
 	.topbar-menu-button {
+		appearance: none;
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		width: 2.25rem;
 		height: 2rem;
-		padding: 0 0.75rem;
-		flex: 1 1 0;
+		padding: 0;
+		flex: 0 0 auto;
 		border: 1px solid transparent;
 		border-radius: 0.375rem;
 		background: transparent;
+		box-shadow: none !important;
 		color: var(--text-muted);
 		transition:
 			background-color 120ms ease,
@@ -137,8 +140,9 @@
 
 	.topbar-selected,
 	.topbar-selected:hover {
-		color: var(--text-on-accent);
-		background: var(--interactive-accent);
+		color: var(--text-accent);
+		background: var(--background-modifier-hover);
+		border-color: var(--background-modifier-border);
 	}
 
 	.topbar-disabled,

--- a/src/ui/obsidian/Button.svelte
+++ b/src/ui/obsidian/Button.svelte
@@ -20,11 +20,15 @@
     let styles: CSSObject;
 
     let button: ButtonComponent;
+    let appliedClassTokens: string[] = [];
+    let clickHandlerRegistered: boolean = false;
 
     const dispatch = createEventDispatcher();
 
     onMount(() => createButton(buttonRef));
-    afterUpdate(() => updateButtonAttributes(button));
+    afterUpdate(() => {
+        if (button) updateButtonAttributes(button);
+    });
 
     function createButton(container: HTMLElement) {
         button = new ButtonComponent(container);
@@ -38,12 +42,10 @@
         if (icon) btn.setIcon(icon);
         if (disabled) btn.setDisabled(disabled);
         if (warning) btn.setWarning(); else btn.buttonEl.classList.remove('mod-warning');
-        if (className) btn.setClass(className);
+        updateButtonClasses(btn, className);
         if (cta) btn.setCta(); else btn.removeCta();
 
-        btn.onClick((event: MouseEvent) => {
-            dispatch("click", { event });
-        });
+        registerClickHandler(btn);
 
         if (styles) {
             btn.buttonEl.setAttr('style', extractStylesFromObj(styles));
@@ -54,6 +56,26 @@
         } else {
             btn.buttonEl.removeAttribute("aria-label");
         }
+    }
+
+    function updateButtonClasses(btn: ButtonComponent, currentClassName: string | undefined) {
+        const nextClassTokens = currentClassName?.split(/\s+/).filter(Boolean) ?? [];
+
+        if (appliedClassTokens.length) {
+            btn.buttonEl.classList.remove(...appliedClassTokens);
+        }
+
+        nextClassTokens.forEach((token) => btn.setClass(token));
+        appliedClassTokens = nextClassTokens;
+    }
+
+    function registerClickHandler(btn: ButtonComponent) {
+        if (clickHandlerRegistered) return;
+
+        btn.onClick((event: MouseEvent) => {
+            dispatch("click", { event });
+        });
+        clickHandlerRegistered = true;
     }
 
 </script>

--- a/src/ui/obsidian/Button.test.ts
+++ b/src/ui/obsidian/Button.test.ts
@@ -1,0 +1,24 @@
+import { render, waitFor } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+
+import Button from "./Button.svelte";
+
+describe("Button", () => {
+	test("applies multiple class tokens from Svelte class prop", async () => {
+		const { container } = render(Button, {
+			props: {
+				class: "player-control-button player-play-button",
+				icon: "play",
+			},
+		});
+
+		const button = await waitFor(() => {
+			const element = container.querySelector("button");
+			expect(element).not.toBeNull();
+			return element as HTMLButtonElement;
+		});
+
+		expect(button).toHaveClass("player-control-button");
+		expect(button).toHaveClass("player-play-button");
+	});
+});

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -63,7 +63,7 @@ export class ButtonComponent extends BaseInteractiveElement {
 	}
 
 	setClass(value: string) {
-		this.buttonEl.className = value;
+		this.buttonEl.classList.add(value);
 		return this;
 	}
 


### PR DESCRIPTION
## Summary
- Add richer episode-row state for partial progress, downloads, queue/favorite/note indicators, and duration.
- Surface quick actions on hover and focus so actions are discoverable without opening the context menu.
- Refine the player layout and fix the Obsidian button class handling that blocked interaction in the player view.
- Clear the player loading state on audio `canplay` and `error` so the artwork overlay does not get stuck.

## Testing
- Added and updated unit/integration coverage for the episode player and Obsidian button wrapper.
- Ran the full test suite and production build locally; both passed.
- Verified the player view live in the dev vault after reloading the plugin.