### PR TITLE
fix(playback): persist listened time during playback (#33)

### DIFF
--- a/scripts/provision-obsidian-e2e-vault.mjs
+++ b/scripts/provision-obsidian-e2e-vault.mjs
@@ -42,6 +42,7 @@ export const DEFAULT_PODNOTES_DATA = {
 		shouldRepeat: false,
 		episodes: [],
 	},
+	autoQueue: true,
 	playlists: {},
 	skipBackwardLength: 15,
 	skipForwardLength: 15,
@@ -53,8 +54,25 @@ export const DEFAULT_PODNOTES_DATA = {
 		path: "",
 		template: "",
 	},
+	feedNote: {
+		path: "PodNotes/Podcasts/{{podcast}}.md",
+		template:
+			"---\n" +
+			"type: podcast\n" +
+			'podcast: "{{podcast}}"\n' +
+			'image: "{{artwork}}"\n' +
+			'url: "{{url}}"\n' +
+			'feedUrl: "{{feedurl}}"\n' +
+			"tags:\n" +
+			"  - podcast\n" +
+			"---\n" +
+			"# {{title}}\n" +
+			"{{author}}\n\n" +
+			"![]({{artwork}})\n\n" +
+			"{{description}}\n",
+	},
 	download: {
-		path: "",
+		path: "PodNotes/{{podcast}}/{{title}}",
 	},
 	downloadedEpisodes: {},
 	localFiles: {

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -164,6 +164,50 @@
 		isPaused.set(false);
 	}
 
+	// Persist playback position during playback (issue #33).
+	//
+	// Previously the position was written only on teardown — the player's
+	// onDestroy, an episode switch (currentEpisode.set), or the episode
+	// finishing. On mobile the OS kills the backgrounded process without firing
+	// onDestroy, so every second listened since the last teardown was lost and
+	// the episode restarted from 0 on reopen.
+	//
+	// Persist periodically while audio plays (throttled) and immediately when it
+	// pauses, so an abrupt kill loses at most SAVE_POSITION_THROTTLE_MS of
+	// progress. saveSettings already coalesces rapid writes, so this cadence
+	// stays cheap.
+	const SAVE_POSITION_THROTTLE_MS = 5000;
+	let lastPositionSaveMs = Number.NEGATIVE_INFINITY;
+
+	function persistPlaybackPosition() {
+		// Never persist before metadata has loaded and the saved position has been
+		// restored (onMetadataLoaded) — writing the pre-restore 0 would clobber the
+		// stored position we are about to resume from.
+		if (isLoading || !$currentEpisode) return;
+
+		playedEpisodes.setEpisodeTime(
+			$currentEpisode,
+			$currentTime,
+			$duration,
+			$currentTime === $duration,
+		);
+	}
+
+	function onTimeUpdate() {
+		const now = Date.now();
+		if (now - lastPositionSaveMs < SAVE_POSITION_THROTTLE_MS) return;
+
+		lastPositionSaveMs = now;
+		persistPlaybackPosition();
+	}
+
+	function onPause() {
+		// An explicit stop is the moment the user is most likely to leave the app,
+		// so capture the exact position immediately rather than waiting for the
+		// next throttled tick.
+		persistPlaybackPosition();
+	}
+
 	let srcPromise: Promise<string> = getSrc($currentEpisode);
 
 	onMount(() => {
@@ -174,6 +218,15 @@
 		});
 
 		const unsubCurrentEpisode = currentEpisode.subscribe((episode) => {
+			// Re-arm the load guard and throttle for the incoming episode. isLoading
+			// is cleared once on the first loadedmetadata and this component instance
+			// is reused across in-player switches (no {#key} around <EpisodePlayer/>),
+			// so without this it would stay false — letting a pause/timeupdate during
+			// the src swap persist the new episode under its key with the old/zero
+			// time and clobber its saved resume position (issue #33).
+			isLoading = true;
+			lastPositionSaveMs = Number.NEGATIVE_INFINITY;
+
 			srcPromise = getSrc($currentEpisode);
 
 			// Fetch chapters when episode changes
@@ -193,15 +246,28 @@
 			playerVolume = clampVolume(value);
 		});
 
+		// Backgrounding the app (mobile home button / app switch) or hiding the
+		// window is the last reliable moment before the OS may suspend or kill the
+		// process. It fires no pause event when audio keeps playing, and the next
+		// throttled tick may never arrive — so persist immediately on hide to make
+		// progress durable in exactly the scenario issue #33 reports.
+		const onVisibilityChange = () => {
+			if (document.visibilityState === "hidden") {
+				persistPlaybackPosition();
+			}
+		};
+		document.addEventListener("visibilitychange", onVisibilityChange);
+
 		return () => {
 			unsubDownloadedSource();
 			unsubCurrentEpisode();
 			unsubVolume();
+			document.removeEventListener("visibilitychange", onVisibilityChange);
 		};
 	});
 
 	onDestroy(() => {
-		playedEpisodes.setEpisodeTime($currentEpisode, $currentTime, $duration, ($currentTime === $duration));
+		persistPlaybackPosition();
 		isPaused.set(true);
 	});
 
