### PR TITLE
feat(queue): allow reordering the playback queue

### DIFF
--- a/docs/docs/podcasts.md
+++ b/docs/docs/podcasts.md
@@ -14,6 +14,8 @@ The playlists are shown in the episode grid, represented by their icons.
 
 By default, you will have a queue playlist and a favorites playlist.
 
+The queue plays from top to bottom: the episode at the top is played next. See [Reordering the queue](#reordering-the-queue) to resequence it.
+
 PodNotes also shows a Played playlist in the episode grid. It is a virtual playlist that lists episodes marked as played across all podcasts. Episodes still available in your feeds can be played or managed like normal episodes. Older played-history entries that can no longer be found in current feeds remain visible so you can mark them as unplayed.
 
 You can delete playlists by pressing the trash bin icon next to the playlist name.
@@ -39,6 +41,18 @@ The context menu will let you
 - Add / remove the episode to favorites
 - Add / remove the episode to queue
 - Add / remove the episode to a playlist
+
+When you open the context menu on an episode in the queue list (shown in the player), it also offers **Move to top / up / down / bottom of queue** so you can resequence without leaving the player.
+
+## Reordering the queue
+The queue plays from the top down, so its order is its play order. There are two ways to change it:
+
+- **From the player's queue list:** right-click (desktop) or long-press (mobile) a queued episode and choose **Move to top**, **Move up**, **Move down**, or **Move to bottom of queue**.
+- **From the command palette:** run **PodNotes: Reorder Queue** to open a dedicated window listing the whole queue, where each episode has move-up / move-down / move-to-top / move-to-bottom buttons (and a remove button). This works the same on desktop and mobile and is the easiest way to resequence a long queue.
+
+The new order is saved automatically and restored the next time you open Obsidian.
+
+Episodes in the queue are kept unique by title, so adding an episode that is already queued will not create a duplicate.
 
 ## Player
 The player will automatically load and play the current episode.

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import type { IAPI } from "src/API/IAPI";
 import { DEFAULT_SETTINGS, VIEW_TYPE } from "src/constants";
 import { PodNotesSettingsTab } from "src/ui/settings/PodNotesSettingsTab";
 import { MainView } from "src/ui/PodcastView";
+import { QueueReorderModal } from "src/ui/QueueReorderModal";
 import type { IPodNotesSettings } from "./types/IPodNotesSettings";
 import { plugin } from "./store";
 import type { IPodNotes } from "./types/IPodNotes";
@@ -44,7 +45,7 @@ import getContextMenuHandler from "./getContextMenuHandler";
 import getUniversalPodcastLink from "./getUniversalPodcastLink";
 import type { IconType } from "./types/IconType";
 import { TranscriptionService } from "./services/TranscriptionService";
-import type { Unsubscriber } from "svelte/store";
+import { get, type Unsubscriber } from "svelte/store";
 
 export default class PodNotes extends Plugin implements IPodNotes {
 	public api!: IAPI;
@@ -217,6 +218,19 @@ export default class PodNotes extends Plugin implements IPodNotes {
 
 				const episode = this.api.podcast;
 				downloadEpisodeWithNotice(episode, this.settings.download.path);
+			},
+		});
+
+		this.addCommand({
+			id: "reorder-queue",
+			name: "Reorder Queue",
+			icon: "list-ordered" as IconType,
+			checkCallback: (checking) => {
+				if (checking) {
+					return get(queue).episodes.length > 1;
+				}
+
+				new QueueReorderModal(this.app).open();
 			},
 		});
 

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -1,9 +1,18 @@
 import { get } from "svelte/store";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Episode } from "src/types/Episode";
+import type { IPodNotes } from "src/types/IPodNotes";
 import type { PlayedEpisode } from "src/types/PlayedEpisode";
