### PR TITLE
feat(notes): add podcast feed-level notes (#163)

### DIFF
--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -33,10 +33,23 @@ This will capture the current timestamp of the currently playing episode.
 
 See [timestamps](timestamps.md) for more information on timestamp templates.
 
-## Create Podcast Note
+## Create episode note
 This will create a note for the currently playing episode.
 
+(This command was previously named "Create Podcast Note". The name was changed to
+distinguish it from the feed-level command below; existing hotkeys are unaffected.)
+
 See [templates](templates.md) for more information on note templates.
+
+## Create podcast feed note
+This creates a note for a whole podcast (the feed as a whole), not a single
+episode. It does **not** require playing anything: running the command opens a
+picker of your saved podcasts, and choosing one creates (or opens) that podcast's
+note. You can also create a feed note from an episode's right-click menu
+("Create feed note").
+
+See [templates](templates.md#podcast-feed-notes) for the feed note template and
+its available tags.
 
 ## Copy universal episode link to clipboard
 This will copy the universal episode link to the clipboard.

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -1,7 +1,9 @@
 PodNotes can create notes from templates. These templates can contain certain syntax, which will be expanded to metadata about the podcast episode you are listening to.
 
-To use templates, you can use the `Create podcast note` Obsidian command.
+To use templates, you can use the `Create episode note` Obsidian command (previously named `Create podcast note`).
 This requires you to have defined a template for both the file path and note text.
+
+PodNotes can also create a note for a whole podcast (the feed). See [Podcast feed notes](#podcast-feed-notes) below.
 
 ## File path
 This template will be used to create the file path for the note. You can use the following syntax:
@@ -29,3 +31,47 @@ This template will be used to create the note text. You can use the following sy
 - `{{date}}`: The publish date of the podcast episode.
 	- You can use `{{date:format}}` to specify a custom [Moment.js](https://momentjs.com) format. E.g. `{{date:YYYY-MM-DD}}`.
 - `{{artwork}}`: The URL of the podcast artwork. If no artwork is found, an empty string will be used.
+
+### Linking an episode to its podcast (feed) note
+In an episode note, `{{url}}` and `{{artwork}}` always describe the **episode**. To reference the parent podcast (feed), use these additional tags:
+
+- `{{episodeurl}}` / `{{episodeartwork}}`: Explicit aliases of `{{url}}` / `{{artwork}}` (the episode's own URL and artwork). Use these when you also use the feed tags below and want to be unambiguous.
+- `{{feedurl}}`: The podcast's RSS feed URL.
+- `{{feedartwork}}`: The podcast's (feed) artwork. Falls back to the episode artwork if the feed isn't saved.
+- `{{podcastlink}}`: A ready-made wikilink to the podcast's [feed note](#podcast-feed-notes). It points at the same file the feed note is created at, so episodes and the feed note link up automatically. When the feed-note path has a folder it is path-qualified (e.g. `[[PodNotes/Podcasts/My Show|My Show]]`) so it can't resolve to an unrelated note that shares the basename; otherwise it's a plain `[[My Show]]`. (Avoid putting a `{{date}}` in the feed-note path, since the episode side can't reproduce the feed note's creation date.)
+
+A Bases-friendly episode template that links back to the feed note:
+
+```
+---
+type: podcastEpisode
+podcast: "{{podcastlink}}"
+title: "{{title}}"
+image: "{{artwork}}"
+url: "{{url}}"
+date: {{date:YYYY-MM-DD}}
+tags:
+  - podcastEpisode
+---
+{{description}}
+```
+
+## Podcast feed notes
+A *feed note* is a single parent note for an entire podcast (the feed), which episode notes can link to (great for [Obsidian Bases](https://help.obsidian.md/bases) / Dataview rollups).
+
+Create one with the `Create podcast feed note` command (pick a saved podcast — no playback needed) or from an episode's right-click menu. Configure the feed note **file path** and **template** under PodNotes settings → *Podcast feed note settings*. PodNotes ships sensible Bases-friendly defaults.
+
+In a feed note, `{{url}}` and `{{artwork}}` describe the **feed** (the note's subject). Available tags:
+
+- `{{title}}`: The podcast's name.
+- `{{podcast}}` / `{{safeTitle}}`: The podcast's name, formatted safely for file paths/links (special characters removed).
+- `{{url}}`: The podcast's website (from the feed's `<link>`). May be empty if the feed has no website.
+- `{{feedurl}}`: The podcast's RSS feed URL.
+- `{{artwork}}` / `{{feedartwork}}`: The URL of the podcast artwork.
+- `{{author}}`: The podcast author (`<itunes:author>`), if present.
+- `{{description}}`: The podcast's description. Supports the `{{description:> }}` prepend syntax, like episode notes.
+- `{{date}}`: The current date (when the note is created). Supports `{{date:format}}`.
+
+The file path template supports `{{title}}`/`{{podcast}}` (with the optional `{{podcast:_}}` whitespace-replacement format) and `{{date}}`.
+
+The default feed note path is `PodNotes/Podcasts/{{podcast}}.md`, so an episode's `{{podcastlink}}` (`[[Podcast Name]]`) resolves to it automatically.

--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { DownloadPathTemplateEngine } from "./TemplateEngine";
+import {
+	DownloadPathTemplateEngine,
+	FeedFilePathTemplateEngine,
+	FeedNoteTemplateEngine,
+	NoteTemplateEngine,
+	getFeedNoteWikilink,
+} from "./TemplateEngine";
 import type { Episode } from "./types/Episode";
+import type { PodcastFeed } from "./types/PodcastFeed";
+import { plugin } from "./store";
 
 // The illegal-character sanitizer is private; exercise it through
 // DownloadPathTemplateEngine, which applies it to {{title}} and {{podcast}}.
@@ -47,5 +55,170 @@ describe("replaceIllegalFileNameCharactersInString (via DownloadPathTemplateEngi
 		expect(sanitizeTitle("Part 1 - The Beginning")).toBe(
 			"Part 1 - The Beginning",
 		);
+	});
+});
+
+const demoEpisode: Episode = {
+	title: "Episode 1",
+	streamUrl: "https://example.com/ep1.mp3",
+	url: "https://example.com/ep1",
+	description: "",
+	content: "",
+	podcastName: "My Show",
+	feedUrl: "https://example.com/feed.xml",
+	artworkUrl: "https://example.com/ep1.png",
+	episodeDate: new Date("2024-01-01"),
+};
+
+describe("NoteTemplateEngine feed-scoped tags (#163)", () => {
+	it("keeps {{url}} and {{artwork}} pointing at the episode itself", () => {
+		plugin.set({ settings: { feedNote: { path: "" }, savedFeeds: {} } } as never);
+		expect(NoteTemplateEngine("{{url}}|{{artwork}}", demoEpisode)).toBe(
+			"https://example.com/ep1|https://example.com/ep1.png",
+		);
+	});
+
+	it("adds episode aliases and {{feedurl}}", () => {
+		plugin.set({ settings: { feedNote: { path: "" }, savedFeeds: {} } } as never);
+		expect(NoteTemplateEngine("{{episodeurl}}", demoEpisode)).toBe(
+			"https://example.com/ep1",
+		);
+		expect(NoteTemplateEngine("{{episodeartwork}}", demoEpisode)).toBe(
+			"https://example.com/ep1.png",
+		);
+		expect(NoteTemplateEngine("{{feedurl}}", demoEpisode)).toBe(
+			"https://example.com/feed.xml",
+		);
+	});
+
+	it("resolves {{feedartwork}} from the saved feed, else the episode art", () => {
+		plugin.set({
+			settings: {
+				feedNote: { path: "" },
+				savedFeeds: {
+					"My Show": {
+						title: "My Show",
+						url: "x",
+						artworkUrl: "https://example.com/feed.png",
+					},
+				},
+			},
+		} as never);
+		expect(NoteTemplateEngine("{{feedartwork}}", demoEpisode)).toBe(
+			"https://example.com/feed.png",
+		);
+
+		plugin.set({ settings: { feedNote: { path: "" }, savedFeeds: {} } } as never);
+		expect(NoteTemplateEngine("{{feedartwork}}", demoEpisode)).toBe(
+			"https://example.com/ep1.png",
+		);
+	});
+
+	it("emits {{podcastlink}} as a path-qualified wikilink to the feed note", () => {
+		plugin.set({
+			settings: {
+				feedNote: { path: "PodNotes/Podcasts/{{podcast}}.md" },
+				savedFeeds: {},
+			},
+		} as never);
+		expect(NoteTemplateEngine("{{podcastlink}}", demoEpisode)).toBe(
+			"[[PodNotes/Podcasts/My Show|My Show]]",
+		);
+	});
+});
+
+describe("FeedNoteTemplateEngine (#163)", () => {
+	const feed: PodcastFeed = {
+		title: "My Show: A Podcast",
+		url: "https://example.com/feed.xml",
+		artworkUrl: "https://example.com/art.png",
+		link: "https://example.com",
+		description: "<p>Great show</p>",
+		author: "Jane Doe",
+	};
+
+	it("maps {{url}}/{{artwork}} to the feed and exposes feed metadata", () => {
+		expect(FeedNoteTemplateEngine("{{url}}", feed)).toBe("https://example.com");
+		expect(FeedNoteTemplateEngine("{{feedurl}}", feed)).toBe(
+			"https://example.com/feed.xml",
+		);
+		expect(FeedNoteTemplateEngine("{{artwork}}", feed)).toBe(
+			"https://example.com/art.png",
+		);
+		expect(FeedNoteTemplateEngine("{{feedartwork}}", feed)).toBe(
+			"https://example.com/art.png",
+		);
+		expect(FeedNoteTemplateEngine("{{author}}", feed)).toBe("Jane Doe");
+		// htmlToMarkdown is a passthrough in the test mock.
+		expect(FeedNoteTemplateEngine("{{description}}", feed)).toBe("<p>Great show</p>");
+	});
+
+	it("exposes raw {{title}} and sanitized {{podcast}}/{{safetitle}}", () => {
+		expect(FeedNoteTemplateEngine("{{title}}", feed)).toBe("My Show: A Podcast");
+		expect(FeedNoteTemplateEngine("{{podcast}}", feed)).toBe("My Show A Podcast");
+		expect(FeedNoteTemplateEngine("{{safetitle}}", feed)).toBe("My Show A Podcast");
+	});
+
+	it("leaves {{url}} empty when the feed has no website link", () => {
+		expect(FeedNoteTemplateEngine("{{url}}", { ...feed, link: undefined })).toBe("");
+	});
+
+	it("strips quote/backslash from URL tags so quoted YAML frontmatter stays valid", () => {
+		const malformed: PodcastFeed = {
+			...feed,
+			link: 'https://example.com/a?x="b"\\c',
+			artworkUrl: 'https://example.com/art".png',
+		};
+		expect(FeedNoteTemplateEngine("{{url}}", malformed)).toBe(
+			"https://example.com/a?x=bc",
+		);
+		expect(FeedNoteTemplateEngine("{{artwork}}", malformed)).toBe(
+			"https://example.com/art.png",
+		);
+	});
+});
+
+describe("FeedFilePathTemplateEngine (#163)", () => {
+	const feed: PodcastFeed = {
+		title: "My Show: A Podcast",
+		url: "u",
+		artworkUrl: "",
+	};
+
+	it("sanitizes the feed title for {{podcast}} and {{title}}", () => {
+		expect(
+			FeedFilePathTemplateEngine("PodNotes/Podcasts/{{podcast}}.md", feed),
+		).toBe("PodNotes/Podcasts/My Show A Podcast.md");
+	});
+
+	it("supports a whitespace-replacement argument", () => {
+		expect(FeedFilePathTemplateEngine("{{podcast:-}}", feed)).toBe(
+			"My-Show-A-Podcast",
+		);
+	});
+});
+
+describe("getFeedNoteWikilink (#163)", () => {
+	it("path-qualifies the link when the feed-note path has a folder", () => {
+		plugin.set({
+			settings: { feedNote: { path: "PodNotes/Podcasts/{{podcast}}.md" } },
+		} as never);
+		expect(getFeedNoteWikilink("My Show: A Podcast")).toBe(
+			"[[PodNotes/Podcasts/My Show A Podcast|My Show A Podcast]]",
+		);
+	});
+
+	it("uses a plain wikilink when the feed-note path has no folder", () => {
+		plugin.set({
+			settings: { feedNote: { path: "{{podcast}}.md" } },
+		} as never);
+		expect(getFeedNoteWikilink("My Show: A Podcast")).toBe(
+			"[[My Show A Podcast]]",
+		);
+	});
+
+	it("falls back to a plain sanitized link when no path is configured", () => {
+		plugin.set({ settings: { feedNote: { path: "" } } } as never);
+		expect(getFeedNoteWikilink("My Show: A Podcast")).toBe("[[My Show A Podcast]]");
 	});
 });

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -3,6 +3,7 @@ import { htmlToMarkdown, Notice } from "obsidian";
 import { plugin } from "src/store";
 import { get } from "svelte/store";
 import type { Episode } from "src/types/Episode";
+import type { PodcastFeed } from "src/types/PodcastFeed";
 import getUrlExtension from "./utility/getUrlExtension";
 import { formatDate } from "./utility/formatDate";
 
@@ -112,6 +113,19 @@ export function NoteTemplateEngine(template: string, episode: Episode) {
 		replaceIllegalFileNameCharactersInString(episode.podcastName),
 	);
 	addTag("artwork", episode.artworkUrl ?? "");
+
+	// Feed-scoped tags so an episode note can reference its parent podcast feed
+	// without changing the meaning of the existing {{url}}/{{artwork}} tags
+	// (which always describe the episode itself). See issue #163.
+	addTag("episodeurl", episode.url);
+	addTag("episodeartwork", episode.artworkUrl ?? "");
+	addTag("feedurl", episode.feedUrl ?? "");
+	const parentFeed =
+		get(plugin)?.settings?.savedFeeds?.[episode.podcastName];
+	addTag("feedartwork", parentFeed?.artworkUrl ?? episode.artworkUrl ?? "");
+	// A ready-made wikilink to the parent feed's note, pointing at the same file
+	// createFeedNote writes (derived from the feed-note path setting).
+	addTag("podcastlink", getFeedNoteWikilink(episode.podcastName));
 
 	return replacer(template);
 }
@@ -240,6 +254,101 @@ export function TranscriptTemplateEngine(
 	addTag("artwork", episode.artworkUrl ?? "");
 
 	return replacer(template);
+}
+
+export function FeedNoteTemplateEngine(template: string, feed: PodcastFeed) {
+	const [replacer, addTag] = useTemplateEngine();
+
+	const safeTitle = replaceIllegalFileNameCharactersInString(feed.title);
+
+	// In a feed note the subject is the feed, so {{url}}/{{artwork}} describe the
+	// feed (mirroring how they describe the episode in NoteTemplateEngine).
+	addTag("title", feed.title);
+	addTag("safetitle", safeTitle);
+	addTag("podcast", safeTitle);
+	// URL tags are sanitized so they stay valid inside quoted YAML frontmatter
+	// scalars (the default feed template quotes them). A well-formed URL never
+	// contains a raw double-quote, backslash, or control character.
+	addTag("url", sanitizeUrlForTemplate(feed.link ?? ""));
+	addTag("feedurl", sanitizeUrlForTemplate(feed.url));
+	addTag("artwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
+	addTag("feedartwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
+	addTag("author", feed.author ?? "");
+	addTag("description", (prependToLines?: string) => {
+		const sanitizeDescription = htmlToMarkdown(feed.description ?? "").replace(
+			/\n{3,}/g,
+			"\n\n",
+		);
+		if (prependToLines) {
+			return sanitizeDescription
+				.split("\n")
+				.map((str) => `${prependToLines}${str}`)
+				.join("\n");
+		}
+
+		return sanitizeDescription;
+	});
+	addTag("date", (format?: string) =>
+		formatDate(new Date(), format ?? "YYYY-MM-DD"),
+	);
+
+	return replacer(template);
+}
+
+export function FeedFilePathTemplateEngine(template: string, feed: PodcastFeed) {
+	const [replacer, addTag] = useTemplateEngine();
+
+	const safeName = replaceIllegalFileNameCharactersInString(feed.title);
+	const nameTag = (whitespaceReplacement?: string) =>
+		whitespaceReplacement
+			? safeName.replace(/\s+/g, whitespaceReplacement)
+			: safeName;
+
+	addTag("title", nameTag);
+	addTag("podcast", nameTag);
+	addTag("date", (format?: string) =>
+		formatDate(new Date(), format ?? "YYYY-MM-DD"),
+	);
+
+	return replacer(template);
+}
+
+/**
+ * Build the wikilink an episode's {{podcastlink}} emits to its feed note,
+ * derived from the configured feed-note path so it points at the exact file
+ * `createFeedNote` writes. When that path has a folder the link is
+ * path-qualified (`[[folder/Name|Name]]`) so it can never resolve to an
+ * unrelated note that happens to share the basename; otherwise a plain
+ * `[[Name]]` is used. Falls back to the sanitized feed name when no feed-note
+ * path is configured (or the plugin store is not yet ready, e.g. in unit tests).
+ */
+export function getFeedNoteWikilink(feedTitle: string): string {
+	const fallback = replaceIllegalFileNameCharactersInString(feedTitle);
+	const path = get(plugin)?.settings?.feedNote?.path?.trim();
+
+	if (!path) return `[[${fallback}]]`;
+
+	const rendered = FeedFilePathTemplateEngine(path, {
+		title: feedTitle,
+		url: "",
+		artworkUrl: "",
+	});
+	const linkPath = rendered.replace(/\.md$/i, "").trim();
+	const basename = linkPath.split("/").pop()?.trim() || fallback;
+
+	return linkPath.includes("/")
+		? `[[${linkPath}|${basename}]]`
+		: `[[${basename}]]`;
+}
+
+/**
+ * Strip the two characters that would break a double-quoted YAML scalar
+ * (and never appear in a well-formed URL): the double-quote that ends the
+ * scalar and the backslash that YAML reads as an escape. Lossless for valid
+ * URLs; only sanitizes malformed feeds so quoted frontmatter stays valid.
+ */
+function sanitizeUrlForTemplate(url: string): string {
+	return url.replace(/["\\]/g, "");
 }
 
 export function replaceIllegalFileNameCharactersInString(string: string) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,31 @@ export const DEFAULT_SETTINGS: IPodNotesSettings = {
 		template: "",
 	},
 
+	feedNote: {
+		path: "PodNotes/Podcasts/{{podcast}}.md",
+		// Bases-friendly frontmatter. Only YAML-safe values go in the frontmatter:
+		// {{podcast}} is sanitized (quotes/colons stripped) and the quoted URL
+		// scalars ({{artwork}}/{{url}}/{{feedurl}}) have their quote/backslash
+		// stripped by the feed engine, so an arbitrary or empty value always
+		// produces valid YAML. The raw {{title}}/{{author}} (which may contain
+		// quotes/colons) live in the note body instead, where YAML rules don't
+		// apply. See issue #163 / #160.
+		template:
+			"---\n" +
+			"type: podcast\n" +
+			'podcast: "{{podcast}}"\n' +
+			'image: "{{artwork}}"\n' +
+			'url: "{{url}}"\n' +
+			'feedUrl: "{{feedurl}}"\n' +
+			"tags:\n" +
+			"  - podcast\n" +
+			"---\n" +
+			"# {{title}}\n" +
+			"{{author}}\n\n" +
+			"![]({{artwork}})\n\n" +
+			"{{description}}\n",
+	},
+
 	download: {
 		path: "",
 	},

--- a/src/createFeedNote.test.ts
+++ b/src/createFeedNote.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TFile } from "obsidian";
+import { plugin } from "./store";
+import createFeedNote from "./createFeedNote";
+import type { PodcastFeed } from "./types/PodcastFeed";
+
+// A feed with every metadata field already populated, so createFeedNote's
+// enrichFeed short-circuits and never hits the network in these tests.
+const fullFeed: PodcastFeed = {
+	title: "My Show: A Podcast",
+	url: "https://example.com/feed.xml",
+	artworkUrl: "https://example.com/art.png",
+	link: "https://example.com",
+	description: "A description",
+	author: "Jane Doe",
+};
+
+const EXPECTED_PATH = "PodNotes/Podcasts/My Show A Podcast.md";
+
+// The real obsidian TFile type has a 0-arg constructor; build one and attach a
+// path so `instanceof TFile` holds and `file.path` reads back in assertions.
+function makeTFile(path: string): TFile {
+	const file = new TFile();
+	(file as { path: string }).path = path;
+	return file;
+}
+
+function setupVault(options: {
+	initial?: string[];
+	createImpl?: (path: string, content: string) => Promise<TFile>;
+}) {
+	const files = new Set(options.initial ?? []);
+	const created: { path: string; content: string }[] = [];
+	const opened: string[] = [];
+
+	const create =
+		options.createImpl ??
+		(async (path: string, content: string) => {
+			if (files.has(path)) throw new Error("File already exists.");
+			files.add(path);
+			created.push({ path, content });
+			return makeTFile(path);
+		});
+
+	(globalThis as { app?: unknown }).app = {
+		vault: {
+			getAbstractFileByPath: (path: string) =>
+				files.has(path) ? makeTFile(path) : null,
+			create: vi.fn(create),
+			createFolder: vi.fn(async (path: string) => {
+				files.add(path);
+			}),
+		},
+		workspace: {
+			getLeaf: () => ({
+				openFile: (file: TFile) => opened.push(file.path),
+			}),
+		},
+	};
+
+	return { files, created, opened };
+}
+
+beforeEach(() => {
+	plugin.set({
+		settings: {
+			feedNote: {
+				path: "PodNotes/Podcasts/{{podcast}}.md",
+				template: "type: podcast\npodcast: {{podcast}}\n",
+			},
+		},
+	} as never);
+});
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+	vi.restoreAllMocks();
+});
+
+describe("createFeedNote", () => {
+	it("creates the note at the sanitized basename derived from the feed title", async () => {
+		const { created, opened } = setupVault({});
+
+		await createFeedNote(fullFeed);
+
+		expect(created).toHaveLength(1);
+		expect(created[0].path).toBe(EXPECTED_PATH);
+		expect(opened).toContain(EXPECTED_PATH);
+	});
+
+	it("opens the existing note instead of creating a duplicate", async () => {
+		const { created, opened } = setupVault({ initial: [EXPECTED_PATH] });
+
+		await createFeedNote(fullFeed);
+
+		expect(created).toHaveLength(0);
+		expect(opened).toContain(EXPECTED_PATH);
+	});
+
+	it("treats a create that loses a race as success (opens the winner)", async () => {
+		// Simulate another invocation winning between our existence check and
+		// create(): the file is absent at check time, but create() throws
+		// "already exists" because a competing create wrote it first.
+		const racedFiles = new Set<string>();
+		const opened: string[] = [];
+
+		(globalThis as { app?: unknown }).app = {
+			vault: {
+				getAbstractFileByPath: (path: string) =>
+					racedFiles.has(path) ? makeTFile(path) : null,
+				create: vi.fn(async (path: string) => {
+					racedFiles.add(path);
+					throw new Error("File already exists.");
+				}),
+				createFolder: vi.fn(async () => {}),
+			},
+			workspace: {
+				getLeaf: () => ({
+					openFile: (file: TFile) => opened.push(file.path),
+				}),
+			},
+		};
+
+		await expect(createFeedNote(fullFeed)).resolves.toBeUndefined();
+		expect(opened).toContain(EXPECTED_PATH);
+	});
+
+	it("does nothing when no feed-note path/template is configured", async () => {
+		plugin.set({
+			settings: { feedNote: { path: "", template: "" } },
+		} as never);
+		const { created } = setupVault({});
+
+		await createFeedNote(fullFeed);
+
+		expect(created).toHaveLength(0);
+	});
+});

--- a/src/createFeedNote.ts
+++ b/src/createFeedNote.ts
@@ -1,0 +1,139 @@
+import { Notice, TFile } from "obsidian";
+import {
+	FeedFilePathTemplateEngine,
+	FeedNoteTemplateEngine,
+} from "./TemplateEngine";
+import type { PodcastFeed } from "./types/PodcastFeed";
+import { get } from "svelte/store";
+import { plugin } from "./store";
+import addExtension from "./utility/addExtension";
+import { ensureFolderExists } from "./utility/ensureFolderExists";
+import FeedParser from "./parser/feedParser";
+
+/**
+ * Resolve the on-disk path of a feed's note from the feed-note path template.
+ * Always derived from the (stable) feed identity passed in, so the path never
+ * shifts even if later metadata enrichment returns a slightly different title.
+ */
+function getFeedNotePath(feed: PodcastFeed): string {
+	const pluginInstance = get(plugin);
+
+	const filePath = FeedFilePathTemplateEngine(
+		pluginInstance.settings.feedNote.path,
+		feed,
+	);
+
+	return addExtension(filePath, "md");
+}
+
+export function getFeedNote(feed: PodcastFeed): TFile | null {
+	const filePathDotMd = getFeedNotePath(feed);
+	const file = app.vault.getAbstractFileByPath(filePathDotMd);
+
+	if (!file || !(file instanceof TFile)) {
+		return null;
+	}
+
+	return file;
+}
+
+export function openFeedNote(feed: PodcastFeed): void {
+	const file = getFeedNote(feed);
+
+	if (!file) {
+		new Notice(`Note for "${feed.title}" does not exist`);
+		return;
+	}
+
+	app.workspace.getLeaf().openFile(file);
+}
+
+export default async function createFeedNote(feed: PodcastFeed): Promise<void> {
+	const pluginInstance = get(plugin);
+	const { path, template } = pluginInstance.settings.feedNote;
+
+	if (!path || !template) {
+		new Notice(
+			"Please set a podcast feed note path and template in the settings.",
+		);
+		return;
+	}
+
+	const existing = getFeedNote(feed);
+	if (existing) {
+		new Notice(`Note for "${feed.title}" already exists`);
+		app.workspace.getLeaf().openFile(existing);
+		return;
+	}
+
+	const filePathDotMd = getFeedNotePath(feed);
+
+	// Best-effort enrichment: fill description/website/author that a saved (or
+	// synthesized) feed may lack. Never changes the title/basename and never
+	// fails note creation when offline.
+	const enrichedFeed = await enrichFeed(feed);
+	const content = FeedNoteTemplateEngine(template, enrichedFeed);
+
+	try {
+		const file = await createFileIfNotExists(filePathDotMd, content, feed);
+		app.workspace.getLeaf().openFile(file);
+	} catch (error) {
+		console.error(error);
+		new Notice(`Failed to create note: "${filePathDotMd}"`);
+	}
+}
+
+async function enrichFeed(feed: PodcastFeed): Promise<PodcastFeed> {
+	const needsEnrichment = !feed.description || !feed.link || !feed.author;
+	if (!needsEnrichment || !feed.url) {
+		return feed;
+	}
+
+	try {
+		const parsed = await new FeedParser(feed).getFeed(feed.url);
+
+		// Keep the saved title/url/artwork; only backfill the new metadata fields
+		// so the computed basename can never change mid-flight. Use `||` (not `??`)
+		// so an empty-string saved field is also backfilled, matching the falsy
+		// `needsEnrichment` gate above.
+		return {
+			...feed,
+			description: feed.description || parsed.description,
+			link: feed.link || parsed.link,
+			author: feed.author || parsed.author,
+		};
+	} catch (error) {
+		console.error("PodNotes: failed to enrich feed metadata", error);
+		return feed;
+	}
+}
+
+async function createFileIfNotExists(
+	path: string,
+	content: string,
+	feed: PodcastFeed,
+): Promise<TFile> {
+	// Re-check immediately before creating: enrichment above awaits the network,
+	// during which a second invocation (command + context menu) could have
+	// created the note already.
+	const existing = getFeedNote(feed);
+	if (existing) {
+		new Notice(`Note for "${feed.title}" already exists`);
+		return existing;
+	}
+
+	const folderPath = path.split("/").slice(0, -1).join("/");
+	await ensureFolderExists(folderPath);
+
+	try {
+		return await app.vault.create(path, content);
+	} catch (error) {
+		// A racing create may have won between the check and here; treat an
+		// already-existing file as success rather than surfacing an error.
+		const raced = app.vault.getAbstractFileByPath(path);
+		if (raced instanceof TFile) {
+			return raced;
+		}
+		throw error;
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,8 @@ import CurrentEpisodeController from "./store_controllers/CurrentEpisodeControll
 import { HidePlayedEpisodesController } from "./store_controllers/HidePlayedEpisodesController";
 import { TimestampTemplateEngine } from "./TemplateEngine";
 import createPodcastNote from "./createPodcastNote";
+import createFeedNote from "./createFeedNote";
+import { FeedSuggestModal, orderFeedsByCurrent } from "./ui/FeedSuggestModal";
 import downloadEpisodeWithNotice from "./downloadEpisode";
 import type DownloadedEpisode from "./types/DownloadedEpisode";
 import DownloadedEpisodesController from "./store_controllers/DownloadedEpisodesController";
@@ -275,7 +277,11 @@ export default class PodNotes extends Plugin implements IPodNotes {
 
 		this.addCommand({
 			id: "create-podcast-note",
-			name: "Create Podcast Note",
+			// Despite the id, this creates a note for the CURRENT EPISODE. The
+			// visible name was corrected to disambiguate it from the feed-level
+			// "Create podcast feed note" command below (issue #163). The id is kept
+			// for backward compatibility (hotkeys/API).
+			name: "Create episode note",
 			icon: "file-plus" as IconType,
 			checkCallback: (checking) => {
 				if (checking) {
@@ -287,6 +293,36 @@ export default class PodNotes extends Plugin implements IPodNotes {
 				}
 
 				createPodcastNote(this.api.podcast);
+			},
+		});
+
+		this.addCommand({
+			id: "create-podcast-feed-note",
+			name: "Create podcast feed note",
+			icon: "file-plus" as IconType,
+			checkCallback: (checking) => {
+				const feeds = Object.values(get(savedFeeds));
+				const canCreate =
+					feeds.length > 0 &&
+					!!this.settings.feedNote.path &&
+					!!this.settings.feedNote.template;
+
+				if (checking) {
+					return canCreate;
+				}
+
+				if (!canCreate) return;
+
+				// Pre-select the playing episode's feed when there is one, so the
+				// picker opens on the most likely choice without requiring playback.
+				const orderedFeeds = orderFeedsByCurrent(
+					feeds,
+					this.api.podcast?.podcastName,
+				);
+
+				new FeedSuggestModal(this.app, orderedFeeds, (feed) => {
+					void createFeedNote(feed);
+				}).open();
 			},
 		});
 

--- a/src/parser/feedParser.test.ts
+++ b/src/parser/feedParser.test.ts
@@ -58,6 +58,77 @@ const invalidRssFeed = `<?xml version="1.0" encoding="UTF-8"?>
   </channel>
 </rss>`;
 
+const sampleRssFeedWithAtomAndMetadata = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://example.com/feed.xml" rel="self" type="application/rss+xml"/>
+    <title>Meta Podcast</title>
+    <link>https://example.com/show</link>
+    <description>Channel description here</description>
+    <itunes:author>Jane Author</itunes:author>
+    <image>
+      <url>https://example.com/artwork.jpg</url>
+    </image>
+    <item>
+      <title>Episode 1</title>
+      <enclosure url="https://example.com/episode1.mp3" type="audio/mpeg"/>
+      <description>Episode-level description (must not become the feed description)</description>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const rssFeedWithoutChannelLink = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://example.com/feed.xml" rel="self"/>
+    <title>No Link Podcast</title>
+    <image>
+      <url>https://example.com/artwork.jpg</url>
+    </image>
+    <item>
+      <title>Episode 1</title>
+      <enclosure url="https://example.com/episode1.mp3" type="audio/mpeg"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const rssFeedWithMetadataPriority = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Priority Podcast</title>
+    <link>https://example.com</link>
+    <managingEditor>editor@example.com (The Editor)</managingEditor>
+    <itunes:author>The Real Author</itunes:author>
+    <description></description>
+    <itunes:summary>Summary used because description is empty</itunes:summary>
+    <item>
+      <title>Episode 1</title>
+      <enclosure url="https://example.com/episode1.mp3" type="audio/mpeg"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const rssFeedWithAtomHubAndAlternate = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://example.com/feed.xml" rel="self"/>
+    <atom:link href="https://pubsubhubbub.appspot.com/" rel="hub"/>
+    <atom:link href="https://example.com/site" rel="alternate"/>
+    <title>Hub Podcast</title>
+    <image>
+      <url>https://example.com/artwork.jpg</url>
+    </image>
+    <item>
+      <title>Episode 1</title>
+      <enclosure url="https://example.com/episode1.mp3" type="audio/mpeg"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
 const rssFeedWithInvalidItem = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
   <channel>
@@ -145,6 +216,71 @@ describe("FeedParser", () => {
 			await expect(parser.getFeed("https://example.com/feed.xml")).rejects.toThrow(
 				"Invalid RSS feed",
 			);
+		});
+
+		test("captures channel link, description and author, skipping atom:link self-refs", async () => {
+			mockRequestWithTimeout.mockResolvedValueOnce({
+				text: sampleRssFeedWithAtomAndMetadata,
+				status: 200,
+				headers: {},
+				arrayBuffer: new ArrayBuffer(0),
+				json: {},
+			});
+
+			const parser = new FeedParser();
+			const feed = await parser.getFeed("https://example.com/feed.xml");
+
+			expect(feed.title).toBe("Meta Podcast");
+			expect(feed.link).toBe("https://example.com/show");
+			expect(feed.description).toBe("Channel description here");
+			expect(feed.author).toBe("Jane Author");
+		});
+
+		test("does not throw when the channel has no website link", async () => {
+			mockRequestWithTimeout.mockResolvedValueOnce({
+				text: rssFeedWithoutChannelLink,
+				status: 200,
+				headers: {},
+				arrayBuffer: new ArrayBuffer(0),
+				json: {},
+			});
+
+			const parser = new FeedParser();
+			const feed = await parser.getFeed("https://example.com/feed.xml");
+
+			expect(feed.title).toBe("No Link Podcast");
+			expect(feed.link).toBeUndefined();
+		});
+
+		test("uses the atom alternate link, never a hub/self link, for the website", async () => {
+			mockRequestWithTimeout.mockResolvedValueOnce({
+				text: rssFeedWithAtomHubAndAlternate,
+				status: 200,
+				headers: {},
+				arrayBuffer: new ArrayBuffer(0),
+				json: {},
+			});
+
+			const parser = new FeedParser();
+			const feed = await parser.getFeed("https://example.com/feed.xml");
+
+			expect(feed.link).toBe("https://example.com/site");
+		});
+
+		test("honours tag priority: itunes:author over managingEditor, itunes:summary when description is empty", async () => {
+			mockRequestWithTimeout.mockResolvedValueOnce({
+				text: rssFeedWithMetadataPriority,
+				status: 200,
+				headers: {},
+				arrayBuffer: new ArrayBuffer(0),
+				json: {},
+			});
+
+			const parser = new FeedParser();
+			const feed = await parser.getFeed("https://example.com/feed.xml");
+
+			expect(feed.author).toBe("The Real Author");
+			expect(feed.description).toBe("Summary used because description is empty");
 		});
 	});
 

--- a/src/parser/feedParser.ts
+++ b/src/parser/feedParser.ts
@@ -24,12 +24,16 @@ export default class FeedParser {
 		const body = await this.parseFeed(url);
 
 		const titleEl = body.querySelector("title");
-		const linkEl = body.querySelector("link");
 		const itunesImageEl = this.findImageElement(body);
 
-		if (!titleEl || !linkEl) {
+		// A feed must have a title. <link> is intentionally NOT required: it is the
+		// human website (now surfaced as {{url}} in feed notes), but many valid
+		// feeds omit a channel <link> or only carry an <atom:link rel="self">.
+		if (!titleEl) {
 			throw new Error("Invalid RSS feed");
 		}
+
+		const channel = body.querySelector("channel") ?? body;
 
 		const title = titleEl.textContent || "";
 		const artworkUrl =
@@ -43,6 +47,22 @@ export default class FeedParser {
 			artworkUrl,
 		};
 
+		const link = this.findFeedLink(channel);
+		if (link) feed.link = link;
+
+		const description = this.findDirectChildText(channel, [
+			"description",
+			"itunes:summary",
+		]);
+		if (description) feed.description = description;
+
+		const author = this.findDirectChildText(channel, [
+			"itunes:author",
+			"author",
+			"managingEditor",
+		]);
+		if (author) feed.author = author;
+
 		this.feed = feed;
 		return feed;
 	}
@@ -54,6 +74,62 @@ export default class FeedParser {
 
 		// Fallback to generic <image> element
 		return doc.querySelector("image");
+	}
+
+	/**
+	 * Resolve the feed's website URL from the channel's direct <link> children.
+	 * Prefers a <link> whose text content is an http(s) URL; RSS feeds commonly
+	 * place an <atom:link rel="self" href="..."/> (URL in the attribute, empty
+	 * text) before the website <link>, so those are skipped, with an atom
+	 * alternate href used only as a last resort. Returns "" when none is present.
+	 */
+	private findFeedLink(scope: Document | Element): string {
+		const directLinks = Array.from(scope.children).filter((el) => {
+			const tag = el.tagName.toLowerCase();
+			return tag === "link" || tag === "atom:link";
+		});
+
+		for (const link of directLinks) {
+			const text = link.textContent?.trim();
+			if (text && /^https?:\/\//i.test(text)) return text;
+		}
+
+		for (const link of directLinks) {
+			// Only an "alternate" (or rel-less) atom link is the human website.
+			// Skip self/hub/next/prev/first/last/payment/edit and similar relations
+			// so a PubSubHubbub hub or pagination URL never becomes the feed link.
+			const rel = link.getAttribute("rel");
+			if (rel && rel !== "alternate") continue;
+			const href = link.getAttribute("href")?.trim();
+			if (href && /^https?:\/\//i.test(href)) return href;
+		}
+
+		return "";
+	}
+
+	/**
+	 * Read a feed-level value from the first DIRECT child of `scope` matching
+	 * `tagNames`, honouring the PRIORITY of `tagNames` (not document order): the
+	 * first tag name with a non-empty value wins. This keeps a preferred tag
+	 * (e.g. <itunes:author>) ahead of a fallback (<managingEditor>) regardless of
+	 * their order in the XML, and lets an empty <description> fall through to
+	 * <itunes:summary>. Direct-child scoping keeps it from matching the same tags
+	 * nested inside an <item>.
+	 */
+	private findDirectChildText(
+		scope: Document | Element,
+		tagNames: string[],
+	): string {
+		const children = Array.from(scope.children);
+		for (const tag of tagNames) {
+			const wanted = tag.toLowerCase();
+			for (const child of children) {
+				if (child.tagName.toLowerCase() !== wanted) continue;
+				const text = child.textContent?.trim() ?? "";
+				if (text) return text;
+			}
+		}
+		return "";
 	}
 
 	protected parsePage(page: Document): Episode[] {

--- a/src/settingsTransfer.test.ts
+++ b/src/settingsTransfer.test.ts
@@ -276,4 +276,15 @@ describe("mergeImportedSettings", () => {
 
 		expect(merged.note).toEqual({ path: "custom/{{title}}.md", template: "custom" });
 	});
+
+	it("backfills a partial feedNote import (path-only) from defaults", () => {
+		const current = makeSettings();
+
+		const merged = mergeImportedSettings(current, {
+			feedNote: { path: "MyPods/{{podcast}}.md" } as never,
+		});
+
+		expect(merged.feedNote.path).toBe("MyPods/{{podcast}}.md");
+		expect(merged.feedNote.template).toBe(DEFAULT_SETTINGS.feedNote.template);
+	});
 });

--- a/src/settingsTransfer.ts
+++ b/src/settingsTransfer.ts
@@ -44,6 +44,7 @@ const IMPORTABLE_KEYS = new Set(
 const NESTED_KEYS: readonly (keyof IPodNotesSettings)[] = [
 	"timestamp",
 	"note",
+	"feedNote",
 	"download",
 	"transcript",
 	"feedCache",

--- a/src/types/IPodNotesSettings.ts
+++ b/src/types/IPodNotesSettings.ts
@@ -30,6 +30,11 @@ export interface IPodNotesSettings {
 		template: string;
 	};
 
+	feedNote: {
+		path: string;
+		template: string;
+	};
+
 	download: {
 		path: string;
 	};

--- a/src/types/PodcastFeed.ts
+++ b/src/types/PodcastFeed.ts
@@ -3,4 +3,10 @@ export interface PodcastFeed {
 	url: string;
 	artworkUrl: string;
 	collectionId?: string;
+	/** Channel <description> / <itunes:summary>. May contain HTML. */
+	description?: string;
+	/** Channel <link> — the podcast's website/homepage (not the RSS url). */
+	link?: string;
+	/** <itunes:author> (falls back to <author> / <managingEditor>). */
+	author?: string;
 }

--- a/src/ui/FeedSuggestModal.test.ts
+++ b/src/ui/FeedSuggestModal.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { orderFeedsByCurrent } from "./FeedSuggestModal";
+import type { PodcastFeed } from "src/types/PodcastFeed";
+
+const feed = (title: string): PodcastFeed => ({
+	title,
+	url: `https://example.com/${title}`,
+	artworkUrl: "",
+});
+
+describe("orderFeedsByCurrent", () => {
+	it("returns feeds unchanged when there is no current podcast", () => {
+		const feeds = [feed("A"), feed("B")];
+		expect(orderFeedsByCurrent(feeds).map((f) => f.title)).toEqual(["A", "B"]);
+	});
+
+	it("moves the current podcast's feed to the front", () => {
+		const feeds = [feed("A"), feed("B"), feed("C")];
+		expect(orderFeedsByCurrent(feeds, "B").map((f) => f.title)).toEqual([
+			"B",
+			"A",
+			"C",
+		]);
+	});
+
+	it("is a no-op when the current podcast has no saved feed", () => {
+		const feeds = [feed("A"), feed("B")];
+		expect(orderFeedsByCurrent(feeds, "Z").map((f) => f.title)).toEqual([
+			"A",
+			"B",
+		]);
+	});
+});

--- a/src/ui/FeedSuggestModal.ts
+++ b/src/ui/FeedSuggestModal.ts
@@ -1,0 +1,51 @@
+import { type App, FuzzySuggestModal } from "obsidian";
+import type { PodcastFeed } from "src/types/PodcastFeed";
+
+/**
+ * Order feeds so the currently-playing podcast's feed (if any) sorts first, so
+ * the picker opens on the most likely choice. Pure, for testability.
+ */
+export function orderFeedsByCurrent(
+	feeds: PodcastFeed[],
+	currentPodcastName?: string,
+): PodcastFeed[] {
+	if (!currentPodcastName) return feeds;
+
+	return [
+		...feeds.filter((feed) => feed.title === currentPodcastName),
+		...feeds.filter((feed) => feed.title !== currentPodcastName),
+	];
+}
+
+/**
+ * Fuzzy picker over the user's saved podcast feeds, used by the "Create podcast
+ * feed note" command so a feed note can be created without playing an episode
+ * (issue #161).
+ */
+export class FeedSuggestModal extends FuzzySuggestModal<PodcastFeed> {
+	private feeds: PodcastFeed[];
+	private onChoose: (feed: PodcastFeed) => void;
+
+	constructor(
+		app: App,
+		feeds: PodcastFeed[],
+		onChoose: (feed: PodcastFeed) => void,
+	) {
+		super(app);
+		this.feeds = feeds;
+		this.onChoose = onChoose;
+		this.setPlaceholder("Select a podcast to create or open its note");
+	}
+
+	getItems(): PodcastFeed[] {
+		return this.feeds;
+	}
+
+	getItemText(feed: PodcastFeed): string {
+		return feed.title;
+	}
+
+	onChooseItem(feed: PodcastFeed): void {
+		this.onChoose(feed);
+	}
+}

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.ts
@@ -1,8 +1,10 @@
 import { Menu, Notice } from "obsidian";
 import createPodcastNote, { getPodcastNote, openPodcastNote } from "src/createPodcastNote";
+import createFeedNote, { getFeedNote, openFeedNote } from "src/createFeedNote";
 import downloadEpisodeWithProgessNotice from "src/downloadEpisode";
-import { currentEpisode, downloadedEpisodes, favorites, playedEpisodes, playlists, plugin, queue, viewState } from "src/store";
+import { currentEpisode, downloadedEpisodes, favorites, playedEpisodes, playlists, plugin, queue, savedFeeds, viewState } from "src/store";
 import type { Episode } from "src/types/Episode";
+import type { PodcastFeed } from "src/types/PodcastFeed";
 import { ViewState } from "src/types/ViewState";
 import { get } from "svelte/store";
 import { isEpisodeFinished } from "src/utility/episodeStatus";
@@ -98,6 +100,27 @@ export default function spawnEpisodeContextMenu(
 					}
 
 					await createPodcastNote(episode);
+				}
+			}));
+
+		// Feed-level note for the episode's parent podcast (issue #163).
+		const feed = resolveFeedForEpisode(episode);
+		const feedNoteExists = Boolean(getFeedNote(feed));
+
+		menu.addItem(item => item
+			.setIcon("rss")
+			.setTitle(`${feedNoteExists ? "Open" : "Create"} feed note`)
+			.onClick(async () => {
+				if (feedNoteExists) {
+					openFeedNote(feed);
+				} else {
+					const { path, template } = get(plugin).settings.feedNote;
+					if (!path || !template) {
+						new Notice(`Please set a podcast feed note path and template in the settings.`);
+						return;
+					}
+
+					await createFeedNote(feed);
 				}
 			}));
 	}
@@ -212,4 +235,21 @@ export default function spawnEpisodeContextMenu(
 
 	menu.showAtMouseEvent(event);
 
+}
+
+/**
+ * Resolve the parent feed for an episode. Prefers the saved feed (keyed by the
+ * raw podcast name, matching episode.podcastName) so its artwork/url/metadata are
+ * used; otherwise synthesizes a minimal feed from the episode (e.g. local files
+ * or history). createFeedNote enriches missing metadata via the feed URL.
+ */
+function resolveFeedForEpisode(episode: Episode): PodcastFeed {
+	const saved = get(savedFeeds)[episode.podcastName];
+	if (saved) return saved;
+
+	return {
+		title: episode.podcastName,
+		url: episode.feedUrl ?? "",
+		artworkUrl: episode.artworkUrl ?? "",
+	};
 }

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -13,6 +13,7 @@ import PlaylistManager from "./PlaylistManager.svelte";
 import { mount, unmount } from "svelte";
 import {
 	DownloadPathTemplateEngine,
+	FeedFilePathTemplateEngine,
 	FilePathTemplateEngine,
 	TimestampTemplateEngine,
 } from "../../TemplateEngine";
@@ -27,6 +28,7 @@ import {
 	volume,
 } from "src/store/index";
 import type { Episode } from "src/types/Episode";
+import type { PodcastFeed } from "src/types/PodcastFeed";
 import type { IPodNotesSettings } from "src/types/IPodNotesSettings";
 import { get } from "svelte/store";
 import { exportOPML, importOPML } from "src/opml";
@@ -86,6 +88,7 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 		this.addDefaultVolumeSetting(settingsContainer);
 		this.addSkipLengthSettings(settingsContainer);
 		this.addNoteSettings(settingsContainer);
+		this.addFeedNoteSettings(settingsContainer);
 		this.addDownloadSettings(settingsContainer);
 		this.addPerformanceSettings(settingsContainer);
 		this.addImportExportSettings(settingsContainer);
@@ -282,6 +285,74 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 		noteCreationSetting.settingEl.style.flexDirection = "column";
 		noteCreationSetting.settingEl.style.alignItems = "unset";
 		noteCreationSetting.settingEl.style.gap = "10px";
+	}
+
+	private addFeedNoteSettings(settingsContainer: HTMLDivElement) {
+		const container = settingsContainer.createDiv();
+
+		container.createEl("h4", { text: "Podcast feed note settings" });
+
+		const desc = container.createEl("p", {
+			text:
+				'Create a note for a whole podcast (the feed), not a single episode. ' +
+				'Run the "Create podcast feed note" command to pick a saved podcast. ' +
+				"Available tags: {{title}}, {{podcast}}, {{url}} (website), " +
+				"{{feedurl}} (RSS), {{artwork}}, {{author}}, {{description}}, {{date}}.",
+		});
+		desc.style.fontSize = "var(--font-ui-smaller)";
+		desc.style.color = "var(--text-muted)";
+
+		const randomFeed = getRandomFeed();
+
+		const feedNotePathSetting = new Setting(container)
+			.setName("Feed note file path")
+			.setHeading()
+			.addText((textComponent) => {
+				textComponent.setValue(this.plugin.settings.feedNote.path);
+				textComponent.setPlaceholder("PodNotes/Podcasts/{{podcast}}.md");
+				textComponent.onChange((value) => {
+					this.plugin.settings.feedNote.path = value;
+					this.plugin.saveSettings();
+					renderFeedPathDemo(value);
+				});
+				textComponent.inputEl.style.width = "100%";
+			});
+
+		feedNotePathSetting.settingEl.style.flexDirection = "column";
+		feedNotePathSetting.settingEl.style.alignItems = "unset";
+		feedNotePathSetting.settingEl.style.gap = "10px";
+
+		const feedNotePathDemoEl = container.createDiv();
+
+		const renderFeedPathDemo = (value: string) => {
+			const demoVal = FeedFilePathTemplateEngine(value, randomFeed);
+			feedNotePathDemoEl.empty();
+			MarkdownRenderer.renderMarkdown(
+				demoVal,
+				feedNotePathDemoEl,
+				"",
+				new Component(),
+			);
+		};
+
+		renderFeedPathDemo(this.plugin.settings.feedNote.path);
+
+		const feedNoteTemplateSetting = new Setting(container)
+			.setName("Feed note template")
+			.setHeading()
+			.addTextArea((textArea) => {
+				textArea.setValue(this.plugin.settings.feedNote.template);
+				textArea.onChange((value) => {
+					this.plugin.settings.feedNote.template = value;
+					this.plugin.saveSettings();
+				});
+				textArea.inputEl.style.width = "100%";
+				textArea.inputEl.style.height = "25vh";
+			});
+
+		feedNoteTemplateSetting.settingEl.style.flexDirection = "column";
+		feedNoteTemplateSetting.settingEl.style.alignItems = "unset";
+		feedNoteTemplateSetting.settingEl.style.gap = "10px";
 	}
 
 	private addDownloadSettings(container: HTMLDivElement) {
@@ -724,6 +795,22 @@ function getRandomEpisode(): Episode {
 		randomFeed[Math.floor(Math.random() * randomFeed.length)];
 
 	return randomEpisode;
+}
+
+function getRandomFeed(): PodcastFeed {
+	const fallbackDemoFeed: PodcastFeed = {
+		title: "Demo Podcast",
+		url: "https://example.com/feed.xml",
+		artworkUrl: "https://example.com/artwork.jpg",
+		description: "A demo podcast feed.",
+		link: "https://example.com",
+		author: "Demo Author",
+	};
+
+	const feeds = Object.values(get(savedFeeds));
+	if (!feeds.length) return fallbackDemoFeed;
+
+	return feeds[Math.floor(Math.random() * feeds.length)];
 }
 
 class ConfirmModal extends Modal {

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -47,6 +47,22 @@ export class Modal {
 	onClose(): void {}
 }
 
+export class SuggestModal<T> extends Modal {
+	setPlaceholder(_placeholder: string): void {}
+}
+
+export class FuzzySuggestModal<T> extends SuggestModal<T> {
+	getItems(): T[] {
+		return [];
+	}
+
+	getItemText(_item: T): string {
+		return "";
+	}
+
+	onChooseItem(_item: T, _evt?: MouseEvent | KeyboardEvent): void {}
+}
+
 class BaseInteractiveElement {
 	protected element: HTMLElement;
 


### PR DESCRIPTION
## Summary
Adds first-class notes for a whole **podcast feed** (not just individual episodes), so episodes can link up to a parent note for Obsidian Bases / Dataview rollups.

- **New command "Create podcast feed note"** — opens a fuzzy picker over your saved podcasts and creates (or opens) that podcast's note. No playback required (addresses #161). The playing episode's feed is pre-selected when there is one.
- **Episode right-click menu** gains "Create/Open feed note".
- The existing **"Create Podcast Note"** command (which actually creates an *episode* note) was renamed to **"Create episode note"**. The command id (`create-podcast-note`) is unchanged, so existing hotkeys/API keep working.
- **Template variables** — guiding rule: `{{url}}`/`{{artwork}}` always describe the note's own subject (the episode in an episode note, the feed in a feed note). No existing tag changes meaning.
  - Episode notes gain `{{episodeurl}}`, `{{episodeartwork}}`, `{{feedurl}}`, `{{feedartwork}}`, and `{{podcastlink}}` (a ready-made wikilink to the feed note).
  - New `FeedNoteTemplateEngine` exposes `{{title}}`, `{{podcast}}`, `{{url}}` (website), `{{feedurl}}`, `{{artwork}}`, `{{author}}`, `{{description}}`, `{{date}}`.
- **Feed metadata** — `PodcastFeed` + `FeedParser.getFeed` now capture the channel `description`, website `link` (atom-`self`/hub-safe), and `author`; `getFeed` no longer throws when a feed omits `<link>`.
- **Settings** — new `feedNote { path, template }` with Bases-friendly defaults (addresses #160), included in settings import/export.

Closes #163. Relates to #161 and #160.

## Implementation notes
- Feed-note creation is race-safe (re-checks existence after on-demand metadata enrichment and treats an "already exists" create as success) and never lets a re-fetched title shift the destination basename.
- The default feed template keeps only YAML-safe values in frontmatter (sanitized `{{podcast}}` + quoted URL scalars); raw `{{title}}`/`{{author}}` live in the note body so arbitrary titles/authors can't produce invalid YAML.
- `TemplateEngine.ts` changes are additive (new exported engines) to compose cleanly with #182.

## Testing
Ran the CI-equivalent gates locally (Node 22):
- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test` ✓ (278 tests, 29 files — includes new unit tests for the feed engines, feed metadata parsing incl. atom hub/alternate, `createFeedNote` race-safety, settings round-trip, and picker ordering)
- `npm run build` ✓
- `npm run check:a11y` ✓ (0 errors, 0 warnings)
- `npm run format:check` ✓

`docs:build` requires mkdocs (not installed locally); docs changes are plain markdown additions to `commands.md`/`templates.md`.

**Runtime verification:** ✅ completed in a real Obsidian dev vault — command → fuzzy picker → live on-demand enrichment → Obsidian-parsed (valid Bases YAML) note, plus settings-migration backfill, the no-duplicate guard, and `{{podcastlink}}` resolution. See the "Runtime verification" comment on this PR for the captured evidence.

## Release / migration impact
- Adds one nested setting `feedNote { path, template }` with shipped defaults; backfills automatically for existing users (no migration needed) and round-trips through settings import/export.
- No existing template tag changes meaning, so existing episode templates are unaffected.
