### PR TITLE
Fix older podcasts not loading due to feed cache cap (#174)

### DIFF
--- a/src/services/FeedCacheService.test.ts
+++ b/src/services/FeedCacheService.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { Episode } from "src/types/Episode";
+import type { PodcastFeed } from "src/types/PodcastFeed";
+import {
+	clearFeedCache,
+	getCachedEpisodes,
+	setCachedEpisodes,
+} from "./FeedCacheService";
+
+const testFeed: PodcastFeed = {
+	title: "Accidental Tech Podcast",
+	url: "https://pod.example.com/feed.xml",
+	artworkUrl: "https://pod.example.com/art.jpg",
+};
+
+function createEpisode(number: number): Episode {
+	return {
+		title: `Episode ${number}`,
+		streamUrl: `https://pod.example.com/ep-${number}.mp3`,
+		url: `https://pod.example.com/ep-${number}`,
+		description: `Description for episode ${number}`,
+		content: `<p>Episode ${number}</p>`,
+		podcastName: testFeed.title,
+		artworkUrl: testFeed.artworkUrl,
+		episodeDate: new Date(`2024-01-${String((number % 28) + 1).padStart(2, "0")}T00:00:00.000Z`),
+	};
+}
+
+describe("FeedCacheService", () => {
+	beforeEach(() => {
+		clearFeedCache();
+	});
+
+	test("persists at most 75 episodes per feed (#124 cap)", () => {
+		const episodes = Array.from({ length: 100 }, (_, index) =>
+			createEpisode(index + 1),
+		);
+
+		setCachedEpisodes(testFeed, episodes);
+
+		const cached = getCachedEpisodes(testFeed);
+		expect(cached).toHaveLength(75);
+		expect(cached?.[0]?.title).toBe("Episode 1");
+		expect(cached?.[74]?.title).toBe("Episode 75");
+		expect(cached?.some((episode) => episode.title === "Episode 100")).toBe(
+			false,
+		);
+	});
+
+	test("returns persisted episodes within TTL", () => {
+		const episodes = [createEpisode(1), createEpisode(2)];
+
+		setCachedEpisodes(testFeed, episodes);
+
+		expect(getCachedEpisodes(testFeed)).toEqual(episodes);
+	});
+});

--- a/src/ui/PodcastView/PodcastView.integration.test.ts
+++ b/src/ui/PodcastView/PodcastView.integration.test.ts
@@ -11,6 +11,10 @@ import {
 
 import createPodcastNote from "src/createPodcastNote";
 import {
+	clearFeedCache,
+	setCachedEpisodes,
+} from "src/services/FeedCacheService";
+import {
 	currentEpisode,
 	episodeCache,
 	hidePlayedEpisodes,
@@ -67,6 +71,43 @@ function resetStores() {
 	viewState.set(ViewState.PodcastGrid);
 	currentEpisode.update(() => undefined as unknown as Episode);
 	plugin.set(undefined as never);
+	clearFeedCache();
+}
+
+function createNumberedEpisode(number: number): Episode {
+	return {
+		title: `Episode ${number}`,
+		streamUrl: `https://pod.example.com/ep-${number}.mp3`,
+		url: `https://pod.example.com/ep-${number}`,
+		description: `Description for episode ${number}`,
+		content: `<p>Episode ${number}</p>`,
+		podcastName: testFeed.title,
+		artworkUrl: testFeed.artworkUrl,
+		episodeDate: new Date(
+			`2024-${String((number % 12) + 1).padStart(2, "0")}-15T00:00:00.000Z`,
+		),
+	};
+}
+
+function createTruncatedFeedCache(): Episode[] {
+	return Array.from({ length: 75 }, (_, index) =>
+		createNumberedEpisode(622 + index),
+	);
+}
+
+function createFullFeed(): Episode[] {
+	return [createNumberedEpisode(100), ...createTruncatedFeedCache()];
+}
+
+function enableFeedCache() {
+	plugin.set({
+		settings: {
+			feedCache: {
+				enabled: true,
+				ttlHours: 6,
+			},
+		},
+	} as never);
 }
 
 beforeEach(() => {
@@ -324,5 +365,92 @@ describe("PodcastView integration flow", () => {
 
 		expect(await screen.findByText(testEpisode.title)).toBeInTheDocument();
 		expect(screen.queryByText("Already Finished")).not.toBeInTheDocument();
+	});
+});
+
+describe("issue #174 feed cache cap regression", () => {
+	const oldEpisode = createNumberedEpisode(100);
+	const truncatedCache = createTruncatedFeedCache();
+	const fullFeed = createFullFeed();
+
+	beforeEach(() => {
+		enableFeedCache();
+		episodeCache.set({ [testFeed.title]: truncatedCache });
+		setCachedEpisodes(testFeed, truncatedCache);
+		mockGetEpisodes.mockResolvedValue(fullFeed);
+	});
+
+	test("opening a show bypasses the truncated cache and loads older episodes", async () => {
+		render(PodcastView);
+
+		await waitFor(() =>
+			expect(get(episodeCache)[testFeed.title]).toHaveLength(75),
+		);
+		expect(mockGetEpisodes).not.toHaveBeenCalled();
+
+		const feedImage = await screen.findByAltText(testFeed.title);
+		await fireEvent.click(feedImage);
+
+		await waitFor(() => expect(mockGetEpisodes).toHaveBeenCalledTimes(1));
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+		expect(get(episodeCache)[testFeed.title]).toHaveLength(76);
+		expect(
+			screen.queryByText(createNumberedEpisode(621).title),
+		).not.toBeInTheDocument();
+	});
+
+	test("played view bypasses the truncated cache for older finished episodes", async () => {
+		hidePlayedEpisodes.set(true);
+		playedEpisodes.set({
+			[`${testFeed.title}::${oldEpisode.title}`]: {
+				title: oldEpisode.title,
+				podcastName: testFeed.title,
+				time: 3600,
+				duration: 3600,
+				finished: true,
+			},
+		});
+
+		render(PodcastView);
+
+		await waitFor(() =>
+			expect(get(episodeCache)[testFeed.title]).toHaveLength(75),
+		);
+		expect(mockGetEpisodes).not.toHaveBeenCalled();
+
+		const playedCard = await screen.findByLabelText("Played");
+		await fireEvent.click(playedCard);
+
+		await waitFor(() => expect(mockGetEpisodes).toHaveBeenCalledTimes(1));
+		expect(await screen.findByText("Played")).toBeInTheDocument();
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Unavailable in current feeds"),
+		).not.toBeInTheDocument();
+
+		await fireEvent.click(screen.getByText(oldEpisode.title));
+		expect(get(currentEpisode)).toMatchObject({ title: oldEpisode.title });
+		expect(get(viewState)).toBe(ViewState.Player);
+	});
+
+	test("latest episodes background fetch still uses the truncated cache", async () => {
+		viewState.set(ViewState.EpisodeList);
+
+		render(PodcastView);
+
+		await waitFor(() =>
+			expect(get(episodeCache)[testFeed.title]).toHaveLength(75),
+		);
+		expect(mockGetEpisodes).not.toHaveBeenCalled();
+		expect(
+			screen.queryByText(oldEpisode.title),
+		).not.toBeInTheDocument();
+		expect(
+			await screen.findByText(createNumberedEpisode(622).title),
+		).toBeInTheDocument();
 	});
 });

--- a/src/ui/PodcastView/PodcastView.integration.test.ts
+++ b/src/ui/PodcastView/PodcastView.integration.test.ts
@@ -453,4 +453,60 @@ describe("issue #174 feed cache cap regression", () => {
 			await screen.findByText(createNumberedEpisode(622).title),
 		).toBeInTheDocument();
 	});
+
+	test("reopening a show reuses full in-memory cache without refetching", async () => {
+		render(PodcastView);
+
+		const feedImage = await screen.findByAltText(testFeed.title);
+		await fireEvent.click(feedImage);
+
+		await waitFor(() => expect(mockGetEpisodes).toHaveBeenCalledTimes(1));
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+
+		await fireEvent.click(
+			screen.getByRole("button", { name: /podcast grid/i }),
+		);
+		expect(get(viewState)).toBe(ViewState.PodcastGrid);
+
+		await fireEvent.click(feedImage);
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+		expect(mockGetEpisodes).toHaveBeenCalledTimes(1);
+	});
+
+	test("reopening played view reuses full in-memory cache without refetching", async () => {
+		hidePlayedEpisodes.set(true);
+		playedEpisodes.set({
+			[`${testFeed.title}::${oldEpisode.title}`]: {
+				title: oldEpisode.title,
+				podcastName: testFeed.title,
+				time: 3600,
+				duration: 3600,
+				finished: true,
+			},
+		});
+
+		render(PodcastView);
+
+		const playedCard = await screen.findByLabelText("Played");
+		await fireEvent.click(playedCard);
+
+		await waitFor(() => expect(mockGetEpisodes).toHaveBeenCalledTimes(1));
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+
+		await fireEvent.click(
+			screen.getByRole("button", { name: /latest episodes/i }),
+		);
+		await fireEvent.click(playedCard);
+
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+		expect(mockGetEpisodes).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/ui/PodcastView/PodcastView.integration.test.ts
+++ b/src/ui/PodcastView/PodcastView.integration.test.ts
@@ -477,6 +477,59 @@ describe("issue #174 feed cache cap regression", () => {
 		expect(mockGetEpisodes).toHaveBeenCalledTimes(1);
 	});
 
+	test("falls back to truncated cache when a full feed fetch fails", async () => {
+		mockGetEpisodes.mockRejectedValue(new Error("network unavailable"));
+
+		render(PodcastView);
+
+		const feedImage = await screen.findByAltText(testFeed.title);
+		await fireEvent.click(feedImage);
+
+		expect(
+			await screen.findByText(createNumberedEpisode(622).title),
+		).toBeInTheDocument();
+		expect(screen.queryByText(oldEpisode.title)).not.toBeInTheDocument();
+		expect(mockGetEpisodes).toHaveBeenCalledTimes(1);
+	});
+
+	test("played view only fetches feeds with finished played episodes", async () => {
+		const secondFeed: PodcastFeed = {
+			title: "Second Podcast",
+			url: "https://pod.example.com/feed-two.xml",
+			artworkUrl: "https://pod.example.com/art-two.jpg",
+		};
+
+		hidePlayedEpisodes.set(true);
+		savedFeeds.set({
+			[testFeed.title]: testFeed,
+			[secondFeed.title]: secondFeed,
+		});
+		episodeCache.set({
+			[testFeed.title]: truncatedCache,
+			[secondFeed.title]: [createNumberedEpisode(900)],
+		});
+		setCachedEpisodes(secondFeed, [createNumberedEpisode(900)]);
+		playedEpisodes.set({
+			[`${testFeed.title}::${oldEpisode.title}`]: {
+				title: oldEpisode.title,
+				podcastName: testFeed.title,
+				time: 3600,
+				duration: 3600,
+				finished: true,
+			},
+		});
+
+		render(PodcastView);
+
+		const playedCard = await screen.findByLabelText("Played");
+		await fireEvent.click(playedCard);
+
+		await waitFor(() => expect(mockGetEpisodes).toHaveBeenCalledTimes(1));
+		expect(
+			await screen.findByText(oldEpisode.title),
+		).toBeInTheDocument();
+	});
+
 	test("reopening played view reuses full in-memory cache without refetching", async () => {
 		hidePlayedEpisodes.set(true);
 		playedEpisodes.set({

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -212,8 +212,42 @@
 				error,
 			);
 			const downloaded = get(downloadedEpisodes);
-			return downloaded[feed.title] || [];
+			if (downloaded[feed.title]?.length) {
+				return downloaded[feed.title];
+			}
+
+			if (!useCache) {
+				if (cachedEpisodesInFeed?.length) {
+					return cachedEpisodesInFeed;
+				}
+
+				if (cacheEnabled) {
+					const persistedEpisodes = getCachedEpisodes(
+						feed,
+						cacheTtlMs,
+					);
+					if (persistedEpisodes?.length) {
+						episodeCache.update((cache) => ({
+							...cache,
+							[feed.title]: persistedEpisodes,
+						}));
+						return persistedEpisodes;
+					}
+				}
+			}
+
+			return [];
 		}
+	}
+
+	function getFeedsWithPlayedEpisodes(): PodcastFeed[] {
+		const playedPodcastNames = new Set(
+			getFinishedPlayedEpisodeRecords(get(playedEpisodes)).map(
+				({ episode }) => episode.podcastName,
+			),
+		);
+
+		return feeds.filter((feed) => playedPodcastNames.has(feed.title));
 	}
 
 	async function fetchFullEpisodes(feed: PodcastFeed): Promise<Episode[]> {
@@ -428,7 +462,10 @@
 
 	async function handleClickRefresh() {
 		if (isShowingPlayedEpisodes) {
-			await fetchEpisodesInAllFeeds(feeds, "network");
+			await fetchEpisodesInAllFeeds(
+				getFeedsWithPlayedEpisodes(),
+				"network",
+			);
 			updateDisplayedPlayedEpisodesIfSelected();
 			return;
 		}
@@ -491,7 +528,10 @@
 			displayedEpisodeEntries = [];
 			viewState.set(ViewState.EpisodeList);
 
-			void fetchEpisodesInAllFeeds(feeds, "full").then(() => {
+			void fetchEpisodesInAllFeeds(
+				getFeedsWithPlayedEpisodes(),
+				"full",
+			).then(() => {
 				updateDisplayedPlayedEpisodesIfSelected();
 			});
 			return;

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -139,16 +139,38 @@
 		};
 	});
 
+	type EpisodeFetchStrategy = "cached" | "full" | "network";
+
+	function getFeedCacheTtlMs(): number {
+		const feedCacheSettings = get(plugin)?.settings?.feedCache;
+		return Math.max(1, feedCacheSettings?.ttlHours ?? 6) * 60 * 60 * 1000;
+	}
+
+	function isFeedCacheEnabled(): boolean {
+		return get(plugin)?.settings?.feedCache?.enabled !== false;
+	}
+
+	function hasFullInMemoryFeed(
+		inMemoryEpisodes: Episode[] | undefined,
+		persistedEpisodes: Episode[] | null,
+	): boolean {
+		if (!inMemoryEpisodes?.length) {
+			return false;
+		}
+
+		if (!persistedEpisodes?.length) {
+			return true;
+		}
+
+		return inMemoryEpisodes.length > persistedEpisodes.length;
+	}
+
 	async function fetchEpisodes(
 		feed: PodcastFeed,
 		useCache: boolean = true,
 	): Promise<Episode[]> {
-
-		const pluginInstance = get(plugin);
-		const feedCacheSettings = pluginInstance?.settings?.feedCache;
-		const cacheEnabled = feedCacheSettings?.enabled !== false;
-		const cacheTtlMs =
-			Math.max(1, feedCacheSettings?.ttlHours ?? 6) * 60 * 60 * 1000;
+		const cacheEnabled = isFeedCacheEnabled();
+		const cacheTtlMs = getFeedCacheTtlMs();
 
 		const currentCache = get(episodeCache);
 		const cachedEpisodesInFeed = currentCache[feed.title];
@@ -192,6 +214,35 @@
 			const downloaded = get(downloadedEpisodes);
 			return downloaded[feed.title] || [];
 		}
+	}
+
+	async function fetchFullEpisodes(feed: PodcastFeed): Promise<Episode[]> {
+		const cacheEnabled = isFeedCacheEnabled();
+		const persistedEpisodes = cacheEnabled
+			? getCachedEpisodes(feed, getFeedCacheTtlMs())
+			: null;
+		const inMemoryEpisodes = get(episodeCache)[feed.title];
+
+		if (hasFullInMemoryFeed(inMemoryEpisodes, persistedEpisodes)) {
+			return inMemoryEpisodes;
+		}
+
+		return fetchEpisodes(feed, false);
+	}
+
+	async function fetchEpisodesByStrategy(
+		feed: PodcastFeed,
+		strategy: EpisodeFetchStrategy = "cached",
+	): Promise<Episode[]> {
+		if (strategy === "network") {
+			return fetchEpisodes(feed, false);
+		}
+
+		if (strategy === "full") {
+			return fetchFullEpisodes(feed);
+		}
+
+		return fetchEpisodes(feed, true);
 	}
 
 	function getPlayedPlaylist(): Playlist {
@@ -301,7 +352,7 @@
 
 	function fetchEpisodesInAllFeeds(
 		feedsToSearch: PodcastFeed[],
-		useCache: boolean = true,
+		strategy: EpisodeFetchStrategy = "cached",
 	): Promise<void> {
 		if (!feedsToSearch.length) return Promise.resolve();
 
@@ -310,7 +361,7 @@
 				setFeedLoading(feed.title, true);
 
 				try {
-					await fetchEpisodes(feed, useCache);
+					await fetchEpisodesByStrategy(feed, strategy);
 				} finally {
 					setFeedLoading(feed.title, false);
 				}
@@ -332,7 +383,7 @@
 		setFeedLoading(feed.title, true);
 
 		try {
-			const episodes = await fetchEpisodes(feed, false);
+			const episodes = await fetchFullEpisodes(feed);
 			displayedEpisodes = currentSearchQuery
 				? searchEpisodes(currentSearchQuery, episodes)
 				: episodes;
@@ -377,7 +428,7 @@
 
 	async function handleClickRefresh() {
 		if (isShowingPlayedEpisodes) {
-			await fetchEpisodesInAllFeeds(feeds, false);
+			await fetchEpisodesInAllFeeds(feeds, "network");
 			updateDisplayedPlayedEpisodesIfSelected();
 			return;
 		}
@@ -387,7 +438,10 @@
 		setFeedLoading(selectedFeed.title, true);
 
 		try {
-			const episodes = await fetchEpisodes(selectedFeed, false);
+			const episodes = await fetchEpisodesByStrategy(
+				selectedFeed,
+				"network",
+			);
 			displayedEpisodeEntries = null;
 			displayedEpisodes = currentSearchQuery
 				? searchEpisodes(currentSearchQuery, episodes)
@@ -437,7 +491,7 @@
 			displayedEpisodeEntries = [];
 			viewState.set(ViewState.EpisodeList);
 
-			void fetchEpisodesInAllFeeds(feeds, false).then(() => {
+			void fetchEpisodesInAllFeeds(feeds, "full").then(() => {
 				updateDisplayedPlayedEpisodesIfSelected();
 			});
 			return;

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -332,7 +332,7 @@
 		setFeedLoading(feed.title, true);
 
 		try {
-			const episodes = await fetchEpisodes(feed);
+			const episodes = await fetchEpisodes(feed, false);
 			displayedEpisodes = currentSearchQuery
 				? searchEpisodes(currentSearchQuery, episodes)
 				: episodes;
@@ -437,7 +437,7 @@
 			displayedEpisodeEntries = [];
 			viewState.set(ViewState.EpisodeList);
 
-			void fetchEpisodesInAllFeeds(feeds).then(() => {
+			void fetchEpisodesInAllFeeds(feeds, false).then(() => {
 				updateDisplayedPlayedEpisodesIfSelected();
 			});
 			return;


### PR DESCRIPTION
## Summary
Fixes #174 by fetching the full RSS feed when a user opens a show or the Played view, instead of reusing the 75-episode disk cache introduced in #124. Background Latest Episodes aggregation still uses the truncated cache for fast startup. Adds regression tests that reproduce the truncated-cache scenario and a unit test documenting the 75-episode persist cap.

## Test plan
- [x] `npm test` — 152 tests pass
- [x] Regression tests fail when cache bypass is reverted
- [ ] Manual: open a large show (e.g. ATP) after reload — older episodes appear without refresh
- [ ] Manual: Played view resolves older finished episodes as playable


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->