### PR TITLE
fix(playback): play local files and downloads on iOS via resource path (#100)

### DIFF
--- a/docs/docs/local_files.md
+++ b/docs/docs/local_files.md
@@ -4,4 +4,4 @@ In the podcast grid, you will see a playlist with a folder icon. This is a playl
 
 PodNotes will attempt to treat all local files as podcast episodes. This means all standard features are available, such as timestamps, note creation, and persisting playback time. Any exceptions will be added here.
 
-Local files and downloaded episodes play on all platforms, including iOS and Android.
+Local files and downloaded episodes are played through Obsidian's native media resource path (the same mechanism Obsidian uses for embedded media), so they work on mobile (iOS and Android) as well as desktop.

--- a/docs/docs/local_files.md
+++ b/docs/docs/local_files.md
@@ -3,3 +3,5 @@ PodNotes supports local files. You can right-click any audio file and click `Pla
 In the podcast grid, you will see a playlist with a folder icon. This is a playlist of every episode you have available offline: both local audio files you have played with `Play with PodNotes` and episodes you have downloaded. Removing a downloaded file also removes it from this playlist.
 
 PodNotes will attempt to treat all local files as podcast episodes. This means all standard features are available, such as timestamps, note creation, and persisting playback time. Any exceptions will be added here.
+
+Local files and downloaded episodes play on all platforms, including iOS and Android.

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -11,13 +11,26 @@ import type { LocalEpisode } from "./types/LocalEpisode";
 import { ViewState } from "./types/ViewState";
 import { createMediaUrlObjectFromFilePath } from "./utility/createMediaUrlObjectFromFilePath";
 
+// Audio/video extensions PodNotes can play. The previous inline regex
+// (/mp3|mp4|.../) had a trailing alternative that matched the empty string, so
+// "Play with PodNotes" surfaced on every file regardless of type.
+const PLAYABLE_EXTENSIONS = new Set([
+	"mp3",
+	"mp4",
+	"wma",
+	"aac",
+	"wav",
+	"webm",
+	"flac",
+	"m4a",
+]);
+
 export default function getContextMenuHandler(app: App): EventRef {
 	return app.workspace.on(
 		"file-menu",
 		(menu: Menu, file: TAbstractFile) => {
 			if (!(file instanceof TFile)) return;
-			if (!file.extension.match(/mp3|mp4|wma|aac|wav|webm|aac|flac|m4a|/))
-				return;
+			if (!PLAYABLE_EXTENSIONS.has(file.extension.toLowerCase())) return;
 
 			menu.addItem((item) =>
 				item

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -11,18 +11,22 @@ import type { LocalEpisode } from "./types/LocalEpisode";
 import { ViewState } from "./types/ViewState";
 import { createMediaUrlObjectFromFilePath } from "./utility/createMediaUrlObjectFromFilePath";
 
-// Audio/video extensions PodNotes can play. The previous inline regex
-// (/mp3|mp4|.../) had a trailing alternative that matched the empty string, so
-// "Play with PodNotes" surfaced on every file regardless of type.
+// Extensions for which "Play with PodNotes" is offered. Kept in sync with the
+// formats PodNotes already recognizes as audio elsewhere (detectAudioFileExtension
+// in downloadEpisode.ts and getExtensionFromContentType), plus the mp4/webm
+// containers, so right-clicking any such file offers playback. The previous inline
+// regex had a trailing empty alternative that matched every file regardless of type.
 const PLAYABLE_EXTENSIONS = new Set([
 	"mp3",
 	"mp4",
-	"wma",
+	"m4a",
 	"aac",
+	"ogg",
 	"wav",
 	"webm",
 	"flac",
-	"m4a",
+	"wma",
+	"amr",
 ]);
 
 export default function getContextMenuHandler(app: App): EventRef {

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -43,9 +43,7 @@ export default function getContextMenuHandler(app: App): EventRef {
 							content: "",
 							podcastName: "local file",
 							url: app.fileManager.generateMarkdownLink(file, ""),
-							streamUrl: await createMediaUrlObjectFromFilePath(
-								file.path
-							),
+							streamUrl: createMediaUrlObjectFromFilePath(file.path),
 							filePath: file.path,
 							episodeDate: new Date(file.stat.ctime),
 						};

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import {
 	hidePlayedEpisodes,
 	volume,
 } from "src/store";
-import { blobUrlManager } from "src/utility/createMediaUrlObjectFromFilePath";
 import { Plugin, type WorkspaceLeaf } from "obsidian";
 import { API } from "src/API/API";
 import type { IAPI } from "src/API/IAPI";
@@ -399,9 +398,6 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		this.hidePlayedEpisodesController?.off();
 		this.volumeUnsubscribe?.();
 		this.localFilesMirrorUnsubscribe?.();
-
-		// Clean up any active blob URLs to prevent memory leaks
-		blobUrlManager.revokeAll();
 
 		// Detach all leaves of this view type to prevent duplicates on reload
 		this.app.workspace.detachLeavesOfType(VIEW_TYPE);

--- a/src/utility/createMediaUrlObjectFromFilePath.test.ts
+++ b/src/utility/createMediaUrlObjectFromFilePath.test.ts
@@ -36,10 +36,12 @@ afterEach(() => {
 });
 
 describe("createMediaUrlObjectFromFilePath", () => {
-	it("returns the Obsidian resource path for a vault file", async () => {
-		const { getResourcePath } = setupVault();
+	it("returns the Obsidian resource path for a vault file", () => {
+		const { getResourcePath, getAbstractFileByPath } = setupVault();
 
-		const url = await createMediaUrlObjectFromFilePath("Audio/ep.mp3");
+		const url = createMediaUrlObjectFromFilePath("Audio/ep.mp3");
+
+		expect(getAbstractFileByPath).toHaveBeenCalledWith("Audio/ep.mp3");
 
 		expect(url).toBe("app://resource/Audio/ep.mp3?1");
 		expect(getResourcePath).toHaveBeenCalledTimes(1);
@@ -47,35 +49,35 @@ describe("createMediaUrlObjectFromFilePath", () => {
 		expect(getResourcePath.mock.calls[0][0]).toBeInstanceOf(TFile);
 	});
 
-	it("does not produce a blob URL", async () => {
+	it("does not produce a blob URL", () => {
 		const { getResourcePath } = setupVault({
 			getResourcePath: () => "capacitor://localhost/_capacitor_file_/x.mp3?2",
 		});
 
-		const url = await createMediaUrlObjectFromFilePath("x.mp3");
+		const url = createMediaUrlObjectFromFilePath("x.mp3");
 
 		expect(url).toBe("capacitor://localhost/_capacitor_file_/x.mp3?2");
 		expect(url.startsWith("blob:")).toBe(false);
 		expect(getResourcePath).toHaveBeenCalledTimes(1);
 	});
 
-	it("returns '' when the path does not resolve to a file", async () => {
+	it("returns '' when the path does not resolve to a file", () => {
 		const { getResourcePath } = setupVault({ resolve: () => null });
 
-		expect(await createMediaUrlObjectFromFilePath("missing.mp3")).toBe("");
+		expect(createMediaUrlObjectFromFilePath("missing.mp3")).toBe("");
 		expect(getResourcePath).not.toHaveBeenCalled();
 	});
 
-	it("returns '' when the path is not a TFile (e.g. a folder)", async () => {
+	it("returns '' when the path is not a TFile (e.g. a folder)", () => {
 		const { getResourcePath } = setupVault({
 			resolve: (path) => ({ path }), // not a TFile instance
 		});
 
-		expect(await createMediaUrlObjectFromFilePath("Some/Folder")).toBe("");
+		expect(createMediaUrlObjectFromFilePath("Some/Folder")).toBe("");
 		expect(getResourcePath).not.toHaveBeenCalled();
 	});
 
-	it("resolves non-mp3 extensions too (MIME is the native server's concern)", async () => {
+	it("resolves non-mp3 extensions too (MIME is the native server's concern)", () => {
 		const seen: string[] = [];
 		setupVault({
 			getResourcePath: (file) => {
@@ -85,7 +87,7 @@ describe("createMediaUrlObjectFromFilePath", () => {
 		});
 
 		for (const path of ["a.wav", "b.flac", "c.m4a", "d.webm"]) {
-			expect(await createMediaUrlObjectFromFilePath(path)).toBe(
+			expect(createMediaUrlObjectFromFilePath(path)).toBe(
 				`app://resource/${path}`,
 			);
 		}

