### PR TITLE
fix(download): prevent Android crash and create missing folders on download

### DIFF
--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { DownloadPathTemplateEngine } from "./TemplateEngine";
+import type { Episode } from "./types/Episode";
+
+// The illegal-character sanitizer is private; exercise it through
+// DownloadPathTemplateEngine, which applies it to {{title}} and {{podcast}}.
+function sanitizeTitle(title: string): string {
+	const episode = {
+		title,
+		streamUrl: "https://example.com/a.mp3",
+		url: "https://example.com",
+		description: "",
+		content: "",
+		podcastName: "Pod",
+		episodeDate: undefined,
+		artworkUrl: "",
+	} as unknown as Episode;
+
+	return DownloadPathTemplateEngine("{{title}}", episode);
+}
+
+describe("replaceIllegalFileNameCharactersInString (via DownloadPathTemplateEngine)", () => {
+	it("preserves dots in titles (no more 'Episode 1.5' -> 'Episode 15')", () => {
+		expect(sanitizeTitle("Episode 1.5")).toBe("Episode 1.5");
+	});
+
+	it("still strips filesystem-illegal and wikilink-hostile characters", () => {
+		expect(sanitizeTitle('a/b\\c:d*e?f"g<h>i|j')).toBe("abcdefghij");
+		expect(sanitizeTitle("a#b%c&d{e}f")).toBe("abcdef");
+	});
+
+	it("replaces every control character with a space (global), not just the first", () => {
+		expect(sanitizeTitle("a\nb\nc")).toBe("a b c");
+		expect(sanitizeTitle("a\tb\rc")).toBe("a b c");
+	});
+
+	it("collapses every run of whitespace, not just the first", () => {
+		expect(sanitizeTitle("a  b  c")).toBe("a b c");
+	});
+
+	it("drops leading and trailing dots", () => {
+		expect(sanitizeTitle("...hidden")).toBe("hidden");
+		expect(sanitizeTitle("trailing...")).toBe("trailing");
+	});
+
+	it("does not strip hyphens or ordinary letters", () => {
+		expect(sanitizeTitle("Part 1 - The Beginning")).toBe(
+			"Part 1 - The Beginning",
+		);
+	});
+});

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -243,8 +243,24 @@ export function TranscriptTemplateEngine(
 }
 
 function replaceIllegalFileNameCharactersInString(string: string) {
-	return string
-		.replace(/[\\,#%&{}/*<>$'":@\u2023|\\.?]/g, "") // Replace illegal file name characters with empty string
-		.replace(/\n/, " ") // replace newlines with spaces
-		.replace("  ", " "); // replace multiple spaces with single space to make sure we don't have double spaces in the file name
+	return (
+		string
+			// Strip characters that are illegal in file names on major platforms,
+			// plus a few the plugin removes for clean paths/wikilinks. Dots are
+			// intentionally preserved so titles like "Episode 1.5" are not mangled
+			// into "Episode 15".
+			.replace(/[\\,#%&{}/*<>$'":@\u2023|?]/g, "")
+			// Replace any control characters (newlines, tabs, carriage returns)
+			// with spaces so they can never end up in a file name.
+			// eslint-disable-next-line no-control-regex
+			.replace(/[\u0000-\u001f]/g, " ")
+			// Collapse every run of whitespace into a single space.
+			.replace(/\s+/g, " ")
+			.trim()
+			// Avoid leading/trailing dots, which create hidden files or "."/".."
+			// segments and are rejected on Windows/Android.
+			.replace(/^\.+/, "")
+			.replace(/\.+$/, "")
+			.trim()
+	);
 }

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+import { requestUrl, TFile } from "obsidian";
+import {
+	detectAudioFileExtension,
+	downloadEpisode,
+} from "./downloadEpisode";
+import { downloadedEpisodes } from "./store";
+import type { Episode } from "./types/Episode";
+
+vi.mock("obsidian", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("obsidian")>();
+	return { ...actual, requestUrl: vi.fn() };
+});
+
+const requestUrlMock = vi.mocked(requestUrl);
+
+function bytes(...values: number[]): ArrayBuffer {
+	return new Uint8Array(values).buffer;
+}
+
+function setupVault() {
+	const present = new Set<string>();
+	const createdFolders: string[] = [];
+
+	const createBinary = vi.fn(async (path: string, _data: ArrayBuffer) => {
+		present.add(path);
+		return new TFile();
+	});
+	const createFolder = vi.fn(async (path: string) => {
+		present.add(path);
+		createdFolders.push(path);
+	});
+
+	(globalThis as { app?: unknown }).app = {
+		vault: {
+			getAbstractFileByPath: (path: string) =>
+				present.has(path) ? new TFile() : null,
+			createBinary,
+			createFolder,
+		},
+	};
+
+	return { present, createdFolders, createBinary, createFolder };
+}
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+	return {
+		title: "My Title",
+		streamUrl: "https://example.com/ep.mp3",
+		url: "https://example.com/ep",
+		description: "",
+		content: "",
+		podcastName: "Pod",
+		episodeDate: undefined,
+		artworkUrl: "",
+		...overrides,
+	} as unknown as Episode;
+}
+
+beforeEach(() => {
+	requestUrlMock.mockReset();
+	downloadedEpisodes.set({});
+});
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+});
+
+describe("detectAudioFileExtension", () => {
+	it("matches exact signatures (ID3 -> mp3, RIFF -> wav, m4a)", () => {
+		expect(detectAudioFileExtension(bytes(0x49, 0x44, 0x33, 0x04))).toBe("mp3");
+		expect(detectAudioFileExtension(bytes(0x52, 0x49, 0x46, 0x46))).toBe("wav");
+		expect(detectAudioFileExtension(bytes(0x4d, 0x34, 0x41, 0x20))).toBe("m4a");
+	});
+
+	it("applies the masked MPEG frame-sync signature", () => {
+		expect(detectAudioFileExtension(bytes(0xff, 0xfb, 0x90, 0x00))).toBe("mp3");
+	});
+
+	it("returns null for unknown content", () => {
+		expect(detectAudioFileExtension(bytes(0x00, 0x01, 0x02, 0x03))).toBeNull();
+	});
+
+	it("does not crash on a buffer shorter than the longest signature", () => {
+		expect(detectAudioFileExtension(bytes(0xff))).toBeNull();
+		expect(detectAudioFileExtension(new ArrayBuffer(0))).toBeNull();
+	});
+});
+
+describe("downloadEpisode (API path)", () => {
+	it("threads a single ArrayBuffer straight to createBinary (no Blob copy) and creates folders", async () => {
+		const { createBinary, createdFolders } = setupVault();
+		const buffer = bytes(0x49, 0x44, 0x33, 0x01, 0x02, 0x03);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "audio/mpeg" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+
+		const episode = makeEpisode();
+		const path = await downloadEpisode(episode, "podcast/{{podcast}}/{{title}}");
+
+		expect(path).toBe("podcast/Pod/My Title.mp3");
+		expect(createdFolders).toEqual(["podcast", "podcast/Pod"]);
+		expect(createBinary).toHaveBeenCalledTimes(1);
+
+		const [writtenPath, writtenData] = createBinary.mock.calls[0];
+		expect(writtenPath).toBe("podcast/Pod/My Title.mp3");
+		// The exact buffer returned by requestUrl must reach createBinary — proving
+		// no Blob round-trip / extra full-file copy is made (issue #113).
+		expect(writtenData).toBe(buffer);
+
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded?.filePath).toBe("podcast/Pod/My Title.mp3");
+		expect(recorded?.size).toBe(buffer.byteLength);
+	});
+
+	it("returns the existing path without downloading when the file already exists", async () => {
+		const { present, createBinary } = setupVault();
+		present.add("My Title.mp3");
+
+		const path = await downloadEpisode(makeEpisode(), "{{title}}");
+
+		expect(path).toBe("My Title.mp3");
+		expect(requestUrlMock).not.toHaveBeenCalled();
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+});

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -4,6 +4,7 @@ import { DownloadPathTemplateEngine } from "./TemplateEngine";
 import type { Episode } from "./types/Episode";
 import type { LocalEpisode } from "./types/LocalEpisode";
 import { encodeUrlForRequest } from "./utility/encodeUrlForRequest";
+import { ensureFolderExists } from "./utility/ensureFolderExists";
 import { isLocalFile } from "./utility/isLocalFile";
 import getUrlExtension from "./utility/getUrlExtension";
 import getExtensionFromContentType from "./utility/getExtensionFromContentType";
@@ -12,13 +13,25 @@ function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+interface DownloadedFile {
+	/**
+	 * The raw episode bytes, held exactly once. On memory-constrained mobile
+	 * (Android) WebViews this single buffer is threaded straight to
+	 * `vault.createBinary`; wrapping it in a Blob and round-tripping back to an
+	 * ArrayBuffer used to triple the peak heap and OOM-crash the app (issue #113).
+	 */
+	data: ArrayBuffer;
+	contentType: string;
+	byteLength: number;
+}
+
 async function downloadFile(
 	url: string,
 	options?: Partial<{
 		onFinished: () => void;
 		onError: (error: Error) => void;
 	}>,
-) {
+): Promise<DownloadedFile> {
 	const encodedUrl = encodeUrlForRequest(url);
 	try {
 		const response = await requestUrl({ url: encodedUrl, method: "GET" });
@@ -27,21 +40,18 @@ async function downloadFile(
 			throw new Error("Could not download episode.");
 		}
 
-		const contentLength = response.arrayBuffer.byteLength;
+		// Read the decoded buffer once and keep that single reference. `requestUrl`
+		// has no streaming API, so this 1x copy is unavoidable; everything
+		// downstream reuses it instead of allocating further copies.
+		const data = response.arrayBuffer;
+		const contentType =
+			response.headers["content-type"] ??
+			response.headers["Content-Type"] ??
+			"";
 
 		options?.onFinished?.();
 
-		return {
-			blob: new Blob([response.arrayBuffer], {
-				type:
-					response.headers["content-type"] ??
-					response.headers["Content-Type"] ??
-					"",
-			}),
-			contentLength,
-			receivedLength: contentLength,
-			responseUrl: encodedUrl,
-		};
+		return { data, contentType, byteLength: data.byteLength };
 	} catch (error: unknown) {
 		const err = new Error(
 			`Failed to download ${url}:\n\n${getErrorMessage(error)}`,
@@ -66,7 +76,7 @@ export default async function downloadEpisodeWithNotice(
 		bodyEl.createEl("p", { text: "Downloading..." });
 	});
 
-	const { blob } = await downloadFile(episode.streamUrl, {
+	const { data, contentType } = await downloadFile(episode.streamUrl, {
 		onFinished: () => {
 			update((bodyEl) => bodyEl.createEl("p", { text: "Download complete!" }));
 		},
@@ -79,14 +89,18 @@ export default async function downloadEpisodeWithNotice(
 		},
 	});
 
-	const inferredExtension = await inferFileExtensionFromDownload(episode, blob);
-	const normalizedType = (blob.type ?? "").toLowerCase();
+	const inferredExtension = inferFileExtensionFromDownload(
+		episode,
+		data,
+		contentType,
+	);
+	const normalizedType = contentType.toLowerCase();
 	const typeAppearsAudio = normalizedType === "" || normalizedType.includes("audio");
 
 	if (!typeAppearsAudio && !inferredExtension) {
 		update((bodyEl) => {
 			bodyEl.createEl("p", {
-				text: `Downloaded file is not an audio file. It is of type "${blob.type}". Blob: ${blob.size} bytes.`,
+				text: `Downloaded file is not an audio file. It is of type "${contentType}". File: ${data.byteLength} bytes.`,
 			});
 		});
 
@@ -101,7 +115,7 @@ export default async function downloadEpisodeWithNotice(
 		await createEpisodeFile({
 			episode,
 			downloadPathTemplate,
-			blob,
+			data,
 			extension: fileExtension,
 		});
 
@@ -155,28 +169,32 @@ function createNoticeDoc(title: string) {
 async function createEpisodeFile({
 	episode,
 	downloadPathTemplate,
-	blob,
+	data,
 	extension,
 }: {
 	episode: Episode;
 	downloadPathTemplate: string;
-	blob: Blob;
+	data: ArrayBuffer;
 	extension: string;
 }) {
 	const basename = DownloadPathTemplateEngine(downloadPathTemplate, episode);
 	const filePath = `${basename}.${extension}`;
 
-	const buffer = await blob.arrayBuffer();
+	// `createBinary` throws if a parent folder is missing, which previously left
+	// users with a templated path like `podcast/{{podcast}}/{{title}}` unable to
+	// download anything (issue #86). Create the folders first.
+	const folderPath = filePath.split("/").slice(0, -1).join("/");
+	await ensureFolderExists(folderPath);
 
 	try {
-		await app.vault.createBinary(filePath, buffer);
+		await app.vault.createBinary(filePath, data);
 	} catch (error: unknown) {
 		throw new Error(
 			`Failed to write file "${filePath}": ${getErrorMessage(error)}`,
 		);
 	}
 
-	downloadedEpisodes.addEpisode(episode, filePath, blob.size);
+	downloadedEpisodes.addEpisode(episode, filePath, data.byteLength);
 }
 
 function resolveLocalEpisodeFilePath(episode: LocalEpisode): string | null {
@@ -229,11 +247,12 @@ function getLocalFilePathFromLink(link: string): string | null {
 	return null;
 }
 
-async function inferFileExtensionFromDownload(
+function inferFileExtensionFromDownload(
 	episode: Episode,
-	blob: Blob,
-): Promise<string | null> {
-	const signatureExtension = await detectAudioFileExtension(blob);
+	data: ArrayBuffer,
+	contentType: string,
+): string | null {
+	const signatureExtension = detectAudioFileExtension(data);
 	if (signatureExtension) {
 		return signatureExtension;
 	}
@@ -243,7 +262,7 @@ async function inferFileExtensionFromDownload(
 		return urlExtension;
 	}
 
-	return getExtensionFromContentType(blob.type);
+	return getExtensionFromContentType(contentType);
 }
 
 export async function downloadEpisode(
@@ -272,16 +291,16 @@ export async function downloadEpisode(
 	}
 
 	try {
-		const { blob } = await downloadFile(episode.streamUrl);
+		const { data, contentType } = await downloadFile(episode.streamUrl);
 
-		if (!blob.type.includes("audio") && !fileExtension) {
+		if (!contentType.includes("audio") && !fileExtension) {
 			throw new Error("Not an audio file.");
 		}
 
 		await createEpisodeFile({
 			episode,
 			downloadPathTemplate,
-			blob,
+			data,
 			extension: fileExtension,
 		});
 
@@ -321,9 +340,7 @@ interface AudioSignature {
 	fileExtension: string;
 }
 
-export async function detectAudioFileExtension(
-	blob: Blob,
-): Promise<string | null> {
+export function detectAudioFileExtension(data: ArrayBuffer): string | null {
 	const audioSignatures: AudioSignature[] = [
 		{ signature: [0xff, 0xe0], mask: [0xff, 0xe0], fileExtension: "mp3" },
 		{ signature: [0x49, 0x44, 0x33], fileExtension: "mp3" },
@@ -341,48 +358,40 @@ export async function detectAudioFileExtension(
 		},
 	];
 
-	return new Promise((resolve, reject) => {
-		const fileReader = new FileReader();
-		fileReader.onloadend = (e) => {
-			if (!e.target?.result) {
-				reject(new Error("No result from file reader"));
-				return;
-			}
+	const maxSignatureLength = Math.max(
+		...audioSignatures.map((sig) => sig.signature.length),
+	);
+	// Zero-copy view over just the header bytes — no Blob slice, no FileReader,
+	// no extra full-file allocation.
+	const arr = new Uint8Array(
+		data,
+		0,
+		Math.min(maxSignatureLength, data.byteLength),
+	);
 
-			const arr = new Uint8Array(e.target.result as ArrayBuffer);
+	for (const { signature, mask, fileExtension } of audioSignatures) {
+		if (signature.length > arr.length) {
+			continue;
+		}
 
-			for (const { signature, mask, fileExtension } of audioSignatures) {
-				let matches = true;
-				for (let i = 0; i < signature.length; i++) {
-					if (mask) {
-						if ((arr[i] & mask[i]) !== (signature[i] & mask[i])) {
-							matches = false;
-							break;
-						}
-					} else {
-						if (arr[i] !== signature[i]) {
-							matches = false;
-							break;
-						}
-					}
+		let matches = true;
+		for (let i = 0; i < signature.length; i++) {
+			if (mask) {
+				if ((arr[i] & mask[i]) !== (signature[i] & mask[i])) {
+					matches = false;
+					break;
 				}
-				if (matches) {
-					resolve(fileExtension);
-					return;
+			} else {
+				if (arr[i] !== signature[i]) {
+					matches = false;
+					break;
 				}
 			}
-			resolve(null);
-		};
+		}
+		if (matches) {
+			return fileExtension;
+		}
+	}
 
-		fileReader.onerror = () => {
-			reject(fileReader.error);
-		};
-
-		fileReader.readAsArrayBuffer(
-			blob.slice(
-				0,
-				Math.max(...audioSignatures.map((sig) => sig.signature.length)),
-			),
-		);
-	});
+	return null;
 }

--- a/src/utility/ensureFolderExists.test.ts
+++ b/src/utility/ensureFolderExists.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureFolderExists } from "./ensureFolderExists";
+
+function setupApp(existing: string[] = []) {
+	const present = new Set(existing);
+	const created: string[] = [];
+
+	const createFolder = vi.fn(async (path: string) => {
+		// Vault.createFolder throws if the folder already exists — the helper
+		// must never call it for an existing prefix.
+		if (present.has(path)) {
+			throw new Error(`Folder already exists: ${path}`);
+		}
+		present.add(path);
+		created.push(path);
+	});
+
+	(globalThis as { app?: unknown }).app = {
+		vault: {
+			getAbstractFileByPath: (path: string) =>
+				present.has(path) ? { path } : null,
+			createFolder,
+		},
+	};
+
+	return { created, createFolder };
+}
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+});
+
+describe("ensureFolderExists", () => {
+	it("creates each missing segment, parents first", async () => {
+		const { created } = setupApp();
+
+		await ensureFolderExists("podcast/My Show/Season 1");
+
+		expect(created).toEqual([
+			"podcast",
+			"podcast/My Show",
+			"podcast/My Show/Season 1",
+		]);
+	});
+
+	it("does not recreate existing intermediate folders", async () => {
+		const { created, createFolder } = setupApp(["podcast", "podcast/My Show"]);
+
+		await expect(
+			ensureFolderExists("podcast/My Show/Season 1"),
+		).resolves.toBeUndefined();
+
+		expect(created).toEqual(["podcast/My Show/Season 1"]);
+		expect(createFolder).toHaveBeenCalledTimes(1);
+	});
+
+	it("is a no-op for an empty path (file at the vault root)", async () => {
+		const { created, createFolder } = setupApp();
+
+		await ensureFolderExists("");
+
+		expect(created).toEqual([]);
+		expect(createFolder).not.toHaveBeenCalled();
+	});
+
+	it("ignores empty segments from leading/trailing/double slashes", async () => {
+		const { created } = setupApp();
+
+		await ensureFolderExists("a//b/");
+
+		expect(created).toEqual(["a", "a/b"]);
+	});
+});

--- a/src/utility/ensureFolderExists.ts
+++ b/src/utility/ensureFolderExists.ts
@@ -1,0 +1,21 @@
+/**
+ * Creates every missing folder along `folderPath`, one segment at a time.
+ *
+ * `Vault.createFolder` throws when the folder already exists, so each prefix is
+ * guarded with `getAbstractFileByPath` before it is created — mirroring the
+ * loops already used in `createPodcastNote` and `TranscriptionService`.
+ *
+ * `folderPath` is a directory path (no trailing file name). An empty path is a
+ * no-op, so callers can pass the directory portion of a file path directly.
+ */
+export async function ensureFolderExists(folderPath: string): Promise<void> {
+	const segments = folderPath.split("/").filter(Boolean);
+
+	let current = "";
+	for (const segment of segments) {
+		current = current ? `${current}/${segment}` : segment;
+		if (!app.vault.getAbstractFileByPath(current)) {
+			await app.vault.createFolder(current);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the long-standing **Android crash when downloading a podcast** (#113), where Obsidian crashes mid-download and no file is created. Also fixes the related **"no file created" with a templated download folder** (#86).

## Root cause

The download path buffered the entire episode via `requestUrl` (kept deliberately over `fetch` to avoid the CORS failures from #31 — `requestUrl` has no streaming), then made **two more full-size copies** before writing:

| copy | where |
|---|---|
| `response.arrayBuffer` | `requestUrl` result |
| `new Blob([response.arrayBuffer])` | `downloadFile` |
| `await blob.arrayBuffer()` | `createEpisodeFile` → `createBinary` |

On Android these ~3× coexist in a memory-constrained Capacitor WebView, so a typical 50–200 MB episode OOM-crashes the app mid-download — matching #113 and #86 (the latter reproduced even with download path `"A"`, ruling out illegal chars / missing folders as the *crash* trigger).

## Changes

1. **Memory (the crash).** `downloadFile` now returns a single `{ data, contentType, byteLength }` and that one `ArrayBuffer` is threaded straight into `vault.createBinary` — the `Blob` wrap and `Blob→ArrayBuffer` round-trip are gone. Audio-signature detection reads a zero-copy `Uint8Array` view instead of `Blob.slice` + `FileReader`. PodNotes-side peak heap drops from ~3× to ~1× the episode size. Applied to both download functions; each keeps its **distinct** extension strategy (UI = byte-signature → URL → content-type; API = URL → HEAD content-type → `mp3`) and the dual-cased content-type lookup.

2. **Missing folders (#86).** New `src/utility/ensureFolderExists.ts` creates parent folders (per-segment guarded, since `createFolder` throws on an existing folder) before `createBinary`, so paths like `podcast/{{podcast}}/{{title}}` can write at all.

3. **File-name sanitizer.** `replaceIllegalFileNameCharactersInString` now preserves dots (`Episode 1.5` no longer becomes `Episode 15`), replaces control chars with spaces **globally**, collapses whitespace, and trims leading/trailing dots — fixing the old non-global-flag bugs.

## Honest caveats

- **This is a mitigation, not a guaranteed cure for arbitrarily large files.** Disassembling the installed Obsidian build shows the dominant unavoidable peak is *inside* `requestUrl`'s native base64 decode (`atob` → binary string → `Uint8Array`), which no plugin can reduce. The fix removes every copy PodNotes controls; the very largest episodes on the most memory-starved devices may still OOM.
- **Filename churn (intentional).** Because the sanitizer now preserves dots / collapses whitespace differently, a previously-downloaded episode whose title contained a dot (e.g. stored as `Episode 15.mp3`) will be re-downloaded once under the corrected name (`Episode 1.5.mp3`), leaving the old file orphaned.
- A title that sanitizes to empty (all-whitespace) now yields `.mp3` (previously `  .mp3` — both broken; vanishingly rare). Possible follow-up.

## Verification

- **Gates (Node 22):** `lint`, `typecheck`, `format:check` (Biome), `check:a11y` (svelte-check, 604 files / 0), `build`, and the full **test suite (172 passing, 16 new)** all green.
- **Real Obsidian runtime (dev vault):** confirmed `createBinary` throws `ENOENT` on a missing folder, writes the **exact bytes** from an `ArrayBuffer` once the folder exists, and `createFolder` throws on an existing folder — validating both fixes' premises in the live app. The Android OOM itself is not reproducible on desktop (ample heap); desktop is a proxy for the path/write logic only.
- **Adversarial review:** design + implementation passes (multi-agent), no blockers.

## Notes

- No public docs changed (the only doc reference is an illustrative QuickAdd macro snippet that already omits the dot).

Closes #113
Closes #86
