### PR TITLE
fix: show downloaded episodes in the Local Files playlist (#176)

### DIFF
--- a/docs/docs/local_files.md
+++ b/docs/docs/local_files.md
@@ -1,5 +1,5 @@
 PodNotes supports local files. You can right-click any audio file and click `Play with PodNotes`.
 
-In the podcast grid, you will see a playlist with a folder icon. This is a playlist consisting of all local files (non-downloaded episodes) you have played with PodNotes.
+In the podcast grid, you will see a playlist with a folder icon. This is a playlist of every episode you have available offline: both local audio files you have played with `Play with PodNotes` and episodes you have downloaded. Removing a downloaded file also removes it from this playlist.
 
 PodNotes will attempt to treat all local files as podcast episodes. This means all standard features are available, such as timestamps, note creation, and persisting playback time. Any exceptions will be added here.

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -3,7 +3,6 @@ import { TFile } from "obsidian";
 import { get } from "svelte/store";
 import {
 	downloadedEpisodes,
-	localFiles,
 	playedEpisodes,
 	currentEpisode,
 	viewState,
@@ -43,13 +42,14 @@ export default function getContextMenuHandler(app: App): EventRef {
 								localEpisode
 							)
 						) {
+							// The Local Files playlist is mirrored from downloadedEpisodes
+							// (see localFiles.syncWithDownloaded), so this single write
+							// surfaces the file there too.
 							downloadedEpisodes.addEpisode(
 								localEpisode,
 								file.path,
 								file.stat.size
 							);
-
-							localFiles.addEpisode(localEpisode);
 						}
 
 						// Fixes where the episode won't play if it has been played.

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ export default class PodNotes extends Plugin implements IPodNotes {
 	private hidePlayedEpisodesController?: StoreController<boolean>;
 	private transcriptionService?: TranscriptionService;
 	private volumeUnsubscribe?: Unsubscriber;
+	private localFilesMirrorUnsubscribe?: Unsubscriber;
 
 	private maxLayoutReadyAttempts = 10;
 	private layoutReadyAttempts = 0;
@@ -121,6 +122,14 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			hidePlayedEpisodes,
 			this,
 		).on();
+
+		// Keep the Local Files playlist in sync with downloaded episodes (issue #176).
+		// downloadedEpisodes is the authoritative offline set, so mirror it into the
+		// localFiles playlist that the Podcast grid renders. Svelte's immediate-fire
+		// backfills already-downloaded episodes on load; later changes keep it current.
+		this.localFilesMirrorUnsubscribe = downloadedEpisodes.subscribe(
+			(downloaded) => localFiles.syncWithDownloaded(downloaded),
+		);
 
 		this.api = new API();
 		this.volumeUnsubscribe = volume.subscribe((value) => {
@@ -375,6 +384,7 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		this.currentEpisodeController?.off();
 		this.hidePlayedEpisodesController?.off();
 		this.volumeUnsubscribe?.();
+		this.localFilesMirrorUnsubscribe?.();
 
 		// Clean up any active blob URLs to prevent memory leaks
 		blobUrlManager.revokeAll();

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -179,19 +179,37 @@ describe("localFiles store — syncWithDownloaded (issue #176)", () => {
 		expect(playlist.icon).toBe(LOCAL_FILES_SETTINGS.icon);
 	});
 
-	test("is a no-op when membership is unchanged", () => {
-		const map = {
+	test("is a no-op when membership is unchanged (no store notification)", () => {
+		localFiles.syncWithDownloaded({
 			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
-		};
-		localFiles.syncWithDownloaded(map);
+		});
 		const before = get(localFiles);
+
+		// Svelte notifies subscribers for every object value (safe_not_equal treats
+		// objects as always-changed), so a no-op must not touch the store at all --
+		// otherwise LocalFilesController.onChange + saveSettings would re-run.
+		let notifications = 0;
+		const unsubscribe = localFiles.subscribe(() => {
+			notifications += 1;
+		});
+		expect(notifications).toBe(1); // immediate fire on subscribe
 
 		localFiles.syncWithDownloaded({
 			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
 		});
+		expect(notifications).toBe(1); // unchanged membership -> no extra notification
+		expect(get(localFiles)).toBe(before); // store value object reused
 
-		// Same key-set -> the store value object is reused (no churn / no extra save).
-		expect(get(localFiles)).toBe(before);
+		// A real membership change does notify.
+		localFiles.syncWithDownloaded({
+			"Podcast A": [
+				downloadedEpisode("Podcast A", "Ep 1"),
+				downloadedEpisode("Podcast A", "Ep 2"),
+			],
+		});
+		expect(notifications).toBe(2);
+
+		unsubscribe();
 	});
 
 	test("getLocalEpisode prefers a manual local file over a same-titled download", () => {

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, test } from "vitest";
 
 import type { Episode } from "src/types/Episode";
 import type { PlayedEpisode } from "src/types/PlayedEpisode";
-import { playedEpisodes } from "./index";
+import type DownloadedEpisode from "src/types/DownloadedEpisode";
+import { LOCAL_FILES_SETTINGS } from "src/constants";
+import { downloadedEpisodes, localFiles, playedEpisodes } from "./index";
 
 const episode: Episode = {
 	title: "Shared title",
@@ -64,5 +66,192 @@ describe("playedEpisodes store", () => {
 		const stored = get(playedEpisodes);
 		expect(stored[episode.title]?.finished).toBe(false);
 		expect(stored["Design Podcast::Shared title"]?.finished).toBe(false);
+	});
+});
+
+function downloadedEpisode(
+	podcastName: string,
+	title: string,
+	overrides: Partial<DownloadedEpisode> = {},
+): DownloadedEpisode {
+	return {
+		title,
+		streamUrl: `https://example.com/${title}.mp3`,
+		url: `https://example.com/${title}`,
+		description: "",
+		content: "",
+		podcastName,
+		filePath: `podcasts/${podcastName} ${title}.mp3`,
+		size: 1024,
+		...overrides,
+	};
+}
+
+describe("localFiles store — syncWithDownloaded (issue #176)", () => {
+	beforeEach(() => {
+		downloadedEpisodes.set({});
+		localFiles.set({
+			...LOCAL_FILES_SETTINGS,
+			episodes: [],
+		});
+	});
+
+	test("mirrors downloaded episodes across every podcast bucket", () => {
+		localFiles.syncWithDownloaded({
+			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
+			"Podcast B": [
+				downloadedEpisode("Podcast B", "Ep 2"),
+				downloadedEpisode("Podcast B", "Ep 3"),
+			],
+		});
+
+		const titles = get(localFiles).episodes.map((ep) => ep.title);
+		expect(titles).toEqual(["Ep 1", "Ep 2", "Ep 3"]);
+	});
+
+	test("keeps same-title episodes from different podcasts (composite-key dedup)", () => {
+		localFiles.syncWithDownloaded({
+			"Podcast A": [downloadedEpisode("Podcast A", "Shared title")],
+			"Podcast B": [downloadedEpisode("Podcast B", "Shared title")],
+		});
+
+		const episodes = get(localFiles).episodes;
+		expect(episodes).toHaveLength(2);
+		expect(episodes.map((ep) => ep.podcastName).sort()).toEqual([
+			"Podcast A",
+			"Podcast B",
+		]);
+	});
+
+	test("preserves filePath/size and the real podcastName (not coerced)", () => {
+		localFiles.syncWithDownloaded({
+			"Real Podcast": [
+				downloadedEpisode("Real Podcast", "Ep 1", {
+					filePath: "podcasts/real.mp3",
+					size: 4096,
+				}),
+			],
+		});
+
+		const [ep] = get(localFiles).episodes;
+		expect(ep.podcastName).toBe("Real Podcast");
+		expect((ep as DownloadedEpisode).filePath).toBe("podcasts/real.mp3");
+		expect((ep as DownloadedEpisode).size).toBe(4096);
+	});
+
+	test("keeps manual local files with podcastName 'local file'", () => {
+		localFiles.syncWithDownloaded({
+			"local file": [downloadedEpisode("local file", "My Recording")],
+		});
+
+		const [ep] = get(localFiles).episodes;
+		expect(ep.podcastName).toBe("local file");
+	});
+
+	test("removal from downloadedEpisodes propagates to the playlist", () => {
+		const map = {
+			"Podcast A": [
+				downloadedEpisode("Podcast A", "Ep 1"),
+				downloadedEpisode("Podcast A", "Ep 2"),
+			],
+		};
+		localFiles.syncWithDownloaded(map);
+		expect(get(localFiles).episodes).toHaveLength(2);
+
+		localFiles.syncWithDownloaded({
+			"Podcast A": [downloadedEpisode("Podcast A", "Ep 2")],
+		});
+
+		const titles = get(localFiles).episodes.map((ep) => ep.title);
+		expect(titles).toEqual(["Ep 2"]);
+	});
+
+	test("empty map clears the playlist but preserves its metadata", () => {
+		localFiles.syncWithDownloaded({
+			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
+		});
+
+		localFiles.syncWithDownloaded({});
+
+		const playlist = get(localFiles);
+		expect(playlist.episodes).toEqual([]);
+		expect(playlist.name).toBe(LOCAL_FILES_SETTINGS.name);
+		expect(playlist.icon).toBe(LOCAL_FILES_SETTINGS.icon);
+	});
+
+	test("is a no-op when membership is unchanged", () => {
+		const map = {
+			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
+		};
+		localFiles.syncWithDownloaded(map);
+		const before = get(localFiles);
+
+		localFiles.syncWithDownloaded({
+			"Podcast A": [downloadedEpisode("Podcast A", "Ep 1")],
+		});
+
+		// Same key-set -> the store value object is reused (no churn / no extra save).
+		expect(get(localFiles)).toBe(before);
+	});
+
+	test("getLocalEpisode prefers a manual local file over a same-titled download", () => {
+		localFiles.syncWithDownloaded({
+			"Real Podcast": [downloadedEpisode("Real Podcast", "Collision")],
+			"local file": [
+				downloadedEpisode("local file", "Collision", {
+					filePath: "recordings/collision.mp3",
+				}),
+			],
+		});
+
+		expect(localFiles.getLocalEpisode("Collision")?.podcastName).toBe(
+			"local file",
+		);
+	});
+
+	test("dedupes identical composite keys, keeping the first occurrence", () => {
+		localFiles.syncWithDownloaded({
+			"Podcast A": [
+				downloadedEpisode("Podcast A", "Dup", { filePath: "first.mp3" }),
+				downloadedEpisode("Podcast A", "Dup", { filePath: "second.mp3" }),
+			],
+		});
+
+		const episodes = get(localFiles).episodes;
+		expect(episodes).toHaveLength(1);
+		expect((episodes[0] as DownloadedEpisode).filePath).toBe("first.mp3");
+	});
+
+	test("skips entries with no usable episode key", () => {
+		localFiles.syncWithDownloaded({
+			"Podcast A": [
+				downloadedEpisode("Podcast A", ""),
+				downloadedEpisode("Podcast A", "Valid"),
+			],
+		});
+
+		const titles = get(localFiles).episodes.map((ep) => ep.title);
+		expect(titles).toEqual(["Valid"]);
+	});
+
+	test("surfaces a file added only to downloadedEpisodes (getContextMenuHandler flow)", () => {
+		// getContextMenuHandler now writes a manual local file only to
+		// downloadedEpisodes and relies on the projection to surface it.
+		downloadedEpisodes.addEpisode(
+			downloadedEpisode("local file", "My Recording", {
+				filePath: "recordings/my recording.m4a",
+			}),
+			"recordings/my recording.m4a",
+			2048,
+		);
+
+		localFiles.syncWithDownloaded(get(downloadedEpisodes));
+
+		const [ep] = get(localFiles).episodes;
+		expect(ep?.title).toBe("My Recording");
+		expect(ep?.podcastName).toBe("local file");
+		expect((ep as DownloadedEpisode).filePath).toBe(
+			"recordings/my recording.m4a",
+		);
 	});
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ import { ViewState } from "src/types/ViewState";
 import type DownloadedEpisode from "src/types/DownloadedEpisode";
 import { TFile } from "obsidian";
 import type { LocalEpisode } from "src/types/LocalEpisode";
+import { LOCAL_FILES_SETTINGS } from "src/constants";
 import { getEpisodeKey } from "src/utility/episodeKey";
 import {
 	getPlayedEpisode,
@@ -473,6 +474,17 @@ export const favorites = writable<Playlist>({
 	shouldRepeat: false,
 });
 
+function sameEpisodeKeySet(a: Episode[], b: Episode[]): boolean {
+	if (a.length !== b.length) return false;
+
+	const keysInA = new Set(a.map(getEpisodeKey));
+	for (const episode of b) {
+		if (!keysInA.has(getEpisodeKey(episode))) return false;
+	}
+
+	return true;
+}
+
 export const localFiles = (() => {
 	const store = writable<Playlist>({
 		icon: "folder",
@@ -488,10 +500,58 @@ export const localFiles = (() => {
 		subscribe,
 		update,
 		set,
-		getLocalEpisode: (title: string): LocalEpisode | undefined => {
-			const ep = get(store).episodes.find((ep) => ep.title === title);
+		/**
+		 * Mirrors downloadedEpisodes into the Local Files playlist (issue #176).
+		 *
+		 * downloadedEpisodes is the authoritative set of offline-available episodes:
+		 * downloads (createEpisodeFile) and manual local files (getContextMenuHandler)
+		 * both write there. Entries are copied verbatim so filePath/size and the real
+		 * podcastName survive — playback resolves the local file from downloadedEpisodes
+		 * keyed by podcastName::title, so coercing podcastName would break it.
+		 *
+		 * This is a pure projection: it intentionally drops any pre-existing localFiles
+		 * entry that is absent from downloadedEpisodes (stale/removed files). Playable
+		 * files are always present in downloadedEpisodes via the download flow and the
+		 * dual-write in getContextMenuHandler, so nothing reachable is lost — and a
+		 * removed download now correctly disappears from Local Files too.
+		 */
+		syncWithDownloaded: (downloaded: {
+			[podcastName: string]: DownloadedEpisode[];
+		}): void => {
+			update((playlist) => {
+				const seen = new Set<string>();
+				const episodes: Episode[] = [];
 
-			return ep as LocalEpisode;
+				for (const episode of Object.values(downloaded).flat()) {
+					const key = getEpisodeKey(episode);
+					if (!key || seen.has(key)) continue;
+
+					seen.add(key);
+					episodes.push(episode);
+				}
+
+				// Skip the store write (and the resulting saveSettings) when the set of
+				// episodes is unchanged, so unrelated downloadedEpisodes mutations and the
+				// load-time immediate-fire don't churn persistence.
+				if (sameEpisodeKeySet(playlist.episodes, episodes)) {
+					return playlist;
+				}
+
+				return { ...playlist, ...LOCAL_FILES_SETTINGS, episodes };
+			});
+		},
+		getLocalEpisode: (title: string): LocalEpisode | undefined => {
+			const { episodes } = get(store);
+
+			// Prefer a genuine manual local file so a same-titled downloaded episode
+			// (now mirrored into this playlist) can't shadow it in deep-links.
+			const ep =
+				episodes.find(
+					(episode) =>
+						episode.title === title && episode.podcastName === "local file",
+				) ?? episodes.find((episode) => episode.title === title);
+
+			return ep as LocalEpisode | undefined;
 		},
 		updateStreamUrl: (title: string, newUrl: string): void => {
 			store.update((playlist) => {
@@ -502,21 +562,9 @@ export const localFiles = (() => {
 				return playlist;
 			});
 		},
-		addEpisode: (episode: LocalEpisode): void => {
-			store.update((playlist) => {
-				const idx = playlist.episodes.findIndex(
-					(ep) => ep.title === episode.title,
-				);
-
-				if (idx !== -1) {
-					playlist.episodes[idx] = episode;
-				} else {
-					playlist.episodes.push(episode);
-				}
-
-				return playlist;
-			});
-		},
+		// NOTE: the Local Files playlist is now a projection of downloadedEpisodes
+		// (see syncWithDownloaded). Add files by writing to downloadedEpisodes; a direct
+		// imperative add here would be overwritten by the next mirror pass.
 	};
 })();
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -518,27 +518,27 @@ export const localFiles = (() => {
 		syncWithDownloaded: (downloaded: {
 			[podcastName: string]: DownloadedEpisode[];
 		}): void => {
-			update((playlist) => {
-				const seen = new Set<string>();
-				const episodes: Episode[] = [];
+			const seen = new Set<string>();
+			const episodes: Episode[] = [];
 
-				for (const episode of Object.values(downloaded).flat()) {
-					const key = getEpisodeKey(episode);
-					if (!key || seen.has(key)) continue;
+			for (const episode of Object.values(downloaded).flat()) {
+				const key = getEpisodeKey(episode);
+				if (!key || seen.has(key)) continue;
 
-					seen.add(key);
-					episodes.push(episode);
-				}
+				seen.add(key);
+				episodes.push(episode);
+			}
 
-				// Skip the store write (and the resulting saveSettings) when the set of
-				// episodes is unchanged, so unrelated downloadedEpisodes mutations and the
-				// load-time immediate-fire don't churn persistence.
-				if (sameEpisodeKeySet(playlist.episodes, episodes)) {
-					return playlist;
-				}
+			// Skip the store write entirely when membership is unchanged. Returning the
+			// same object from update() would still notify subscribers (Svelte treats
+			// every object value as changed), re-running LocalFilesController.onChange and
+			// saveSettings on every unrelated downloadedEpisodes mutation and the
+			// load-time immediate-fire. Comparing before touching the store avoids that.
+			if (sameEpisodeKeySet(get(store).episodes, episodes)) {
+				return;
+			}
 
-				return { ...playlist, ...LOCAL_FILES_SETTINGS, episodes };
-			});
+			update((playlist) => ({ ...playlist, ...LOCAL_FILES_SETTINGS, episodes }));
 		},
 		getLocalEpisode: (title: string): LocalEpisode | undefined => {
 			const { episodes } = get(store);


### PR DESCRIPTION
Closes #176

## Summary
Downloaded episodes never appeared in the Podcast grid's **Local Files** playlist — it showed "No episodes found" even though the file was on disk and the episode list offered **Remove file**.

Root cause: the download flow (`createEpisodeFile` → `downloadedEpisodes.addEpisode`) recorded episodes only in the `downloadedEpisodes` store, while the Local Files playlist (`localFiles` store) was only ever populated by the file-explorer **Play with PodNotes** menu. The two stores drifted. (The reporter's `{{title}}`-less download path was a red herring — the playlist was empty regardless of path.)

## Fix
Make `localFiles` a **change-gated projection of `downloadedEpisodes`** — the authoritative set of offline-available episodes (both downloads and manual local files write there):

- `src/store/index.ts`: new `localFiles.syncWithDownloaded()` — flattens all podcasts, dedupes by `podcastName::title` (`getEpisodeKey`), copies entries **verbatim** so `filePath`/`size`/real `podcastName` survive (playback resolves the local file from `downloadedEpisodes` by that key), and no-ops when membership is unchanged to avoid persistence churn. Hardened `getLocalEpisode` to prefer genuine `"local file"` entries so a same-titled download can't shadow a manual local file in deep-links.
- `src/main.ts`: subscribe `downloadedEpisodes` → mirror into `localFiles`; Svelte's immediate-fire **backfills existing downloads on load**. Unsubscribed in `onunload`.
- `src/getContextMenuHandler.ts`: removed the now-redundant `localFiles.addEpisode` (the `downloadedEpisodes` write drives the mirror).
- Docs + tests updated.

Side benefit: **Remove file** now also removes the episode from Local Files (fixes a latent asymmetry).

The frozen `src/ui/PodcastView/*` files (PR #173) are untouched — the fix flows entirely through the `localFiles` store that `PodcastView` already renders.

## Release / migration impact
No settings migration. `settings.localFiles` is now derived (re-projected from `downloadedEpisodes` each load); existing users' previously-downloaded episodes are backfilled automatically on next load. A pure mirror intentionally drops any stale `localFiles` entry absent from `downloadedEpisodes` (the on-disk file is untouched and recoverable via Play with PodNotes).

## Verification
Commands: `npm run typecheck` ✅, `npm run lint` ✅, `npm run format:check` ✅, `npm run test` ✅ (164 passed, +10 new store tests), `npm run build` ✅. (`docs:build` not run locally — `mkdocs` unavailable in the dev environment.)

**Obsidian runtime verification** (real app, dev vault, reporter's path `podcasts/{{podcast}} {{date}}`, test audio `download.samplelib.com/mp3/sample-3s.mp3`):
- Before: Local Files card `(0)` → "No episodes found."
- After: card `(1)` → episode listed, with real `podcastName` and `filePath`/`size` preserved; file written to disk.