--- a/src/utility/createMediaUrlObjectFromFilePath.test.ts
+++ b/src/utility/createMediaUrlObjectFromFilePath.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TFile } from "obsidian";
+import { createMediaUrlObjectFromFilePath } from "./createMediaUrlObjectFromFilePath";
+
+// `tsc` resolves `obsidian` to the real typings (TFile has a no-arg constructor),
+// while Vitest aliases it to tests/mocks/obsidian.ts. Build a TFile that satisfies
+// both: construct with no args, then set the path the helper reads.
+function tfile(path: string): TFile {
+	const file = new TFile();
+	(file as unknown as { path: string }).path = path;
+	return file;
+}
+
+function setupVault(
+	opts: {
+		resolve?: (path: string) => unknown;
+		getResourcePath?: (file: TFile) => string;
+	} = {},
+) {
+	const getResourcePath = vi.fn(
+		opts.getResourcePath ?? ((file: TFile) => `app://resource/${file.path}?1`),
+	);
+	const getAbstractFileByPath = vi.fn(
+		opts.resolve ?? ((path: string) => tfile(path)),
+	);
+
+	(globalThis as { app?: unknown }).app = {
+		vault: { getAbstractFileByPath, getResourcePath },
+	};
+
+	return { getResourcePath, getAbstractFileByPath };
+}
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+});
+
+describe("createMediaUrlObjectFromFilePath", () => {
+	it("returns the Obsidian resource path for a vault file", async () => {
+		const { getResourcePath } = setupVault();
+
+		const url = await createMediaUrlObjectFromFilePath("Audio/ep.mp3");
+
+		expect(url).toBe("app://resource/Audio/ep.mp3?1");
+		expect(getResourcePath).toHaveBeenCalledTimes(1);
+		// Must pass the TFile (not the raw string) so the TFile overload is used.
+		expect(getResourcePath.mock.calls[0][0]).toBeInstanceOf(TFile);
+	});
+
+	it("does not produce a blob URL", async () => {
+		const { getResourcePath } = setupVault({
+			getResourcePath: () => "capacitor://localhost/_capacitor_file_/x.mp3?2",
+		});
+
+		const url = await createMediaUrlObjectFromFilePath("x.mp3");
+
+		expect(url).toBe("capacitor://localhost/_capacitor_file_/x.mp3?2");
+		expect(url.startsWith("blob:")).toBe(false);
+		expect(getResourcePath).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns '' when the path does not resolve to a file", async () => {
+		const { getResourcePath } = setupVault({ resolve: () => null });
+
+		expect(await createMediaUrlObjectFromFilePath("missing.mp3")).toBe("");
+		expect(getResourcePath).not.toHaveBeenCalled();
+	});
+
+	it("returns '' when the path is not a TFile (e.g. a folder)", async () => {
+		const { getResourcePath } = setupVault({
+			resolve: (path) => ({ path }), // not a TFile instance
+		});
+
+		expect(await createMediaUrlObjectFromFilePath("Some/Folder")).toBe("");
+		expect(getResourcePath).not.toHaveBeenCalled();
+	});
+
+	it("resolves non-mp3 extensions too (MIME is the native server's concern)", async () => {
+		const seen: string[] = [];
+		setupVault({
+			getResourcePath: (file) => {
+				seen.push(file.path);
+				return `app://resource/${file.path}`;
+			},
+		});
+
+		for (const path of ["a.wav", "b.flac", "c.m4a", "d.webm"]) {
+			expect(await createMediaUrlObjectFromFilePath(path)).toBe(
+				`app://resource/${path}`,
+			);
+		}
+
+		expect(seen).toEqual(["a.wav", "b.flac", "c.m4a", "d.webm"]);
+	});
+});