-import { playedEpisodes } from "./index";
+import { QUEUE_SETTINGS } from "src/constants";
+import { QueueController } from "src/store_controllers/QueueController";
+import {
+	currentEpisode,
+	dedupeEpisodesByTitle,
+	playedEpisodes,
+	queue,
+	reorderEpisodes,
+} from "./index";
 
 const episode: Episode = {
 	title: "Shared title",
@@ -64,5 +73,166 @@ describe("playedEpisodes store", () => {
 		const stored = get(playedEpisodes);
 		expect(stored[episode.title]?.finished).toBe(false);
 		expect(stored["Design Podcast::Shared title"]?.finished).toBe(false);
+	});
+});
+
+function ep(title: string, podcastName = "Pod"): Episode {
+	return {
+		title,
+		streamUrl: `https://example.com/${title}.mp3`,
+		url: `https://example.com/${title}`,
+		description: "",
+		content: "",
+		podcastName,
+	};
+}
+
+function queueTitles(): string[] {
+	return get(queue).episodes.map((e) => e.title);
+}
+
+function setQueue(...titles: string[]) {
+	queue.set({
+		...QUEUE_SETTINGS,
+		episodes: titles.map((title) => ep(title)),
+	});
+}
+
+describe("reorderEpisodes", () => {
+	const episodes = [ep("A"), ep("B"), ep("C"), ep("D")];
+	const titles = (list: Episode[]) => list.map((e) => e.title);
+
+	test("moves forward (from < to)", () => {
+		expect(titles(reorderEpisodes(episodes, 0, 2))).toEqual([
+			"B",
+			"C",
+			"A",
+			"D",
+		]);
+	});
+
+	test("moves backward (from > to)", () => {
+		expect(titles(reorderEpisodes(episodes, 3, 1))).toEqual([
+			"A",
+			"D",
+			"B",
+			"C",
+		]);
+	});
+
+	test("move to last index truly lands last", () => {
+		expect(titles(reorderEpisodes(episodes, 0, episodes.length - 1))).toEqual([
+			"B",
+			"C",
+			"D",
+			"A",
+		]);
+	});
+
+	test("returns the same reference for no-op / out-of-range indices", () => {
+		expect(reorderEpisodes(episodes, 1, 1)).toBe(episodes);
+		expect(reorderEpisodes(episodes, -1, 0)).toBe(episodes);
+		expect(reorderEpisodes(episodes, 0, 99)).toBe(episodes);
+		expect(reorderEpisodes(episodes, 99, 0)).toBe(episodes);
+	});
+
+	test("does not mutate the input array", () => {
+		const input = [ep("A"), ep("B"), ep("C")];
+		reorderEpisodes(input, 0, 2);
+		expect(titles(input)).toEqual(["A", "B", "C"]);
+	});
+});
+
+describe("dedupeEpisodesByTitle", () => {
+	test("keeps the first occurrence and preserves order", () => {
+		const result = dedupeEpisodesByTitle([
+			ep("A"),
+			ep("B"),
+			ep("A"),
+			ep("C"),
+		]);
+		expect(result.map((e) => e.title)).toEqual(["A", "B", "C"]);
+	});
+
+	test("handles empty / undefined input", () => {
+		expect(dedupeEpisodesByTitle([])).toEqual([]);
+		expect(dedupeEpisodesByTitle()).toEqual([]);
+	});
+});
+
+describe("queue store", () => {
+	beforeEach(() => {
+		queue.set({ ...QUEUE_SETTINGS, episodes: [] });
+	});
+
+	test("add dedupes episodes by title", () => {
+		queue.add(ep("A"));
+		queue.add(ep("A"));
+		queue.add(ep("B"));
+
+		expect(queueTitles()).toEqual(["A", "B"]);
+	});
+
+	test("set dedupes a persisted queue that already has duplicate titles", () => {
+		queue.set({
+			...QUEUE_SETTINGS,
+			episodes: [ep("A"), ep("B"), ep("A"), ep("C"), ep("B")],
+		});
+
+		expect(queueTitles()).toEqual(["A", "B", "C"]);
+	});
+
+	test("moveToTop / moveToBottom reorder the queue", () => {
+		setQueue("A", "B", "C");
+
+		queue.moveToBottom(0);
+		expect(queueTitles()).toEqual(["B", "C", "A"]);
+
+		queue.moveToTop(2);
+		expect(queueTitles()).toEqual(["A", "B", "C"]);
+	});
+
+	test("moveUp / moveDown shift a single position", () => {
+		setQueue("A", "B", "C");
+
+		queue.moveDown(0);
+		expect(queueTitles()).toEqual(["B", "A", "C"]);
+
+		queue.moveUp(2);
+		expect(queueTitles()).toEqual(["B", "C", "A"]);
+	});
+
+	test("end and out-of-range moves are no-ops", () => {
+		setQueue("A", "B", "C");
+
+		queue.moveUp(0);
+		queue.moveDown(2);
+		queue.move(-1, 0);
+		queue.move(0, 99);
+
+		expect(queueTitles()).toEqual(["A", "B", "C"]);
+	});
+
+	test("a move persists the new order through QueueController", () => {
+		setQueue("A", "B", "C");
+		currentEpisode.set(undefined as unknown as Episode, false);
+
+		const fakePlugin = {
+			settings: { queue: { ...QUEUE_SETTINGS, episodes: [] } },
+			saveSettings: vi.fn(),
+		} as unknown as IPodNotes;
+
+		const controller = new QueueController(queue, fakePlugin).on();
+
+		try {
+			queue.moveToBottom(0);
+
+			expect(
+				fakePlugin.settings.queue.episodes.map((e) => e.title),
+			).toEqual(["B", "C", "A"]);
+			expect(fakePlugin.saveSettings).toHaveBeenCalled();
+		} finally {
+			controller.off();
+		}
 	});
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -423,6 +423,51 @@ export const downloadedEpisodes = (() => {
 	};
 })();
 
+/**
+ * Returns a new array with the episode at `from` moved to position `to`.
+ *
+ * Any out-of-range, negative, or equal index pair is treated as a no-op and the
+ * original array reference is returned unchanged, so callers can cheaply detect
+ * "nothing moved" and skip a store write. Guarding `from < 0` is essential: a
+ * `findIndex` miss yields -1, and `splice(-1, 1)` would destructively remove the
+ * last element.
+ */
+export function reorderEpisodes(
+	episodes: Episode[],
+	from: number,
+	to: number,
+): Episode[] {
+	const length = episodes.length;
+	if (from < 0 || from >= length || to < 0 || to >= length || from === to) {
+		return episodes;
+	}
+
+	const next = [...episodes];
+	const [moved] = next.splice(from, 1);
+	next.splice(to, 0, moved);
+	return next;
+}
+
+/**
+ * Returns the episodes with later duplicate titles removed, preserving order and
+ * the first occurrence. The queue is title-identified everywhere, so this keeps
+ * it title-unique regardless of how it was populated — including queues
+ * persisted or synced before dedup-on-add existed.
+ */
+export function dedupeEpisodesByTitle(episodes: Episode[] = []): Episode[] {
+	const seen = new Set<string>();
+	const result: Episode[] = [];
+
+	for (const episode of episodes) {
+		if (seen.has(episode.title)) continue;
+
+		seen.add(episode.title);
+		result.push(episode);
+	}
+
+	return result;
+}
+
 export const queue = (() => {
 	const store = writable<Playlist>({
 		icon: "list-ordered",
@@ -431,14 +476,41 @@ export const queue = (() => {
 		shouldEpisodeRemoveAfterPlay: true,
 		shouldRepeat: false,
 	});
-	const { subscribe, update, set } = store;
+	const { subscribe, update, set: setStore } = store;
+
+	// The queue identifies episodes by title everywhere (remove, played-cleanup,
+	// context menu). Keeping it title-unique on add makes those lookups — and the
+	// reorder index lookups below — unambiguous.
+	const isAlreadyQueued = (episodes: Episode[], episode: Episode) =>
+		episodes.some((e) => e.title === episode.title);
+
+	function move(from: number, to: number) {
+		const { episodes } = get(store);
+		const reordered = reorderEpisodes(episodes, from, to);
+
+		// No-op move: skip the store write so we don't churn saveSettings.
+		if (reordered === episodes) return;
+
+		update((queue) => {
+			queue.episodes = reordered;
+			return queue;
+		});
+	}
 
 	return {
 		subscribe,
 		update,
-		set,
+		// Enforce the title-unique invariant on every set (load, import, sync),
+		// not just on incremental adds.
+		set: (playlist: Playlist) =>
+			setStore({
+				...playlist,
+				episodes: dedupeEpisodesByTitle(playlist.episodes),
+			}),
 		add: (episode: Episode) => {
 			update((queue) => {
+				if (isAlreadyQueued(queue.episodes, episode)) return queue;
+
 				queue.episodes.push(episode);
 				return queue;
 			});
@@ -462,6 +534,12 @@ export const queue = (() => {
 				return queue;
 			});
 		},
+		move,
+		moveUp: (index: number) => move(index, index - 1),
+		moveDown: (index: number) => move(index, index + 1),
+		moveToTop: (index: number) => move(index, 0),
+		moveToBottom: (index: number) =>
+			move(index, get(store).episodes.length - 1),
 	};
 })();
 
@@ -539,6 +617,12 @@ export const viewState = (() => {
 
 function addEpisodeToQueue(episode: Episode) {
 	queue.update((playlist) => {
+		// Keep the queue title-unique: a previously-played episode that is already
+		// queued stays in place rather than being re-prepended.
+		if (playlist.episodes.some((e) => e.title === episode.title)) {
+			return playlist;
+		}
+
 		const newEpisodes = [episode, ...playlist.episodes];
 		playlist.episodes = newEpisodes;
 

--- a/src/ui/PodcastView/queueReorderMenu.test.ts
+++ b/src/ui/PodcastView/queueReorderMenu.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+
+import type { Episode } from "src/types/Episode";
+import { ViewState } from "src/types/ViewState";
+import { buildQueueReorderMenuItems } from "./queueReorderMenu";
+
+function ep(title: string): Episode {
+	return {
+		title,
+		streamUrl: `https://example.com/${title}.mp3`,
+		url: `https://example.com/${title}`,
+		description: "",
+		content: "",
+		podcastName: "Pod",
+	};
+}
+
+const queueEpisodes = [ep("A"), ep("B"), ep("C")];
+const titles = (items: { title: string }[]) => items.map((i) => i.title);
+
+describe("buildQueueReorderMenuItems", () => {
+	test("returns nothing outside the Player view", () => {
+		expect(
+			buildQueueReorderMenuItems(ViewState.EpisodeList, queueEpisodes, ep("B")),
+		).toEqual([]);
+		expect(
+			buildQueueReorderMenuItems(ViewState.PodcastGrid, queueEpisodes, ep("B")),
+		).toEqual([]);
+	});
+
+	test("returns nothing when the episode is not queued", () => {
+		expect(
+			buildQueueReorderMenuItems(ViewState.Player, queueEpisodes, ep("Z")),
+		).toEqual([]);
+	});
+
+	test("returns nothing for a single-item queue", () => {
+		expect(
+			buildQueueReorderMenuItems(ViewState.Player, [ep("A")], ep("A")),
+		).toEqual([]);
+	});
+
+	test("a middle item offers all four moves with its index", () => {
+		const items = buildQueueReorderMenuItems(
+			ViewState.Player,
+			queueEpisodes,
+			ep("B"),
+		);
+
+		expect(titles(items)).toEqual([
+			"Move to top of queue",
+			"Move up in queue",
+			"Move down in queue",
+			"Move to bottom of queue",
+		]);
+		expect(items.map((i) => i.kind)).toEqual(["top", "up", "down", "bottom"]);
+		expect(items.every((i) => i.index === 1)).toBe(true);
+	});
+
+	test("the first item omits the upward moves", () => {
+		const items = buildQueueReorderMenuItems(
+			ViewState.Player,
+			queueEpisodes,
+			ep("A"),
+		);
+
+		expect(items.map((i) => i.kind)).toEqual(["down", "bottom"]);
+		expect(items.every((i) => i.index === 0)).toBe(true);
+	});
+
+	test("the last item omits the downward moves", () => {
+		const items = buildQueueReorderMenuItems(
+			ViewState.Player,
+			queueEpisodes,
+			ep("C"),
+		);
+
+		expect(items.map((i) => i.kind)).toEqual(["top", "up"]);
+		expect(items.every((i) => i.index === 2)).toBe(true);
+	});
+});

--- a/src/ui/PodcastView/queueReorderMenu.ts
+++ b/src/ui/PodcastView/queueReorderMenu.ts
@@ -1,0 +1,67 @@
+import type { Episode } from "src/types/Episode";
+import type { IconType } from "src/types/IconType";
+import { ViewState } from "src/types/ViewState";
+
+export type QueueMoveKind = "top" | "up" | "down" | "bottom";
+
+export interface QueueReorderMenuItem {
+	icon: IconType;
+	title: string;
+	kind: QueueMoveKind;
+	index: number;
+}
+
+/**
+ * Builds the "move within queue" context-menu entries for an episode.
+ *
+ * Returns an empty list unless the menu is opened from the Player (the only
+ * place the queue is shown as an ordered list), the episode is actually in the
+ * queue, and there is more than one episode to reorder. End entries are omitted
+ * when they would be no-ops (no "move up" on the first item, etc.).
+ */
+export function buildQueueReorderMenuItems(
+	viewState: ViewState,
+	queueEpisodes: Episode[],
+	episode: Episode,
+): QueueReorderMenuItem[] {
+	if (viewState !== ViewState.Player) return [];
+
+	const index = queueEpisodes.findIndex((e) => e.title === episode.title);
+	if (index === -1 || queueEpisodes.length <= 1) return [];
+
+	const items: QueueReorderMenuItem[] = [];
+	const isFirst = index === 0;
+	const isLast = index === queueEpisodes.length - 1;
+
+	if (!isFirst) {
+		items.push({
+			icon: "chevrons-up",
+			title: "Move to top of queue",
+			kind: "top",
+			index,
+		});
+		items.push({
+			icon: "chevron-up",
+			title: "Move up in queue",
+			kind: "up",
+			index,
+		});
+	}
+
+	if (!isLast) {
+		items.push({
+			icon: "chevron-down",
+			title: "Move down in queue",
+			kind: "down",
+			index,
+		});
+		items.push({
+			icon: "chevrons-down",
+			title: "Move to bottom of queue",
+			kind: "bottom",
+			index,
+		});
+	}
+
+	return items;
+}

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.ts
@@ -6,6 +6,7 @@ import type { Episode } from "src/types/Episode";
 import { ViewState } from "src/types/ViewState";
 import { get } from "svelte/store";
 import { isEpisodeFinished } from "src/utility/episodeStatus";
+import { buildQueueReorderMenuItems } from "./queueReorderMenu";
 
 interface DisabledMenuItems {
 	play: boolean;
@@ -130,20 +131,54 @@ export default function spawnEpisodeContextMenu(
 			.setTitle(`${episodeIsInQueue ? "Remove from" : "Add to"} Queue`)
 			.onClick(() => {
 				if (episodeIsInQueue) {
-					queue.update(playlist => {
-						playlist.episodes = playlist.episodes.filter(e => e.title !== episode.title);
-
-						return playlist;
-					});
+					queue.remove(episode);
 				} else {
-					queue.update(playlist => {
-						const newEpisodes = [...playlist.episodes, episode];
-						playlist.episodes = newEpisodes;
-
-						return playlist;
-					});
+					queue.add(episode);
 				}
 			}));
+
+		// Reorder controls — only meaningful when viewing the queue as an ordered
+		// list in the Player. spawnEpisodeContextMenu is shared with the feed,
+		// playlist and Latest lists, so gate on the active view state.
+		const reorderItems = buildQueueReorderMenuItems(
+			get(viewState),
+			get(queue).episodes,
+			episode,
+		);
+
+		if (reorderItems.length > 0) {
+			menu.addSeparator();
+
+			for (const reorderItem of reorderItems) {
+				menu.addItem(item => item
+					.setIcon(reorderItem.icon)
+					.setTitle(reorderItem.title)
+					.onClick(() => {
+						// Resolve the index live: the queue can shift (e.g. the
+						// episode ends and playNext advances it) between opening
+						// the menu and clicking.
+						const index = get(queue).episodes.findIndex(
+							e => e.title === episode.title,
+						);
+						if (index === -1) return;
+
+						switch (reorderItem.kind) {
+							case "top":
+								queue.moveToTop(index);
+								break;
+							case "up":
+								queue.moveUp(index);
+								break;
+							case "down":
+								queue.moveDown(index);
+								break;
+							case "bottom":
+								queue.moveToBottom(index);
+								break;
+						}
+					}));
+			}
+		}
 	}
 
 	if (!disabledMenuItems?.playlists) {

--- a/src/ui/QueueReorderModal.test.ts
+++ b/src/ui/QueueReorderModal.test.ts
@@ -1,0 +1,41 @@
+import { App } from "obsidian";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { QUEUE_SETTINGS } from "src/constants";
+import { queue } from "src/store";
+import type { Episode } from "src/types/Episode";
+import { QueueReorderModal } from "./QueueReorderModal";
+
+function ep(title: string): Episode {
+	return {
+		title,
+		streamUrl: `https://example.com/${title}.mp3`,
+		url: `https://example.com/${title}`,
+		description: "",
+		content: "",
+		podcastName: "Pod",
+	};
+}
+
+describe("QueueReorderModal", () => {
+	beforeEach(() => {
+		queue.set({
+			...QUEUE_SETTINGS,
+			episodes: [ep("A"), ep("B"), ep("C")],
+		});
+	});
+
+	test("mounts the reorder list on open and tears it down on close", () => {
+		const modal = new QueueReorderModal(new App());
+
+		modal.open();
+		expect(modal.titleEl.textContent).toBe("Reorder Queue");
+		expect(
+			modal.contentEl.querySelectorAll(".queue-reorder-item").length,
+		).toBe(3);
+
+		modal.close();
+		expect(modal.contentEl.querySelector(".queue-reorder-item")).toBeNull();
+		expect(modal.contentEl.childElementCount).toBe(0);
+	});
+});

--- a/src/ui/QueueReorderModal.ts
+++ b/src/ui/QueueReorderModal.ts
@@ -1,0 +1,35 @@
+import { type App, Modal } from "obsidian";
+import { mount, unmount } from "svelte";
+import ReorderQueue from "./ReorderQueue.svelte";
+
+/**
+ * A focused modal for resequencing the playback queue. The episode list lives in
+ * the frozen Player UI, so this provides the only full-list reorder surface —
+ * with per-row move buttons that work identically on desktop and mobile.
+ */
+export class QueueReorderModal extends Modal {
+	private component: Record<string, unknown> | null = null;
+
+	constructor(app: App) {
+		super(app);
+	}
+
+	override onOpen(): void {
+		this.titleEl.setText("Reorder Queue");
+		this.component = mount(ReorderQueue, {
+			target: this.contentEl,
+			props: {
+				close: () => this.close(),
+			},
+		});
+	}
+
+	override onClose(): void {
+		if (this.component) {
+			unmount(this.component);
+			this.component = null;
+		}
+
+		this.contentEl.empty();
+	}
+}

--- a/src/ui/ReorderQueue.svelte
+++ b/src/ui/ReorderQueue.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	import { queue } from "src/store";
+	import type { Episode } from "src/types/Episode";
+	import Icon from "./obsidian/Icon.svelte";
+
+	export let close: () => void = () => {};
+
+	$: episodes = $queue.episodes;
+
+	// Resolve the live index by title at click time rather than trusting the
+	// index captured at render. The queue is title-unique (deduped on add), so
+	// this is unambiguous, and it stays correct even if playback advances the
+	// queue while the modal is open.
+	function indexOf(episode: Episode): number {
+		return $queue.episodes.findIndex((e) => e.title === episode.title);
+	}
+
+	function moveToTop(episode: Episode) {
+		const index = indexOf(episode);
+		if (index > 0) queue.moveToTop(index);
+	}
+
+	function moveUp(episode: Episode) {
+		const index = indexOf(episode);
+		if (index > 0) queue.moveUp(index);
+	}
+
+	function moveDown(episode: Episode) {
+		const index = indexOf(episode);
+		if (index !== -1 && index < $queue.episodes.length - 1) {
+			queue.moveDown(index);
+		}
+	}
+
+	function moveToBottom(episode: Episode) {
+		const index = indexOf(episode);
+		if (index !== -1 && index < $queue.episodes.length - 1) {
+			queue.moveToBottom(index);
+		}
+	}
+
+	function removeFromQueue(episode: Episode) {
+		queue.remove(episode);
+	}
+</script>
+
+<div class="queue-reorder">
+	{#if episodes.length === 0}
+		<p class="queue-reorder-empty">Your queue is empty.</p>
+	{:else}
+		<ol class="queue-reorder-list">
+			{#each episodes as episode, index (episode.title)}
+				<li class="queue-reorder-item">
+					<span class="queue-reorder-position">{index + 1}</span>
+					<div class="queue-reorder-info">
+						<span class="queue-reorder-title">{episode.title}</span>
+						{#if episode.podcastName}
+							<span class="queue-reorder-podcast">{episode.podcastName}</span>
+						{/if}
+					</div>
+					<div class="queue-reorder-actions">
+						<Icon
+							icon="chevrons-up"
+							label="Move to top"
+							size={18}
+							disabled={index === 0}
+							on:click={() => moveToTop(episode)}
+						/>
+						<Icon
+							icon="chevron-up"
+							label="Move up"
+							size={18}
+							disabled={index === 0}
+							on:click={() => moveUp(episode)}
+						/>
+						<Icon
+							icon="chevron-down"
+							label="Move down"
+							size={18}
+							disabled={index === episodes.length - 1}
+							on:click={() => moveDown(episode)}
+						/>
+						<Icon
+							icon="chevrons-down"
+							label="Move to bottom"
+							size={18}
+							disabled={index === episodes.length - 1}
+							on:click={() => moveToBottom(episode)}
+						/>
+						<Icon
+							icon="x"
+							label="Remove from queue"
+							size={18}
+							on:click={() => removeFromQueue(episode)}
+						/>
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+
+	<div class="queue-reorder-footer">
+		<button type="button" class="mod-cta" on:click={close}>Done</button>
+	</div>
+</div>
+
+<style>
+	.queue-reorder {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.queue-reorder-empty {
+		text-align: center;
+		color: var(--text-muted);
+		padding: 1.5rem 0;
+	}
+
+	.queue-reorder-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	.queue-reorder-item {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.5rem 0.625rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 0.5rem;
+		background: var(--background-secondary);
+	}
+
+	.queue-reorder-position {
+		flex: 0 0 1.5rem;
+		text-align: center;
+		font-variant-numeric: tabular-nums;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.queue-reorder-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	.queue-reorder-title {
+		font-size: 0.9rem;
+		color: var(--text-normal);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.queue-reorder-podcast {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.queue-reorder-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.125rem;
+		flex: 0 0 auto;
+	}
+
+	.queue-reorder-footer {
+		display: flex;
+		justify-content: flex-end;
+	}
+</style>

--- a/src/ui/ReorderQueue.test.ts
+++ b/src/ui/ReorderQueue.test.ts
@@ -1,0 +1,143 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { QUEUE_SETTINGS } from "src/constants";
+import { queue } from "src/store";
+import type { Episode } from "src/types/Episode";
+import ReorderQueue from "./ReorderQueue.svelte";
+
+function ep(title: string, podcastName = "Pod"): Episode {
+	return {
+		title,
+		streamUrl: `https://example.com/${title}.mp3`,
+		url: `https://example.com/${title}`,
+		description: "",
+		content: "",
+		podcastName,
+	};
+}
+
+function seed(...titles: string[]) {
+	queue.set({ ...QUEUE_SETTINGS, episodes: titles.map((t) => ep(t)) });
+}
+
+function titles(): string[] {
+	return get(queue).episodes.map((e) => e.title);
+}
+
+describe("ReorderQueue", () => {
+	beforeEach(() => {
+		queue.set({ ...QUEUE_SETTINGS, episodes: [] });
+	});
+
+	test("lists the queued episodes in order with 1-based positions", () => {
+		seed("A", "B", "C");
+		const { container } = render(ReorderQueue);
+
+		const renderedTitles = Array.from(
+			container.querySelectorAll(".queue-reorder-title"),
+		).map((el) => el.textContent);
+		expect(renderedTitles).toEqual(["A", "B", "C"]);
+
+		const positions = Array.from(
+			container.querySelectorAll(".queue-reorder-position"),
+		).map((el) => el.textContent);
+		expect(positions).toEqual(["1", "2", "3"]);
+	});
+
+	test("moving an episode up updates the queue order", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		// Second row ("B") -> move up.
+		await fireEvent.click(getAllByLabelText("Move up")[1]);
+
+		expect(titles()).toEqual(["B", "A", "C"]);
+	});
+
+	test("moving a middle episode to the top updates the queue order", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		// Second row ("B") -> move to top.
+		await fireEvent.click(getAllByLabelText("Move to top")[1]);
+
+		expect(titles()).toEqual(["B", "A", "C"]);
+	});
+
+	test("moving the first episode down updates the queue order", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		// First row ("A") -> move down.
+		await fireEvent.click(getAllByLabelText("Move down")[0]);
+
+		expect(titles()).toEqual(["B", "A", "C"]);
+	});
+
+	test("moving an episode to the bottom updates the queue order", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		// First row ("A") -> move to bottom.
+		await fireEvent.click(getAllByLabelText("Move to bottom")[0]);
+
+		expect(titles()).toEqual(["B", "C", "A"]);
+	});
+
+	test("the first episode's upward controls are disabled and inert", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		const firstMoveUp = getAllByLabelText("Move up")[0] as HTMLButtonElement;
+		const firstMoveToTop = getAllByLabelText(
+			"Move to top",
+		)[0] as HTMLButtonElement;
+		expect(firstMoveUp).toBeDisabled();
+		expect(firstMoveToTop).toBeDisabled();
+
+		await fireEvent.click(firstMoveUp);
+		await fireEvent.click(firstMoveToTop);
+		expect(titles()).toEqual(["A", "B", "C"]);
+	});
+
+	test("the last episode's downward controls are disabled and inert", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		const lastMoveDown = getAllByLabelText("Move down")[2] as HTMLButtonElement;
+		const lastMoveToBottom = getAllByLabelText(
+			"Move to bottom",
+		)[2] as HTMLButtonElement;
+		expect(lastMoveDown).toBeDisabled();
+		expect(lastMoveToBottom).toBeDisabled();
+
+		await fireEvent.click(lastMoveDown);
+		await fireEvent.click(lastMoveToBottom);
+		expect(titles()).toEqual(["A", "B", "C"]);
+	});
+
+	test("clicking Done invokes the close callback", async () => {
+		seed("A", "B");
+		const close = vi.fn();
+		const { getByText } = render(ReorderQueue, { props: { close } });
+
+		await fireEvent.click(getByText("Done"));
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	test("removing an episode drops it from the queue", async () => {
+		seed("A", "B", "C");
+		const { getAllByLabelText } = render(ReorderQueue);
+
+		await fireEvent.click(getAllByLabelText("Remove from queue")[1]);
+
+		expect(titles()).toEqual(["A", "C"]);
+	});
+
+	test("shows an empty state when the queue is empty", () => {
+		const { getByText } = render(ReorderQueue);
+		expect(getByText("Your queue is empty.")).toBeInTheDocument();
+	});
+});

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -19,6 +19,34 @@ export class Notice {
 export class WorkspaceLeaf {}
 export class ItemView {}
 
+export class Modal {
+	app: App;
+	containerEl: HTMLElement;
+	contentEl: HTMLElement;
+	titleEl: HTMLElement;
+
+	constructor(app: App) {
+		this.app = app;
+		this.containerEl = document.createElement("div");
+		this.titleEl = document.createElement("div");
+		this.contentEl = document.createElement("div");
+		this.containerEl.append(this.titleEl, this.contentEl);
+	}
+
+	open(): void {
+		document.body.appendChild(this.containerEl);
+		this.onOpen();
+	}
+
+	close(): void {
+		this.onClose();
+		this.containerEl.remove();
+	}
+
+	onOpen(): void {}
+	onClose(): void {}
+}
+
 class BaseInteractiveElement {
 	protected element: HTMLElement;
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -124,3 +124,19 @@ if (!(HTMLElement.prototype as unknown as { setAttr?: (name: string, value: stri
 			this.setAttribute(name, value);
 		};
 }
+
+if (!(HTMLElement.prototype as unknown as { setText?: (text: string) => void }).setText) {
+	(HTMLElement.prototype as unknown as { setText: (text: string) => void }).setText =
+		function (this: HTMLElement, text: string) {
+			this.textContent = text;
+		};
+}
+
+if (!(HTMLElement.prototype as unknown as { empty?: () => void }).empty) {
+	(HTMLElement.prototype as unknown as { empty: () => void }).empty =
+		function (this: HTMLElement) {
+			while (this.firstChild) {
+				this.removeChild(this.firstChild);
+			}
+		};
+}


### PR DESCRIPTION
## Summary
Adds the ability to **reorder the playback Queue** (requested in #80). Until now the Queue had no reorder affordance — its order was fixed by insertion. You can now resequence it two complementary ways, both working on desktop and mobile:

- **From the player's queue list** — right-click (desktop) / long-press (mobile) a queued episode and choose **Move to top / up / down / bottom of queue**.
- **From the command palette** — **PodNotes: Reorder Queue** opens a focused window listing the whole queue, with per-row move-up / move-down / move-to-top / move-to-bottom (and remove) buttons. Best for resequencing a long queue.

Closes #80.

## What changed
- **Store (`src/store/index.ts`)** — pure `reorderEpisodes(from, to)` (defensively clamped so a `-1` lookup miss can never reach `splice`) and `queue.move/moveUp/moveDown/moveToTop/moveToBottom`. Order already persists automatically via `QueueController` → `settings.queue`, so **no settings migration**. The queue is now kept **title-unique on every add _and_ set**, so persisted/synced queues that contain duplicate titles are normalized on load.
- **Context menu (`spawnEpisodeContextMenu.ts` + new pure `queueReorderMenu.ts`)** — move verbs gated to `ViewState.Player` + in-queue + length > 1 (so they never leak into the Latest/feed/playlist menus, which share this helper). Index resolved from the live store at click time.
- **Command + modal (`main.ts`, new `QueueReorderModal.ts` + `ReorderQueue.svelte`)** — a button-list reorder window (deliberately not drag-and-drop, which is non-functional on touch). Live index resolution; Svelte 5 `mount`/`unmount`.
- **Docs** — `docs/docs/podcasts.md` "Reordering the queue" section.
- **Tests** — store (reorder math both directions, `moveToBottom` lands last, `-1`/equal/out-of-range no-ops, dedup on add and set, end-to-end persistence via `QueueController`), the context-menu gating helper, the `ReorderQueue` component (all four moves, disabled-control inertness, ordering/position assertions, Done-close), and `QueueReorderModal` mount/unmount.

## Constraint compliance (#173)
The Player/Episode-UI files frozen by draft #173 (`EpisodePlayer`, `EpisodeList`, `EpisodeListHeader`, `EpisodeListItem`, `PodcastView`, `TopBar`) are **untouched**. The in-player queue list is reached only through the non-frozen `spawnEpisodeContextMenu` helper and the new modal.

## Testing
Ran the full CI-equivalent suite locally, all green:

```
npm run lint && npm run format:check && npm run typecheck && npm run build && npm run test
```

`npm run test` → **186 passed** (32 new). `npm run docs:build` builds in CI (local `mkdocs` not installed).

**Obsidian runtime verification** (dev vault `dev`, this branch's build, real `Accidental Tech Podcast` episodes):
- `PodNotes: Reorder Queue` opened the modal — 3 numbered rows, correct per-row buttons, correct disabled states (top row's up-controls and bottom row's down-controls greyed).
- Clicked **Move to bottom** → both the modal and the persisted `settings.queue` became `[689, 688, 681]`, confirming reorder **auto-persists** end-to-end. **Move to top** undid it; **Done** closed/unmounted cleanly. Vault restored afterwards (`data.json` byte-for-byte identical to a pre-test backup).

## Release / behavior impact
- **No settings schema migration** — reorder rides the existing `settings.queue` array order.
- **Behavior note:** the queue is now title-unique. Two genuinely different episodes that share an exact title (e.g. two shows with "Episode 1") can no longer both be queued — consistent with the queue's pre-existing title-based identity (`remove`/played-cleanup were already title-keyed), and documented.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->