@@ -287,6 +353,8 @@
 			bind:volume={playerVolume}
 			on:ended={onEpisodeEnded}
 			on:loadedmetadata={onMetadataLoaded}
+			on:timeupdate={onTimeUpdate}
+			on:pause={onPause}
 			on:play|preventDefault
 			autoplay={true}
 		></audio>

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
 	currentEpisode,
@@ -83,5 +83,157 @@ describe("EpisodePlayer", () => {
 		expect(get(currentTime)).toBe(1800);
 		expect(get(isPaused)).toBe(false);
 		expect(get(requestedPlaybackTime)).toBeNull();
+	});
+});
+
+describe("EpisodePlayer — persists playback position during playback (issue #33)", () => {
+	const episodeKey = `${testEpisode.podcastName}::${testEpisode.title}`;
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	async function renderLoadedPlayer() {
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+		// loadedmetadata flips isLoading off and runs the restore, after which
+		// progress is allowed to persist.
+		await fireEvent.loadedMetadata(audio);
+		return audio;
+	}
+
+	test("saves position on timeupdate, throttling rapid updates", async () => {
+		let now = 1_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const audio = await renderLoadedPlayer();
+
+		currentTime.set(120);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(120);
+
+		// A second update within the throttle window must not overwrite it.
+		now += 2000;
+		currentTime.set(121);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(120);
+
+		// Past the throttle window, the latest position is persisted.
+		now += 4000;
+		currentTime.set(200);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(200);
+
+		// Boundary: an update exactly SAVE_POSITION_THROTTLE_MS after the last save
+		// is not throttled (the guard uses a strict <), so it persists.
+		now += 5000;
+		currentTime.set(260);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(260);
+	});
+
+	test("saves the exact position immediately on pause, bypassing the throttle", async () => {
+		let now = 5_000_000;
+		vi.spyOn(Date, "now").mockImplementation(() => now);
+
+		const audio = await renderLoadedPlayer();
+
+		// Consume the leading-edge save so the throttle window is now active.
+		currentTime.set(50);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(50);
+
+		// A timeupdate within the throttle window is ignored...
+		now += 1000;
+		currentTime.set(60);
+		await fireEvent.timeUpdate(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(50);
+
+		// ...but a pause within the same window must still persist immediately.
+		currentTime.set(137);
+		await fireEvent.pause(audio);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(137);
+	});
+
+	test("does not clobber the saved position before metadata has loaded", async () => {
+		playedEpisodes.setEpisodeTime(testEpisode, 1800, 3600, false);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+
+		// No loadedmetadata yet: isLoading is still true and currentTime is the
+		// pre-restore 0. Neither a pause nor a timeupdate may overwrite 1800.
+		currentTime.set(0);
+		await fireEvent.pause(audio);
+		await fireEvent.timeUpdate(audio);
+
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(1800);
+	});
+
+	test("re-arms the load guard on episode switch so the next episode's saved position is not clobbered", async () => {
+		const episodeB: Episode = {
+			title: "Episode B",
+			streamUrl: "https://pod.example.com/b.mp3",
+			url: "https://pod.example.com/b",
+			description: "",
+			content: "",
+			podcastName: "Test Podcast",
+		};
+		const keyB = `${episodeB.podcastName}::${episodeB.title}`;
+		// B already has a saved resume position from a previous listen.
+		playedEpisodes.setEpisodeTime(episodeB, 1800, 3600, false);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		await fireEvent.loadedMetadata(
+			container.querySelector("audio") as HTMLAudioElement,
+		);
+
+		// Switch to B in-player (queue click / auto-advance reuse this instance).
+		// The re-arm must set isLoading=true until B's metadata loads.
+		currentEpisode.set(episodeB);
+		await waitFor(() => {
+			const next = container.querySelector("audio");
+			expect(next?.getAttribute("src")).toBe(episodeB.streamUrl);
+		});
+		const audioB = container.querySelector("audio") as HTMLAudioElement;
+
+		// A pause/timeupdate during B's src swap, before its loadedmetadata and at
+		// the pre-restore 0, must not overwrite B's saved 1800.
+		currentTime.set(0);
+		await fireEvent.pause(audioB);
+		await fireEvent.timeUpdate(audioB);
+
+		expect(get(playedEpisodes)[keyB]?.time).toBe(1800);
+	});
+
+	test("persists immediately when the app is backgrounded (visibilitychange → hidden)", async () => {
+		await renderLoadedPlayer();
+		currentTime.set(222);
+
+		const originalDescriptor =
+			Object.getOwnPropertyDescriptor(document, "visibilityState") ??
+			Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+		Object.defineProperty(document, "visibilityState", {
+			configurable: true,
+			get: () => "hidden",
+		});
+
+		try {
+			document.dispatchEvent(new Event("visibilitychange"));
+			expect(get(playedEpisodes)[episodeKey]?.time).toBe(222);
+		} finally {
+			if (originalDescriptor) {
+				Object.defineProperty(document, "visibilityState", originalDescriptor);
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #33 — podcast playback no longer restarts from the beginning after you leave and reopen the app.

The listened position was persisted **only on teardown events** — the player's `onDestroy`, an episode switch, or the episode finishing. On mobile the OS kills the backgrounded process **without firing `onDestroy`**, so every second listened since the last teardown was lost and the episode resumed from `0`. (Also reported "after closing Obsidian" on macOS, where a hard quit can beat the async settings write.)

This PR persists the position **during** playback, so progress is durable no matter how the app terminates.

## Root cause (verified on current `master`)

`EpisodePlayer.svelte` only wrote the position via `onDestroy` / `currentEpisode.set` / `markAsPlayed`. There was no `timeupdate`/interval save during playback. Reproduced in a real isolated Obsidian vault:

- Played an episode to `137s`, waited 3s while "playing" → `settings.playedEpisodes` stayed `{}`.
- On-disk `data.json` had nothing; a simulated cold restart restored `0` → **137s lost**.

## The fix (`src/ui/PodcastView/EpisodePlayer.svelte`)

- **Periodic save while playing** — throttled `on:timeupdate` (`SAVE_POSITION_THROTTLE_MS = 5000`, leading-edge). An abrupt kill loses at most ~5s.
- **Immediate save on pause** — `on:pause` (the "stop, then leave" path) writes the exact position, bypassing the throttle.
- **Immediate save on background** — a `visibilitychange → hidden` listener captures the exact moment the app is backgrounded / window hidden, before the OS can suspend or kill the process. This is the headline mobile scenario.
- **Teardown save kept** — `onDestroy` still saves, now via the shared `persistPlaybackPosition()` helper.
- **No clobber before restore** — `persistPlaybackPosition()` skips writes while `isLoading` is true, so it never overwrites the stored position with the pre-restore `0`. (This also repairs a latent bug where `onDestroy` before metadata load wrote `finished: true`.)
- **Re-armed on episode switch** — `isLoading` / throttle are reset in the `currentEpisode` subscription, so an in-player switch (queue click, auto-advance) cannot clobber the next episode's saved resume position. `<EpisodePlayer/>` has no `{#key}`, so the instance is reused across switches and the guard would otherwise stay inert.

Writes flow through the existing `setEpisodeTime → EpisodeStatusController → saveSettings` chain, which already coalesces, so the cadence stays cheap.

## Tests (`EpisodePlayer.test.ts`)

7 tests, mounting the real component and firing real DOM events:
- throttled periodic save (incl. the exact-5000ms boundary);
- pause saves immediately and bypasses the throttle;
- no clobber before metadata loads;
- episode-switch re-arm cannot clobber the next episode's saved position;
- `visibilitychange → hidden` persists immediately.

## Runtime verification (real Obsidian, isolated e2e vault)

With a real local audio file driven through the player (no teardown):
- position persisted to `data.json` **during playback** (e.g. `time: 27.16` after ~6s) — previously stayed `{}`;
- `on:pause` wrote the exact position (`423`);
- `visibilitychange → hidden` wrote the exact position (`480`) to disk.

## Gates

`npm run lint`, `format:check`, `typecheck`, `check:a11y`, `build` ✅ — full `npm run test` passes for this change.

> Note: `scripts/provision-obsidian-e2e-vault.test.ts` fails on `master` independently of this PR (pre-existing e2e-seed vs `DEFAULT_SETTINGS` drift); confirmed by stashing this branch's changes. Out of scope here.

## Release / migration impact

None. No settings shape, storage, API, or URI changes — only more frequent writes to the existing `playedEpisodes` map.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

### CI fix (separate commit)

CI's `Test` check was red due to a **pre-existing failure on `master`**, not this change: `scripts/provision-obsidian-e2e-vault.test.ts` asserts the e2e seed `DEFAULT_PODNOTES_DATA` mirrors `DEFAULT_SETTINGS`, and recent merges (#108 `autoQueue`, #163 `feedNote`, #183 `download.path`) drifted the seed. Filed as #191 and fixed here in a dedicated `fix(devx)` commit (`Closes #191`) so this PR's CI can go green — easily separable if you'd prefer it on its own.