--- a/src/utility/createMediaUrlObjectFromFilePath.ts
+++ b/src/utility/createMediaUrlObjectFromFilePath.ts
@@ -1,65 +1,22 @@
 import { TFile } from "obsidian";
 
 /**
- * Manages blob URLs to prevent memory leaks.
- * Tracks created URLs and provides cleanup mechanism.
+ * Resolves a vault file path to a URL the webview's media element can play.
+ *
+ * Uses Obsidian's resource path (`app.vault.getResourcePath`) — the same mechanism
+ * Obsidian uses for native `![[media]]` embeds. The native layer serves it with
+ * byte-range support, which iOS requires: the WKWebView media stack loads audio
+ * out-of-process and cannot read in-memory `blob:` URLs. The previous blob approach
+ * worked on desktop (Electron/Chromium) but silently failed on iOS (issue #100).
+ *
+ * Returns an empty string when the path does not resolve to a vault file, matching
+ * the prior behavior (binding `src=""` is a benign no-op on the audio element).
  */
-class BlobUrlManager {
-	private activeUrls: Map<string, string> = new Map();
+export async function createMediaUrlObjectFromFilePath(
+	filePath: string,
+): Promise<string> {
+	const file = app.vault.getAbstractFileByPath(filePath);
+	if (!file || !(file instanceof TFile)) return "";
 
-	/**
-	 * Creates a blob URL for a file path, cleaning up any previous URL for the same path.
-	 */
-	async createUrl(filePath: string): Promise<string> {
-		// Revoke existing URL for this file path to prevent memory leak
-		this.revokeUrl(filePath);
-
-		const file = app.vault.getAbstractFileByPath(filePath);
-		if (!file || !(file instanceof TFile)) return "";
-
-		const binary = await app.vault.readBinary(file);
-		const url = URL.createObjectURL(new Blob([binary], { type: "audio/mpeg" }));
-
-		this.activeUrls.set(filePath, url);
-		return url;
-	}
-
-	/**
-	 * Revokes a blob URL for a specific file path.
-	 */
-	revokeUrl(filePath: string): void {
-		const existingUrl = this.activeUrls.get(filePath);
-		if (existingUrl) {
-			URL.revokeObjectURL(existingUrl);
-			this.activeUrls.delete(filePath);
-		}
-	}
-
-	/**
-	 * Revokes all active blob URLs. Call this on plugin unload.
-	 */
-	revokeAll(): void {
-		for (const url of this.activeUrls.values()) {
-			URL.revokeObjectURL(url);
-		}
-		this.activeUrls.clear();
-	}
-
-	/**
-	 * Returns the number of active blob URLs (for debugging).
-	 */
-	get activeCount(): number {
-		return this.activeUrls.size;
-	}
-}
-
-// Singleton instance
-export const blobUrlManager = new BlobUrlManager();
-
-/**
- * Creates a blob URL from a file path in the vault.
- * Automatically cleans up previous URL for the same file.
- */
-export async function createMediaUrlObjectFromFilePath(filePath: string): Promise<string> {
-	return blobUrlManager.createUrl(filePath);
+	return app.vault.getResourcePath(file);
 }

--- a/src/utility/createMediaUrlObjectFromFilePath.ts
+++ b/src/utility/createMediaUrlObjectFromFilePath.ts
@@ -12,9 +12,7 @@ import { TFile } from "obsidian";
  * Returns an empty string when the path does not resolve to a vault file, matching
  * the prior behavior (binding `src=""` is a benign no-op on the audio element).
  */
-export async function createMediaUrlObjectFromFilePath(
-	filePath: string,
-): Promise<string> {
+export function createMediaUrlObjectFromFilePath(filePath: string): string {
 	const file = app.vault.getAbstractFileByPath(filePath);
 	if (!file || !(file instanceof TFile)) return "";
 


### PR DESCRIPTION
## Summary
Local audio files and downloaded episodes could not be played on iOS — the player never started — while streaming worked (issue #100, filed Jul 2024).

**Root cause.** Both local files and downloaded episodes were played from in-memory `blob:` URLs (`URL.createObjectURL`), while streaming used the raw `https://` URL. iOS's WKWebView `<audio>` element loads media out-of-process and **cannot read an in-memory `blob:` URL**, so playback silently failed on iOS. Desktop (Electron/Chromium) plays `blob:` audio fine, which is why the bug was iOS-only and never reproduced on desktop.

The player code path is identical for streaming vs. local/downloaded except for the value bound to `<audio src>` — `getSrc()` returns a real URL for streaming (works on iOS) vs. a blob for local/downloaded (fails). That isolates the blob URL as the cause.

**Fix.** Resolve vault files with `app.vault.getResourcePath(file)` — the same native-served, byte-range-capable URL Obsidian uses for its own `![[media]]` embeds (which play on iOS). The change lives in the shared `createMediaUrlObjectFromFilePath` helper, so both call sites (`getContextMenuHandler` and `EpisodePlayer.getSrc`) are fixed with no player-UI changes. It also stops reading the entire audio file into memory as an `ArrayBuffer` just to play it.

## Changes
- `src/utility/createMediaUrlObjectFromFilePath.ts` — blob URL → `getResourcePath`; removed the now-dead `BlobUrlManager`.
- `src/main.ts` — removed the `blobUrlManager` import + `revokeAll()` unload wiring (its only consumer).
- `src/getContextMenuHandler.ts` — fixed the "Play with PodNotes" extension check: the inline regex `/mp3|…|/` had a trailing empty alternative that matched **every** file, so the menu item appeared on all files. Replaced with an explicit `PLAYABLE_EXTENSIONS` set.
- `src/utility/createMediaUrlObjectFromFilePath.test.ts` — new unit tests (forwards resource URL; `""` for missing/non-file; non-mp3 extensions).
- `docs/docs/local_files.md` — note that local/downloaded files play on all platforms.

## Verification
- Desktop (real dev vault, Obsidian CLI eval): both the blob URL and `getResourcePath` play (`loadedmetadata`, `duration: 3`, `readyState: 4`) — confirming desktop **cannot** reproduce the iOS-only failure and that the resource URL is a valid, playable source.
- Gates (Node 22, npm): `lint`, `format:check`, `typecheck`, `build`, `test` (248 passed / 27 files, incl. `EpisodePlayer.test.ts`) all green. `docs:build` not run locally (`mkdocs` unavailable in the environment; change is one prose line, no nav/reference changes).

## ⚠️ Pre-merge verification needed (iOS device)
This fix is reasoned and desktop-validated but **not device-proven**. The exact URL `getResourcePath` returns on iOS could not be confirmed here (the typings document `resourcePathPrefix` as `file:///` on mobile). It is the same API behind Obsidian's own iOS-working media embeds, so it is very likely correct — but before relying on it, please confirm on a real iPhone: log `app.vault.getResourcePath(tfile)` for a local audio file and verify `<audio>` fires `loadedmetadata` (`readyState >= 2`).

Closes #100
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->