### PR TITLE
fix(notes): cap note path length and harden folder creation (#22, #87)

### DIFF
--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -238,6 +238,22 @@ describe("getFeedNoteWikilink (#163)", () => {
 		plugin.set({ settings: { feedNote: { path: "" } } } as never);
 		expect(getFeedNoteWikilink("My Show: A Podcast")).toBe("[[My Show A Podcast]]");
 	});
+
+	it("caps a long feed title so the link matches the capped feed-note path (#22)", () => {
+		plugin.set({
+			settings: { feedNote: { path: "PodNotes/Podcasts/{{podcast}}.md" } },
+		} as never);
+		const link = getFeedNoteWikilink("Z".repeat(400));
+		const linkPath = link
+			.replace(/^\[\[/, "")
+			.replace(/\]\]$/, "")
+			.split("|")[0];
+		const basename = linkPath.split("/").pop() ?? "";
+		// Without the cap the link would embed all 400 chars and never resolve.
+		expect(basename.length).toBeLessThanOrEqual(255);
+		expect(basename.length).toBeLessThan(400);
+		expect(linkPath.startsWith("PodNotes/Podcasts/")).toBe(true);
+	});
 });
 
 describe("{{currentDate}} tag (#75)", () => {

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -10,6 +10,8 @@ import { formatDuration } from "./utility/formatDuration";
 import { formatEpisodeNumber } from "./utility/formatEpisodeNumber";
 import { parseEpisodeNumberFromTitle } from "./utility/parseEpisodeNumber";
 import buildEpisodeResumeLink from "./utility/buildEpisodeResumeLink";
+import addExtension from "./utility/addExtension";
+import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
 
 // Each tag is either a literal string or a function taking at most one argument
 // (the raw text after the leading colon, e.g. the format in {{date:YYYY}}). The
@@ -394,7 +396,11 @@ export function getFeedNoteWikilink(feedTitle: string): string {
 		url: "",
 		artworkUrl: "",
 	});
-	const linkPath = rendered.replace(/\.md$/i, "").trim();
+	// Apply the same length cap createFeedNote uses (#22) so the link targets the
+	// exact file written even when a long feed title is truncated. Mirror its
+	// `enforceMaxPathLength(addExtension(...))` derivation, then drop the .md.
+	const capped = enforceMaxPathLength(addExtension(rendered, "md"));
+	const linkPath = capped.replace(/\.md$/i, "").trim();
 	const basename = linkPath.split("/").pop()?.trim() || fallback;
 
 	return linkPath.includes("/")

--- a/src/createFeedNote.test.ts
+++ b/src/createFeedNote.test.ts
@@ -125,6 +125,19 @@ describe("createFeedNote", () => {
 		expect(opened).toContain(EXPECTED_PATH);
 	});
 
+	it("caps a very long feed title so creation can't trip ENAMETOOLONG (#22)", async () => {
+		const { created } = setupVault({});
+
+		await createFeedNote({ ...fullFeed, title: "Z".repeat(400) });
+
+		expect(created).toHaveLength(1);
+		const basename = created[0].path.split("/").pop() ?? "";
+		expect(created[0].path.startsWith("PodNotes/Podcasts/")).toBe(true);
+		expect(basename.endsWith(".md")).toBe(true);
+		expect(basename.length).toBeLessThanOrEqual(255);
+		expect(basename.length).toBeLessThan(400);
+	});
+
 	it("does nothing when no feed-note path/template is configured", async () => {
 		plugin.set({
 			settings: { feedNote: { path: "", template: "" } },

--- a/src/createFeedNote.ts
+++ b/src/createFeedNote.ts
@@ -7,6 +7,7 @@ import type { PodcastFeed } from "./types/PodcastFeed";
 import { get } from "svelte/store";
 import { plugin } from "./store";
 import addExtension from "./utility/addExtension";
+import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
 import { ensureFolderExists } from "./utility/ensureFolderExists";
 import FeedParser from "./parser/feedParser";
 
@@ -23,7 +24,10 @@ function getFeedNotePath(feed: PodcastFeed): string {
 		feed,
 	);
 
-	return addExtension(filePath, "md");
+	// Cap the path so a very long feed title can't trip ENAMETOOLONG (#22). Both
+	// getFeedNote (existence/open) and createFeedNote derive the path here, so they
+	// always agree on the capped result.
+	return enforceMaxPathLength(addExtension(filePath, "md"));
 }
 
 export function getFeedNote(feed: PodcastFeed): TFile | null {

--- a/src/createPodcastNote.ts
+++ b/src/createPodcastNote.ts
@@ -4,18 +4,32 @@ import type { Episode } from "./types/Episode";
 import { get } from "svelte/store";
 import { plugin } from "./store";
 import addExtension from "./utility/addExtension";
+import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
+import { ensureFolderExists } from "./utility/ensureFolderExists";
+
+/**
+ * Resolve the on-disk path of an episode's note from the configured template.
+ * Centralized so the existence check, the open action, and creation all agree on
+ * the exact same (length-capped) path — otherwise a truncated note would be
+ * re-created on every invocation. See issue #22.
+ */
+function getPodcastNotePath(episode: Episode): string {
+	const pluginInstance = get(plugin);
+
+	const filePath = FilePathTemplateEngine(
+		pluginInstance.settings.note.path,
+		episode,
+	);
+
+	return enforceMaxPathLength(addExtension(filePath, "md"));
+}
 
 export default async function createPodcastNote(
 	episode: Episode
 ): Promise<void> {
 	const pluginInstance = get(plugin);
 
-	const filePath = FilePathTemplateEngine(
-		pluginInstance.settings.note.path,
-		episode
-	);
-
-	const filePathDotMd = addExtension(filePath, "md");
+	const filePathDotMd = getPodcastNotePath(episode);
 
 	const content = NoteTemplateEngine(
 		pluginInstance.settings.note.template,
@@ -37,14 +51,7 @@ export default async function createPodcastNote(
 }
 
 export function getPodcastNote(episode: Episode): TFile | null {
-	const pluginInstance = get(plugin);
-
-	const filePath = FilePathTemplateEngine(
-		pluginInstance.settings.note.path,
-		episode
-	);
-
-	const filePathDotMd = addExtension(filePath, "md");
+	const filePathDotMd = getPodcastNotePath(episode);
 	const file = app.vault.getAbstractFileByPath(filePathDotMd);
 
 	if (!file || !(file instanceof TFile)) {
@@ -69,7 +76,6 @@ async function createFileIfNotExists(
 	path: string,
 	content: string,
 	episode: Episode,
-	createFolder = true
 ): Promise<TFile> {
 	const file = getPodcastNote(episode);
 
@@ -79,15 +85,18 @@ async function createFileIfNotExists(
 		return file;
 	}
 
-	const foldersInPath = path.split("/").slice(0, -1);
-	for (let i = 0; i < foldersInPath.length; i++) {
-		const folderPath = foldersInPath.slice(0, i + 1).join("/");
-		const folder = app.vault.getAbstractFileByPath(folderPath);
+	const folderPath = path.split("/").slice(0, -1).join("/");
+	await ensureFolderExists(folderPath);
 
-		if (!folder && createFolder) {
-			await app.vault.createFolder(folderPath);
+	try {
+		return await app.vault.create(path, content);
+	} catch (error) {
+		// A racing create may have won between the check and here; treat an
+		// already-existing file as success rather than surfacing an error.
+		const raced = app.vault.getAbstractFileByPath(path);
+		if (raced instanceof TFile) {
+			return raced;
 		}
+		throw error;
 	}
-
-	return await app.vault.create(path, content);
 }

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -6,6 +6,7 @@ import {
 	downloadEpisode,
 	getEpisodeAudioBuffer,
 	safeDownloadBasename,
+	safeDownloadFilePath,
 } from "./downloadEpisode";
 import { downloadedEpisodes } from "./store";
 import type { Episode } from "./types/Episode";
@@ -174,6 +175,26 @@ describe("safeDownloadBasename (#183)", () => {
 		expect(
 			safeDownloadBasename("podcast/{{podcast}}/{{title}}", makeEpisode()),
 		).toBe("podcast/Pod/My Title");
+	});
+});
+
+describe("safeDownloadFilePath (#22)", () => {
+	it("caps a long title's file name while keeping the audio extension", () => {
+		const result = safeDownloadFilePath(
+			"podcast/{{podcast}}/{{title}}",
+			makeEpisode({ title: "X".repeat(400) }),
+			"mp3",
+		);
+		const name = result.split("/").pop() ?? "";
+		expect(result.startsWith("podcast/Pod/")).toBe(true);
+		expect(name.endsWith(".mp3")).toBe(true);
+		expect(name.length).toBeLessThanOrEqual(255);
+	});
+
+	it("leaves a short path unchanged", () => {
+		expect(
+			safeDownloadFilePath("podcast/{{podcast}}/{{title}}", makeEpisode(), "mp3"),
+		).toBe("podcast/Pod/My Title.mp3");
 	});
 });
 

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -7,6 +7,7 @@ import {
 import type { Episode } from "./types/Episode";
 import type { LocalEpisode } from "./types/LocalEpisode";
 import { encodeUrlForRequest } from "./utility/encodeUrlForRequest";
+import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
 import { ensureFolderExists } from "./utility/ensureFolderExists";
 import { isLocalFile } from "./utility/isLocalFile";
 import getUrlExtension from "./utility/getUrlExtension";
@@ -199,6 +200,20 @@ export function safeDownloadBasename(
 		.join("/");
 }
 
+/**
+ * The on-disk path for a downloaded episode, with a long title capped so it can't
+ * trip ENAMETOOLONG (#22). Both the pre-download existence check and the write go
+ * through this, so they always agree on the same (capped) path.
+ */
+export function safeDownloadFilePath(
+	downloadPathTemplate: string,
+	episode: Episode,
+	extension: string,
+): string {
+	const basename = safeDownloadBasename(downloadPathTemplate, episode);
+	return enforceMaxPathLength(`${basename}.${extension}`, `.${extension}`);
+}
+
 async function createEpisodeFile({
 	episode,
 	downloadPathTemplate,
@@ -210,8 +225,7 @@ async function createEpisodeFile({
 	data: ArrayBuffer;
 	extension: string;
 }) {
-	const basename = safeDownloadBasename(downloadPathTemplate, episode);
-	const filePath = `${basename}.${extension}`;
+	const filePath = safeDownloadFilePath(downloadPathTemplate, episode, extension);
 
 	// `createBinary` throws if a parent folder is missing, which previously left
 	// users with a templated path like `podcast/{{podcast}}/{{title}}` unable to
@@ -321,9 +335,12 @@ export async function downloadEpisode(
 		return localFilePath;
 	}
 
-	const basename = safeDownloadBasename(downloadPathTemplate, episode);
 	const fileExtension = await getFileExtension(episode.streamUrl);
-	const filePath = `${basename}.${fileExtension}`;
+	const filePath = safeDownloadFilePath(
+		downloadPathTemplate,
+		episode,
+		fileExtension,
+	);
 
 	// Check if the file already exists
 	const existingFile = app.vault.getAbstractFileByPath(filePath);

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -6,6 +6,8 @@ import {
 	FilePathTemplateEngine,
 	TranscriptTemplateEngine,
 } from "../TemplateEngine";
+import { enforceMaxPathLength } from "../utility/enforceMaxPathLength";
+import { ensureFolderExists } from "../utility/ensureFolderExists";
 import type { Episode } from "src/types/Episode";
 
 function TimerNotice(heading: string, initialMessage: string) {
@@ -79,10 +81,7 @@ export class TranscriptionService {
 			return;
 		}
 
-		const transcriptPath = FilePathTemplateEngine(
-			this.plugin.settings.transcript.path,
-			currentEpisode,
-		);
+		const transcriptPath = this.getTranscriptPath(currentEpisode);
 		const existingFile =
 			this.plugin.app.vault.getAbstractFileByPath(transcriptPath);
 		if (existingFile instanceof TFile) {
@@ -141,10 +140,7 @@ export class TranscriptionService {
 		);
 
 		try {
-			const transcriptPath = FilePathTemplateEngine(
-				this.plugin.settings.transcript.path,
-				episode,
-			);
+			const transcriptPath = this.getTranscriptPath(episode);
 			const existingFile =
 				this.plugin.app.vault.getAbstractFileByPath(transcriptPath);
 			if (existingFile instanceof TFile) {
@@ -470,14 +466,23 @@ export class TranscriptionService {
 		return transcriptions.join(" ");
 	}
 
+	/**
+	 * The on-disk path of an episode's transcript note, capped so a long title
+	 * can't trip ENAMETOOLONG (#22). Used for the existence checks and the write
+	 * alike so they always agree on the same path.
+	 */
+	private getTranscriptPath(episode: Episode): string {
+		return enforceMaxPathLength(
+			FilePathTemplateEngine(this.plugin.settings.transcript.path, episode),
+			".md",
+		);
+	}
+
 	private async saveTranscription(
 		episode: Episode,
 		transcription: string,
 	): Promise<void> {
-		const transcriptPath = FilePathTemplateEngine(
-			this.plugin.settings.transcript.path,
-			episode,
-		);
+		const transcriptPath = this.getTranscriptPath(episode);
 		const formattedTranscription = transcription.replace(/\.\s+/g, ".\n\n");
 		const transcriptContent = TranscriptTemplateEngine(
 			this.plugin.settings.transcript.template,
@@ -487,21 +492,15 @@ export class TranscriptionService {
 
 		const vault = this.plugin.app.vault;
 
-		// Ensure the directory exists (create nested folders recursively)
+		// Create nested folders recursively. ensureFolderExists tolerates a
+		// "Folder already exists" thrown when a case-insensitive lookup misses an
+		// existing folder, which the old hand-rolled loop surfaced as a spurious
+		// failure (the #87 class of bug).
 		const directory = transcriptPath.substring(
 			0,
 			transcriptPath.lastIndexOf("/"),
 		);
-		if (directory) {
-			const parts = directory.split("/");
-			let current = "";
-			for (const part of parts) {
-				current = current ? `${current}/${part}` : part;
-				if (!vault.getAbstractFileByPath(current)) {
-					await vault.createFolder(current);
-				}
-			}
-		}
+		await ensureFolderExists(directory);
 
 		const file = vault.getAbstractFileByPath(transcriptPath);
 

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -6,7 +6,10 @@ import {
 	FilePathTemplateEngine,
 	TranscriptTemplateEngine,
 } from "../TemplateEngine";
-import { enforceMaxPathLength } from "../utility/enforceMaxPathLength";
+import {
+	enforceMaxPathLength,
+	lastSegmentExtension,
+} from "../utility/enforceMaxPathLength";
 import { ensureFolderExists } from "../utility/ensureFolderExists";
 import type { Episode } from "src/types/Episode";
 
@@ -469,13 +472,16 @@ export class TranscriptionService {
 	/**
 	 * The on-disk path of an episode's transcript note, capped so a long title
 	 * can't trip ENAMETOOLONG (#22). Used for the existence checks and the write
-	 * alike so they always agree on the same path.
+	 * alike so they always agree on the same path. The extension comes from the
+	 * configured template (not forced to ".md") so a custom transcript path keeps
+	 * the user's chosen suffix.
 	 */
 	private getTranscriptPath(episode: Episode): string {
-		return enforceMaxPathLength(
-			FilePathTemplateEngine(this.plugin.settings.transcript.path, episode),
-			".md",
+		const rendered = FilePathTemplateEngine(
+			this.plugin.settings.transcript.path,
+			episode,
 		);
+		return enforceMaxPathLength(rendered, lastSegmentExtension(rendered));
 	}
 
 	private async saveTranscription(
@@ -500,7 +506,7 @@ export class TranscriptionService {
 			0,
 			transcriptPath.lastIndexOf("/"),
 		);
-		await ensureFolderExists(directory);
+		await ensureFolderExists(directory, vault);
 
 		const file = vault.getAbstractFileByPath(transcriptPath);
 

--- a/src/utility/enforceMaxPathLength.test.ts
+++ b/src/utility/enforceMaxPathLength.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+	FALLBACK_BASENAME,
+	MAX_FILENAME_BYTES,
+	enforceMaxPathLength,
+} from "./enforceMaxPathLength";
+
+const lastSegment = (path: string) => path.split("/").pop() ?? "";
+const byteLength = (value: string) => new TextEncoder().encode(value).length;
+
+describe("enforceMaxPathLength", () => {
+	it("leaves a short, valid path untouched", () => {
+		expect(enforceMaxPathLength("PodNotes/My Show/Episode 1.md")).toBe(
+			"PodNotes/My Show/Episode 1.md",
+		);
+	});
+
+	it("caps an over-long file name at 255 bytes, keeping folders and extension", () => {
+		const longTitle = "A".repeat(400);
+		const result = enforceMaxPathLength(`PodNotes/My Show/${longTitle}.md`);
+
+		expect(result.startsWith("PodNotes/My Show/")).toBe(true);
+		expect(result.endsWith(".md")).toBe(true);
+		// The file name component (not the whole path) is what must fit.
+		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(
+			MAX_FILENAME_BYTES,
+		);
+		// Pure ASCII: 252 base bytes + ".md" fills the budget exactly.
+		expect(lastSegment(result)).toBe(`${"A".repeat(252)}.md`);
+	});
+
+	it("preserves the extension exactly (never truncates into it)", () => {
+		const result = enforceMaxPathLength(`${"x".repeat(300)}.md`);
+		expect(result.endsWith(".md")).toBe(true);
+		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+	});
+
+	it("budgets by bytes, not characters, for multibyte titles (Android/ext4)", () => {
+		// "界" is 3 UTF-8 bytes; 252 of them are 756 bytes — a char-based cap would
+		// leave a name that still trips ENAMETOOLONG on ext4/Android.
+		const result = enforceMaxPathLength(`${"界".repeat(252)}.md`);
+		expect(result.endsWith(".md")).toBe(true);
+		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+		// 252 bytes / 3 bytes-per-char = 84 characters fit before ".md".
+		expect(lastSegment(result)).toBe(`${"界".repeat(84)}.md`);
+	});
+
+	it("never splits a surrogate pair at the truncation boundary", () => {
+		// Emoji are surrogate pairs (4 UTF-8 bytes). A naive .length/charAt cut
+		// could keep a lone half; truncation must stay on code-point boundaries.
+		const result = enforceMaxPathLength(`${"😀".repeat(100)}.md`);
+		const name = lastSegment(result);
+		expect(name.endsWith(".md")).toBe(true);
+		expect(byteLength(name)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+		// No lone surrogate: the string round-trips through UTF-8 unchanged.
+		expect(name).toBe(Buffer.from(name, "utf8").toString("utf8"));
+		expect(/[\uD800-\uDFFF]/.test(name.replace(/(\uD83D[\uDE00-\uDE4F])/g, "")))
+			.toBe(false);
+	});
+
+	it("substitutes a fallback when the title is empty (bare extension)", () => {
+		// An all-illegal-character title sanitizes to "", leaving "<folder>/.md".
+		expect(enforceMaxPathLength("PodNotes/My Show/.md")).toBe(
+			`PodNotes/My Show/${FALLBACK_BASENAME}.md`,
+		);
+	});
+
+	it("substitutes a fallback for a degenerate, segment-less path", () => {
+		expect(enforceMaxPathLength(".md")).toBe(`${FALLBACK_BASENAME}.md`);
+		expect(enforceMaxPathLength("")).toBe(`${FALLBACK_BASENAME}.md`);
+	});
+
+	it("always reattaches the extension even when the input lacks it", () => {
+		// Defensive: addExtension normally runs first, but the helper must still
+		// yield a Markdown note if handed a bare path.
+		expect(enforceMaxPathLength("PodNotes/Episode 1")).toBe(
+			"PodNotes/Episode 1.md",
+		);
+	});
+
+	it("drops empty segments from leading/trailing/double slashes", () => {
+		expect(enforceMaxPathLength("PodNotes//My Show/Episode 1.md")).toBe(
+			"PodNotes/My Show/Episode 1.md",
+		);
+		expect(enforceMaxPathLength("/PodNotes/Episode 1.md")).toBe(
+			"PodNotes/Episode 1.md",
+		);
+	});
+
+	it("trims trailing dots/spaces that truncation exposes (illegal on Windows)", () => {
+		// Force the cut to land right after a space, then a dot.
+		const result = enforceMaxPathLength(`${"A".repeat(251)} tail.md`);
+		const name = lastSegment(result).replace(/\.md$/, "");
+		expect(name.endsWith(".")).toBe(false);
+		expect(name.endsWith(" ")).toBe(false);
+		// Trimming can leave the name under the budget — the guarantee is "<=".
+		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(
+			MAX_FILENAME_BYTES,
+		);
+	});
+
+	it("keeps interior dots in ordinary titles", () => {
+		expect(enforceMaxPathLength("PodNotes/Episode 1.5.md")).toBe(
+			"PodNotes/Episode 1.5.md",
+		);
+	});
+
+	it("caps a pathologically long folder segment too", () => {
+		const longFolder = "F".repeat(400);
+		const result = enforceMaxPathLength(`${longFolder}/Episode 1.md`);
+		expect(byteLength(result.split("/")[0])).toBeLessThanOrEqual(
+			MAX_FILENAME_BYTES,
+		);
+		expect(lastSegment(result)).toBe("Episode 1.md");
+	});
+
+	it("supports a non-default extension", () => {
+		const result = enforceMaxPathLength(`${"a".repeat(300)}.mp3`, ".mp3");
+		expect(result.endsWith(".mp3")).toBe(true);
+		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+	});
+
+	it("is deterministic: two titles sharing the truncated prefix map to one path", () => {
+		// Documented tradeoff (issue #22 wants the same title -> same note name):
+		// titles that agree on the capped prefix collide. createPodcastNote then
+		// surfaces the existing note ("already exists") rather than failing.
+		const a = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-alpha.md`);
+		const b = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-beta.md`);
+		expect(a).toBe(b);
+	});
+});

--- a/src/utility/enforceMaxPathLength.test.ts
+++ b/src/utility/enforceMaxPathLength.test.ts
@@ -6,6 +6,7 @@ import {
 	MAX_FILENAME_UNITS,
 	enforceMaxPathLength,
 	getPlatformFilenameLimit,
+	lastSegmentExtension,
 } from "./enforceMaxPathLength";
 
 const lastSegment = (path: string) => path.split("/").pop() ?? "";
@@ -122,6 +123,22 @@ describe("enforceMaxPathLength", () => {
 		);
 	});
 
+	it("trims trailing dots/spaces from a short (un-truncated) folder segment", () => {
+		expect(enforceMaxPathLength("Notes. /Episode 1.md", ".md", BYTES)).toBe(
+			"Notes/Episode 1.md",
+		);
+	});
+
+	it("preserves a non-.md extension when asked to (transcripts/downloads)", () => {
+		// With an empty extension it does not force one (preserves a no-suffix path).
+		expect(enforceMaxPathLength("transcripts/Show/Ep", "", BYTES)).toBe(
+			"transcripts/Show/Ep",
+		);
+		expect(enforceMaxPathLength("transcripts/Show/Ep.txt", ".txt", BYTES)).toBe(
+			"transcripts/Show/Ep.txt",
+		);
+	});
+
 	it("caps a pathologically long folder segment too", () => {
 		const result = enforceMaxPathLength(`${"F".repeat(400)}/Episode 1.md`, ".md", BYTES);
 		expect(byteLength(result.split("/")[0])).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
@@ -141,6 +158,23 @@ describe("enforceMaxPathLength", () => {
 		const a = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-alpha.md`, ".md", BYTES);
 		const b = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-beta.md`, ".md", BYTES);
 		expect(a).toBe(b);
+	});
+});
+
+describe("lastSegmentExtension", () => {
+	it("returns the final segment's extension", () => {
+		expect(lastSegmentExtension("transcripts/Show/Ep.md")).toBe(".md");
+		expect(lastSegmentExtension("a/b/Ep.txt")).toBe(".txt");
+	});
+
+	it("returns empty when the final segment has no extension", () => {
+		expect(lastSegmentExtension("transcripts/Show/Ep")).toBe("");
+		expect(lastSegmentExtension("Ep")).toBe("");
+	});
+
+	it("ignores dots in folder segments and leading-dot files", () => {
+		expect(lastSegmentExtension("a.b/Episode")).toBe("");
+		expect(lastSegmentExtension(".env")).toBe("");
 	});
 });
 

--- a/src/utility/enforceMaxPathLength.test.ts
+++ b/src/utility/enforceMaxPathLength.test.ts
@@ -1,131 +1,171 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { Platform } from "obsidian";
 import {
 	FALLBACK_BASENAME,
-	MAX_FILENAME_BYTES,
+	type FilenameLimit,
+	MAX_FILENAME_UNITS,
 	enforceMaxPathLength,
+	getPlatformFilenameLimit,
 } from "./enforceMaxPathLength";
 
 const lastSegment = (path: string) => path.split("/").pop() ?? "";
 const byteLength = (value: string) => new TextEncoder().encode(value).length;
 
+const BYTES: FilenameLimit = { mode: "bytes", max: MAX_FILENAME_UNITS };
+const UTF16: FilenameLimit = { mode: "utf16", max: MAX_FILENAME_UNITS };
+
 describe("enforceMaxPathLength", () => {
 	it("leaves a short, valid path untouched", () => {
-		expect(enforceMaxPathLength("PodNotes/My Show/Episode 1.md")).toBe(
+		expect(enforceMaxPathLength("PodNotes/My Show/Episode 1.md", ".md", BYTES)).toBe(
 			"PodNotes/My Show/Episode 1.md",
 		);
 	});
 
-	it("caps an over-long file name at 255 bytes, keeping folders and extension", () => {
+	it("caps an over-long ASCII file name at 255, keeping folders and extension", () => {
 		const longTitle = "A".repeat(400);
-		const result = enforceMaxPathLength(`PodNotes/My Show/${longTitle}.md`);
+		const result = enforceMaxPathLength(
+			`PodNotes/My Show/${longTitle}.md`,
+			".md",
+			BYTES,
+		);
 
 		expect(result.startsWith("PodNotes/My Show/")).toBe(true);
 		expect(result.endsWith(".md")).toBe(true);
-		// The file name component (not the whole path) is what must fit.
-		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(
-			MAX_FILENAME_BYTES,
-		);
-		// Pure ASCII: 252 base bytes + ".md" fills the budget exactly.
+		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+		// 252 base bytes + ".md" fills the budget exactly.
 		expect(lastSegment(result)).toBe(`${"A".repeat(252)}.md`);
 	});
 
 	it("preserves the extension exactly (never truncates into it)", () => {
-		const result = enforceMaxPathLength(`${"x".repeat(300)}.md`);
+		const result = enforceMaxPathLength(`${"x".repeat(300)}.md`, ".md", BYTES);
 		expect(result.endsWith(".md")).toBe(true);
-		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
 	});
 
-	it("budgets by bytes, not characters, for multibyte titles (Android/ext4)", () => {
-		// "界" is 3 UTF-8 bytes; 252 of them are 756 bytes — a char-based cap would
-		// leave a name that still trips ENAMETOOLONG on ext4/Android.
-		const result = enforceMaxPathLength(`${"界".repeat(252)}.md`);
-		expect(result.endsWith(".md")).toBe(true);
-		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
-		// 252 bytes / 3 bytes-per-char = 84 characters fit before ".md".
-		expect(lastSegment(result)).toBe(`${"界".repeat(84)}.md`);
+	describe("bytes mode (ext4 / Android)", () => {
+		it("budgets by bytes for multibyte titles", () => {
+			// "界" is 3 UTF-8 bytes; a char-based cap would leave a name that still
+			// trips ENAMETOOLONG on ext4/Android.
+			const result = enforceMaxPathLength(`${"界".repeat(252)}.md`, ".md", BYTES);
+			expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+			// 252 bytes / 3 bytes-per-char = 84 characters fit before ".md".
+			expect(lastSegment(result)).toBe(`${"界".repeat(84)}.md`);
+		});
+
+		it("never splits a surrogate pair at the truncation boundary", () => {
+			const result = enforceMaxPathLength(`${"😀".repeat(100)}.md`, ".md", BYTES);
+			const name = lastSegment(result);
+			expect(name.endsWith(".md")).toBe(true);
+			expect(byteLength(name)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+			// Round-trips through UTF-8 unchanged -> no lone surrogate.
+			expect(name).toBe(Buffer.from(name, "utf8").toString("utf8"));
+		});
 	});
 
-	it("never splits a surrogate pair at the truncation boundary", () => {
-		// Emoji are surrogate pairs (4 UTF-8 bytes). A naive .length/charAt cut
-		// could keep a lone half; truncation must stay on code-point boundaries.
-		const result = enforceMaxPathLength(`${"😀".repeat(100)}.md`);
-		const name = lastSegment(result);
-		expect(name.endsWith(".md")).toBe(true);
-		expect(byteLength(name)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
-		// No lone surrogate: the string round-trips through UTF-8 unchanged.
-		expect(name).toBe(Buffer.from(name, "utf8").toString("utf8"));
-		expect(/[\uD800-\uDFFF]/.test(name.replace(/(\uD83D[\uDE00-\uDE4F])/g, "")))
-			.toBe(false);
+	describe("utf16 mode (NTFS / APFS)", () => {
+		it("budgets by UTF-16 units, allowing full-length multibyte names", () => {
+			// On APFS a 255-unit CJK name (~750 bytes) is legal; bytes-mode would
+			// needlessly truncate it to 84 chars.
+			const result = enforceMaxPathLength(`${"界".repeat(300)}.md`, ".md", UTF16);
+			expect(lastSegment(result).length).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+			expect(lastSegment(result)).toBe(`${"界".repeat(252)}.md`);
+		});
+
+		it("keeps an astral char whole (2 UTF-16 units) at the boundary", () => {
+			// 251 'A' (251 units) + ".md" (3) leaves 1 unit of budget; a 2-unit emoji
+			// must NOT be half-included.
+			const result = enforceMaxPathLength(`${"A".repeat(251)}😀X.md`, ".md", UTF16);
+			const name = lastSegment(result);
+			expect(name.length).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+			expect(name).toBe(Buffer.from(name, "utf8").toString("utf8"));
+			expect(name).toBe(`${"A".repeat(251)}.md`); // emoji dropped, no half-pair
+		});
 	});
 
 	it("substitutes a fallback when the title is empty (bare extension)", () => {
-		// An all-illegal-character title sanitizes to "", leaving "<folder>/.md".
-		expect(enforceMaxPathLength("PodNotes/My Show/.md")).toBe(
+		expect(enforceMaxPathLength("PodNotes/My Show/.md", ".md", BYTES)).toBe(
 			`PodNotes/My Show/${FALLBACK_BASENAME}.md`,
 		);
 	});
 
 	it("substitutes a fallback for a degenerate, segment-less path", () => {
-		expect(enforceMaxPathLength(".md")).toBe(`${FALLBACK_BASENAME}.md`);
-		expect(enforceMaxPathLength("")).toBe(`${FALLBACK_BASENAME}.md`);
+		expect(enforceMaxPathLength(".md", ".md", BYTES)).toBe(`${FALLBACK_BASENAME}.md`);
+		expect(enforceMaxPathLength("", ".md", BYTES)).toBe(`${FALLBACK_BASENAME}.md`);
 	});
 
 	it("always reattaches the extension even when the input lacks it", () => {
-		// Defensive: addExtension normally runs first, but the helper must still
-		// yield a Markdown note if handed a bare path.
-		expect(enforceMaxPathLength("PodNotes/Episode 1")).toBe(
+		expect(enforceMaxPathLength("PodNotes/Episode 1", ".md", BYTES)).toBe(
 			"PodNotes/Episode 1.md",
 		);
 	});
 
 	it("drops empty segments from leading/trailing/double slashes", () => {
-		expect(enforceMaxPathLength("PodNotes//My Show/Episode 1.md")).toBe(
-			"PodNotes/My Show/Episode 1.md",
-		);
-		expect(enforceMaxPathLength("/PodNotes/Episode 1.md")).toBe(
+		expect(
+			enforceMaxPathLength("PodNotes//My Show/Episode 1.md", ".md", BYTES),
+		).toBe("PodNotes/My Show/Episode 1.md");
+		expect(enforceMaxPathLength("/PodNotes/Episode 1.md", ".md", BYTES)).toBe(
 			"PodNotes/Episode 1.md",
 		);
 	});
 
 	it("trims trailing dots/spaces that truncation exposes (illegal on Windows)", () => {
-		// Force the cut to land right after a space, then a dot.
-		const result = enforceMaxPathLength(`${"A".repeat(251)} tail.md`);
+		const result = enforceMaxPathLength(`${"A".repeat(251)} tail.md`, ".md", BYTES);
 		const name = lastSegment(result).replace(/\.md$/, "");
 		expect(name.endsWith(".")).toBe(false);
 		expect(name.endsWith(" ")).toBe(false);
-		// Trimming can leave the name under the budget — the guarantee is "<=".
-		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(
-			MAX_FILENAME_BYTES,
-		);
+		expect(byteLength(lastSegment(result))).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
 	});
 
 	it("keeps interior dots in ordinary titles", () => {
-		expect(enforceMaxPathLength("PodNotes/Episode 1.5.md")).toBe(
+		expect(enforceMaxPathLength("PodNotes/Episode 1.5.md", ".md", BYTES)).toBe(
 			"PodNotes/Episode 1.5.md",
 		);
 	});
 
 	it("caps a pathologically long folder segment too", () => {
-		const longFolder = "F".repeat(400);
-		const result = enforceMaxPathLength(`${longFolder}/Episode 1.md`);
-		expect(byteLength(result.split("/")[0])).toBeLessThanOrEqual(
-			MAX_FILENAME_BYTES,
-		);
+		const result = enforceMaxPathLength(`${"F".repeat(400)}/Episode 1.md`, ".md", BYTES);
+		expect(byteLength(result.split("/")[0])).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
 		expect(lastSegment(result)).toBe("Episode 1.md");
 	});
 
 	it("supports a non-default extension", () => {
-		const result = enforceMaxPathLength(`${"a".repeat(300)}.mp3`, ".mp3");
+		const result = enforceMaxPathLength(`${"a".repeat(300)}.mp3`, ".mp3", BYTES);
 		expect(result.endsWith(".mp3")).toBe(true);
-		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_BYTES);
+		expect(byteLength(result)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
 	});
 
 	it("is deterministic: two titles sharing the truncated prefix map to one path", () => {
 		// Documented tradeoff (issue #22 wants the same title -> same note name):
 		// titles that agree on the capped prefix collide. createPodcastNote then
 		// surfaces the existing note ("already exists") rather than failing.
-		const a = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-alpha.md`);
-		const b = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-beta.md`);
+		const a = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-alpha.md`, ".md", BYTES);
+		const b = enforceMaxPathLength(`Pod/${"Z".repeat(300)}-beta.md`, ".md", BYTES);
 		expect(a).toBe(b);
+	});
+});
+
+describe("getPlatformFilenameLimit", () => {
+	const original = { ...Platform };
+	const setPlatform = (flags: Partial<typeof Platform>) =>
+		Object.assign(Platform, { isWin: false, isMacOS: false, isLinux: false, isIosApp: false, isAndroidApp: false }, flags);
+
+	afterEach(() => {
+		Object.assign(Platform, original);
+	});
+
+	it("uses UTF-16 units on Windows, macOS and iOS (NTFS/APFS)", () => {
+		for (const flag of ["isWin", "isMacOS", "isIosApp"] as const) {
+			setPlatform({ [flag]: true });
+			expect(getPlatformFilenameLimit()).toEqual({ mode: "utf16", max: 255 });
+		}
+	});
+
+	it("uses bytes on Linux and Android, and as the safe default (ext4/F2FS)", () => {
+		setPlatform({ isLinux: true });
+		expect(getPlatformFilenameLimit()).toEqual({ mode: "bytes", max: 255 });
+		setPlatform({ isAndroidApp: true });
+		expect(getPlatformFilenameLimit()).toEqual({ mode: "bytes", max: 255 });
+		setPlatform({});
+		expect(getPlatformFilenameLimit()).toEqual({ mode: "bytes", max: 255 });
 	});
 });

--- a/src/utility/enforceMaxPathLength.test.ts
+++ b/src/utility/enforceMaxPathLength.test.ts
@@ -176,6 +176,44 @@ describe("lastSegmentExtension", () => {
 		expect(lastSegmentExtension("a.b/Episode")).toBe("");
 		expect(lastSegmentExtension(".env")).toBe("");
 	});
+
+	it("rejects a non-extension-like suffix (dotted title, leftover token)", () => {
+		// A dotted title's trailing chunk is part of the name, not an extension.
+		expect(lastSegmentExtension(`Episode.Part.${"X".repeat(400)}`)).toBe("");
+		expect(lastSegmentExtension("Episode.{{episodeNumber}}")).toBe("");
+		// A short alphanumeric suffix is still treated as an extension.
+		expect(lastSegmentExtension("Episode 1.5")).toBe(".5");
+	});
+});
+
+describe("enforceMaxPathLength with template-derived extension (transcripts)", () => {
+	it("caps a no-extension path whose title contains dots (no pseudo-extension)", () => {
+		// Mirrors getTranscriptPath: extension comes from lastSegmentExtension of the
+		// rendered path. A dotted, very long title must NOT be mistaken for a huge
+		// extension that escapes the cap (round-3 regression guard).
+		const rendered = `transcripts/Show/Episode.Part.${"X".repeat(400)}`;
+		const result = enforceMaxPathLength(
+			rendered,
+			lastSegmentExtension(rendered),
+			BYTES,
+		);
+		const name = result.split("/").pop() ?? "";
+		expect(byteLength(name)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+	});
+
+	it("preserves a real .md/.txt extension on a long title", () => {
+		for (const ext of [".md", ".txt"]) {
+			const rendered = `transcripts/Show/${"Y".repeat(400)}${ext}`;
+			const result = enforceMaxPathLength(
+				rendered,
+				lastSegmentExtension(rendered),
+				BYTES,
+			);
+			const name = result.split("/").pop() ?? "";
+			expect(name.endsWith(ext)).toBe(true);
+			expect(byteLength(name)).toBeLessThanOrEqual(MAX_FILENAME_UNITS);
+		}
+	});
 });
 
 describe("getPlatformFilenameLimit", () => {

--- a/src/utility/enforceMaxPathLength.ts
+++ b/src/utility/enforceMaxPathLength.ts
@@ -1,0 +1,122 @@
+/**
+ * Cross-platform safe cap for a single path component (file or folder name),
+ * measured in BYTES. The most restrictive mainstream limits are per-component,
+ * not per-path: NTFS/Windows and APFS cap names at 255 UTF-16 units, while
+ * ext4/F2FS (Linux, and Android internal storage) cap them at 255 *bytes*.
+ * Budgeting by UTF-8 byte length satisfies all of them at once, so a long
+ * episode title (e.g. The Tim Ferriss Show) — including non-ASCII titles where
+ * one character is several bytes — no longer produces a name the filesystem
+ * rejects with ENAMETOOLONG. See issue #22.
+ *
+ * This caps each path *component*; it does not bound the total path length
+ * (Windows legacy MAX_PATH), which would require knowing the absolute vault root.
+ * The per-component limit is what a long title actually trips.
+ */
+export const MAX_FILENAME_BYTES = 255;
+
+/**
+ * Base name used when a title sanitizes/truncates down to nothing — e.g. a title
+ * made entirely of illegal characters becomes "" after sanitization. Without it
+ * the path would end in a bare ".md", a hidden dotfile Obsidian never indexes.
+ * See issue #99 (the empty-name edge case flagged when illegal-char handling
+ * landed).
+ */
+export const FALLBACK_BASENAME = "Untitled";
+
+const encoder = new TextEncoder();
+
+function byteLength(value: string): number {
+	return encoder.encode(value).length;
+}
+
+/**
+ * Truncate `value` to at most `maxBytes` UTF-8 bytes, cutting only on code-point
+ * boundaries so a surrogate pair (e.g. an emoji) is never split into a lone,
+ * malformed half. Iterating with `for...of` yields whole code points.
+ */
+function truncateToByteBudget(value: string, maxBytes: number): string {
+	if (byteLength(value) <= maxBytes) {
+		return value;
+	}
+
+	let result = "";
+	let used = 0;
+	for (const codePoint of value) {
+		const size = byteLength(codePoint);
+		if (used + size > maxBytes) {
+			break;
+		}
+		result += codePoint;
+		used += size;
+	}
+
+	return result;
+}
+
+// Trailing dots and spaces are rejected on Windows; truncating a title can newly
+// expose them (e.g. cutting "Episode 1. The Beginning" mid-word). Also trim
+// leading whitespace a cut may expose. Mirrors the trimming in
+// replaceIllegalFileNameCharactersInString so capped names stay legal.
+function trimSegmentEdges(segment: string): string {
+	return segment.replace(/[\s.]+$/g, "").replace(/^\s+/, "");
+}
+
+function capFolderName(segment: string): string {
+	if (byteLength(segment) <= MAX_FILENAME_BYTES) {
+		return segment;
+	}
+
+	return (
+		trimSegmentEdges(truncateToByteBudget(segment, MAX_FILENAME_BYTES)) ||
+		FALLBACK_BASENAME
+	);
+}
+
+function capFileName(segment: string, extension: string): string {
+	// The path is built by addExtension, so the final segment normally ends with
+	// the known extension. Split it off (when present), cap only the base name,
+	// then always reattach the extension so the file stays a Markdown note even
+	// after truncation or when a caller passed a path without the suffix.
+	const hasExtension = segment.toLowerCase().endsWith(extension.toLowerCase());
+	const base = hasExtension
+		? segment.slice(0, segment.length - extension.length)
+		: segment;
+
+	const budget = Math.max(1, MAX_FILENAME_BYTES - byteLength(extension));
+	const cappedBase =
+		trimSegmentEdges(truncateToByteBudget(base, budget)) || FALLBACK_BASENAME;
+
+	return `${cappedBase}${extension}`;
+}
+
+/**
+ * Make a vault-relative note path safe to create across platforms:
+ *  - drop empty path segments (collapsing `a//b` and stray leading/trailing `/`),
+ *    which would otherwise create invalid or empty folder names;
+ *  - cap every path component at {@link MAX_FILENAME_BYTES} UTF-8 bytes,
+ *    truncating the title (the file's base name) while preserving its extension
+ *    and the surrounding folders;
+ *  - substitute {@link FALLBACK_BASENAME} when the file name reduces to nothing
+ *    (e.g. an all-illegal-character title);
+ *  - trim trailing dots/spaces a truncation may expose (illegal on Windows).
+ *
+ * The `extension` (default ".md") is the suffix already appended to `path`; it is
+ * kept intact so the file stays a Markdown note even after truncation.
+ */
+export function enforceMaxPathLength(path: string, extension = ".md"): string {
+	const segments = path.split("/").filter((segment) => segment.length > 0);
+
+	if (segments.length === 0) {
+		return `${FALLBACK_BASENAME}${extension}`;
+	}
+
+	const lastIndex = segments.length - 1;
+
+	return segments
+		.map((segment, index) =>
+			index === lastIndex
+				? capFileName(segment, extension)
+				: capFolderName(segment),
+		)
+		.join("/");
+}

--- a/src/utility/enforceMaxPathLength.ts
+++ b/src/utility/enforceMaxPathLength.ts
@@ -89,14 +89,14 @@ function trimSegmentEdges(segment: string): string {
 }
 
 function capFolderName(segment: string, limit: FilenameLimit): string {
-	if (measure(segment, limit.mode) <= limit.max) {
-		return segment;
-	}
+	const capped =
+		measure(segment, limit.mode) <= limit.max
+			? segment
+			: truncateToLimit(segment, limit.max, limit.mode);
 
-	return (
-		trimSegmentEdges(truncateToLimit(segment, limit.max, limit.mode)) ||
-		FALLBACK_BASENAME
-	);
+	// Trim even when under the cap: a literal template folder like "Notes. " has
+	// a trailing space/dot that is illegal on Windows regardless of length.
+	return trimSegmentEdges(capped) || FALLBACK_BASENAME;
 }
 
 function capFileName(
@@ -119,6 +119,19 @@ function capFileName(
 		FALLBACK_BASENAME;
 
 	return `${cappedBase}${extension}`;
+}
+
+/**
+ * The extension of a path's final segment (".md", ".txt", …), or "" when it has
+ * none. Callers whose extension comes from a user template rather than
+ * addExtension (e.g. transcripts) pass this to {@link enforceMaxPathLength} so it
+ * preserves the configured extension instead of forcing a default one.
+ */
+export function lastSegmentExtension(path: string): string {
+	const last = path.split("/").pop() ?? "";
+	const dot = last.lastIndexOf(".");
+	// `dot > 0` so a dotfile (".env") is treated as a name, not an extension.
+	return dot > 0 ? last.slice(dot) : "";
 }
 
 /**

--- a/src/utility/enforceMaxPathLength.ts
+++ b/src/utility/enforceMaxPathLength.ts
@@ -131,7 +131,16 @@ export function lastSegmentExtension(path: string): string {
 	const last = path.split("/").pop() ?? "";
 	const dot = last.lastIndexOf(".");
 	// `dot > 0` so a dotfile (".env") is treated as a name, not an extension.
-	return dot > 0 ? last.slice(dot) : "";
+	if (dot <= 0) {
+		return "";
+	}
+
+	const ext = last.slice(dot);
+	// A real extension is a short alphanumeric suffix. Anything else — a dotted
+	// title ("Episode.Part.<very long>"), or a leftover template token — is part
+	// of the name, not an extension; treating it as one would reattach an
+	// arbitrarily long "extension" past the cap and still trip ENAMETOOLONG.
+	return /^\.[A-Za-z0-9]{1,16}$/.test(ext) ? ext : "";
 }
 
 /**

--- a/src/utility/enforceMaxPathLength.ts
+++ b/src/utility/enforceMaxPathLength.ts
@@ -1,18 +1,13 @@
+import { Platform } from "obsidian";
+
 /**
- * Cross-platform safe cap for a single path component (file or folder name),
- * measured in BYTES. The most restrictive mainstream limits are per-component,
- * not per-path: NTFS/Windows and APFS cap names at 255 UTF-16 units, while
- * ext4/F2FS (Linux, and Android internal storage) cap them at 255 *bytes*.
- * Budgeting by UTF-8 byte length satisfies all of them at once, so a long
- * episode title (e.g. The Tim Ferriss Show) — including non-ASCII titles where
- * one character is several bytes — no longer produces a name the filesystem
- * rejects with ENAMETOOLONG. See issue #22.
- *
- * This caps each path *component*; it does not bound the total path length
- * (Windows legacy MAX_PATH), which would require knowing the absolute vault root.
- * The per-component limit is what a long title actually trips.
+ * The per-component filename limit is 255 on every mainstream filesystem — but
+ * the *unit* differs: NTFS (Windows) and APFS/HFS+ (macOS, iOS) count 255 UTF-16
+ * code units, while ext4/F2FS (Linux, and Android internal storage) count 255
+ * bytes. A long episode title (e.g. The Tim Ferriss Show) otherwise produces a
+ * name the filesystem rejects with ENAMETOOLONG and note creation fails. See #22.
  */
-export const MAX_FILENAME_BYTES = 255;
+export const MAX_FILENAME_UNITS = 255;
 
 /**
  * Base name used when a title sanitizes/truncates down to nothing — e.g. a title
@@ -23,27 +18,59 @@ export const MAX_FILENAME_BYTES = 255;
  */
 export const FALLBACK_BASENAME = "Untitled";
 
+/** How a path component's length is measured on the current platform. */
+export interface FilenameLimit {
+	mode: "bytes" | "utf16";
+	max: number;
+}
+
 const encoder = new TextEncoder();
 
 function byteLength(value: string): number {
 	return encoder.encode(value).length;
 }
 
+function measure(value: string, mode: FilenameLimit["mode"]): number {
+	// "utf16" uses String#length (UTF-16 code units); "bytes" uses UTF-8 bytes.
+	return mode === "bytes" ? byteLength(value) : value.length;
+}
+
 /**
- * Truncate `value` to at most `maxBytes` UTF-8 bytes, cutting only on code-point
- * boundaries so a surrogate pair (e.g. an emoji) is never split into a lone,
- * malformed half. Iterating with `for...of` yields whole code points.
+ * The per-component limit for the OS the user is on, using Obsidian's native
+ * `Platform` detection. NTFS/APFS (Windows, macOS, iOS) count UTF-16 code units;
+ * ext4/F2FS (Linux, Android) count bytes — verified empirically on APFS, where a
+ * 255-unit name (~750 bytes of CJK) is accepted but 256 is rejected. Capping to
+ * the local unit keeps the most generous legal name on each OS; the byte mode is
+ * the portable floor, so a vault synced from a UTF-16-limit OS to a byte-limit OS
+ * could, for heavily multibyte titles, exceed the destination's limit.
  */
-function truncateToByteBudget(value: string, maxBytes: number): string {
-	if (byteLength(value) <= maxBytes) {
+export function getPlatformFilenameLimit(): FilenameLimit {
+	if (Platform.isWin || Platform.isMacOS || Platform.isIosApp) {
+		return { mode: "utf16", max: MAX_FILENAME_UNITS };
+	}
+	return { mode: "bytes", max: MAX_FILENAME_UNITS };
+}
+
+/**
+ * Truncate `value` to at most `max` units (bytes or UTF-16 code units), cutting
+ * only on code-point boundaries so a surrogate pair (e.g. an emoji) is never
+ * split into a lone, malformed half. Iterating with `for...of` yields whole code
+ * points; an astral character is kept only when both of its UTF-16 units fit.
+ */
+function truncateToLimit(
+	value: string,
+	max: number,
+	mode: FilenameLimit["mode"],
+): string {
+	if (measure(value, mode) <= max) {
 		return value;
 	}
 
 	let result = "";
 	let used = 0;
 	for (const codePoint of value) {
-		const size = byteLength(codePoint);
-		if (used + size > maxBytes) {
+		const size = measure(codePoint, mode);
+		if (used + size > max) {
 			break;
 		}
 		result += codePoint;
@@ -61,18 +88,22 @@ function trimSegmentEdges(segment: string): string {
 	return segment.replace(/[\s.]+$/g, "").replace(/^\s+/, "");
 }
 
-function capFolderName(segment: string): string {
-	if (byteLength(segment) <= MAX_FILENAME_BYTES) {
+function capFolderName(segment: string, limit: FilenameLimit): string {
+	if (measure(segment, limit.mode) <= limit.max) {
 		return segment;
 	}
 
 	return (
-		trimSegmentEdges(truncateToByteBudget(segment, MAX_FILENAME_BYTES)) ||
+		trimSegmentEdges(truncateToLimit(segment, limit.max, limit.mode)) ||
 		FALLBACK_BASENAME
 	);
 }
 
-function capFileName(segment: string, extension: string): string {
+function capFileName(
+	segment: string,
+	extension: string,
+	limit: FilenameLimit,
+): string {
 	// The path is built by addExtension, so the final segment normally ends with
 	// the known extension. Split it off (when present), cap only the base name,
 	// then always reattach the extension so the file stays a Markdown note even
@@ -82,9 +113,10 @@ function capFileName(segment: string, extension: string): string {
 		? segment.slice(0, segment.length - extension.length)
 		: segment;
 
-	const budget = Math.max(1, MAX_FILENAME_BYTES - byteLength(extension));
+	const budget = Math.max(1, limit.max - measure(extension, limit.mode));
 	const cappedBase =
-		trimSegmentEdges(truncateToByteBudget(base, budget)) || FALLBACK_BASENAME;
+		trimSegmentEdges(truncateToLimit(base, budget, limit.mode)) ||
+		FALLBACK_BASENAME;
 
 	return `${cappedBase}${extension}`;
 }
@@ -93,17 +125,22 @@ function capFileName(segment: string, extension: string): string {
  * Make a vault-relative note path safe to create across platforms:
  *  - drop empty path segments (collapsing `a//b` and stray leading/trailing `/`),
  *    which would otherwise create invalid or empty folder names;
- *  - cap every path component at {@link MAX_FILENAME_BYTES} UTF-8 bytes,
- *    truncating the title (the file's base name) while preserving its extension
- *    and the surrounding folders;
+ *  - cap every path component at the platform's per-component limit
+ *    ({@link getPlatformFilenameLimit}), truncating the title (the file's base
+ *    name) while preserving its extension and the surrounding folders;
  *  - substitute {@link FALLBACK_BASENAME} when the file name reduces to nothing
  *    (e.g. an all-illegal-character title);
  *  - trim trailing dots/spaces a truncation may expose (illegal on Windows).
  *
  * The `extension` (default ".md") is the suffix already appended to `path`; it is
- * kept intact so the file stays a Markdown note even after truncation.
+ * kept intact so the file stays a Markdown note even after truncation. `limit`
+ * defaults to the current platform's limit and is injectable for testing.
  */
-export function enforceMaxPathLength(path: string, extension = ".md"): string {
+export function enforceMaxPathLength(
+	path: string,
+	extension = ".md",
+	limit: FilenameLimit = getPlatformFilenameLimit(),
+): string {
 	const segments = path.split("/").filter((segment) => segment.length > 0);
 
 	if (segments.length === 0) {
@@ -115,8 +152,8 @@ export function enforceMaxPathLength(path: string, extension = ".md"): string {
 	return segments
 		.map((segment, index) =>
 			index === lastIndex
-				? capFileName(segment, extension)
-				: capFolderName(segment),
+				? capFileName(segment, extension, limit)
+				: capFolderName(segment, limit),
 		)
 		.join("/");
 }

--- a/src/utility/ensureFolderExists.test.ts
+++ b/src/utility/ensureFolderExists.test.ts
@@ -70,4 +70,39 @@ describe("ensureFolderExists", () => {
 
 		expect(created).toEqual(["a", "a/b"]);
 	});
+
+	it("swallows 'already exists' when the case-sensitive lookup misses an existing folder", async () => {
+		// Mimic a case-insensitive filesystem: the folder is present on disk but
+		// the case-sensitive getAbstractFileByPath never finds it, so createFolder
+		// throws "Folder already exists". The helper must treat that as success
+		// (regression guard for #87's spurious "Failed to create note").
+		const createFolder = vi.fn(async () => {
+			throw new Error("Folder already exists.");
+		});
+		(globalThis as { app?: unknown }).app = {
+			vault: {
+				getAbstractFileByPath: () => null,
+				createFolder,
+			},
+		};
+
+		await expect(ensureFolderExists("Podcasts/My Show")).resolves.toBeUndefined();
+		expect(createFolder).toHaveBeenCalled();
+	});
+
+	it("rethrows a genuine createFolder failure", async () => {
+		const createFolder = vi.fn(async () => {
+			throw new Error("EACCES: permission denied");
+		});
+		(globalThis as { app?: unknown }).app = {
+			vault: {
+				getAbstractFileByPath: () => null,
+				createFolder,
+			},
+		};
+
+		await expect(ensureFolderExists("Podcasts/My Show")).rejects.toThrow(
+			"EACCES",
+		);
+	});
 });

--- a/src/utility/ensureFolderExists.test.ts
+++ b/src/utility/ensureFolderExists.test.ts
@@ -90,6 +90,22 @@ describe("ensureFolderExists", () => {
 		expect(createFolder).toHaveBeenCalled();
 	});
 
+	it("uses a passed vault instead of the global app.vault", async () => {
+		// Global app.vault would record nothing; the injected vault must be used.
+		setupApp();
+		const created: string[] = [];
+		const injected = {
+			getAbstractFileByPath: () => null,
+			createFolder: vi.fn(async (path: string) => {
+				created.push(path);
+			}),
+		} as unknown as Parameters<typeof ensureFolderExists>[1];
+
+		await ensureFolderExists("Podcasts/My Show", injected);
+
+		expect(created).toEqual(["Podcasts", "Podcasts/My Show"]);
+	});
+
 	it("rethrows a genuine createFolder failure", async () => {
 		const createFolder = vi.fn(async () => {
 			throw new Error("EACCES: permission denied");

--- a/src/utility/ensureFolderExists.ts
+++ b/src/utility/ensureFolderExists.ts
@@ -2,8 +2,13 @@
  * Creates every missing folder along `folderPath`, one segment at a time.
  *
  * `Vault.createFolder` throws when the folder already exists, so each prefix is
- * guarded with `getAbstractFileByPath` before it is created — mirroring the
- * loops already used in `createPodcastNote` and `TranscriptionService`.
+ * guarded with `getAbstractFileByPath` before it is created. That guard is not
+ * always enough: on a case-insensitive filesystem (default on macOS/Windows)
+ * the lookup is case-sensitive while creation is not, and a concurrent create
+ * can win the race — both make `createFolder` throw "Folder already exists" for
+ * a folder that is genuinely present. Such a throw is swallowed (the folder we
+ * wanted exists either way); any other error is rethrown. Fixes #87, where this
+ * surfaced as a spurious "Failed to create note".
  *
  * `folderPath` is a directory path (no trailing file name). An empty path is a
  * no-op, so callers can pass the directory portion of a file path directly.
@@ -14,8 +19,22 @@ export async function ensureFolderExists(folderPath: string): Promise<void> {
 	let current = "";
 	for (const segment of segments) {
 		current = current ? `${current}/${segment}` : segment;
-		if (!app.vault.getAbstractFileByPath(current)) {
+		if (app.vault.getAbstractFileByPath(current)) {
+			continue;
+		}
+
+		try {
 			await app.vault.createFolder(current);
+		} catch (error) {
+			const alreadyExists =
+				error instanceof Error && /already exists/i.test(error.message);
+			// Re-check after a failed create: a case-insensitive filesystem or a
+			// concurrent create can leave the folder present even though the
+			// pre-check missed it. Only a genuine failure (still absent and not an
+			// "already exists" error) is propagated.
+			if (!alreadyExists && !app.vault.getAbstractFileByPath(current)) {
+				throw error;
+			}
 		}
 	}
 }

--- a/src/utility/ensureFolderExists.ts
+++ b/src/utility/ensureFolderExists.ts
@@ -1,3 +1,5 @@
+import type { Vault } from "obsidian";
+
 /**
  * Creates every missing folder along `folderPath`, one segment at a time.
  *
@@ -12,19 +14,26 @@
  *
  * `folderPath` is a directory path (no trailing file name). An empty path is a
  * no-op, so callers can pass the directory portion of a file path directly.
+ *
+ * `vault` defaults to the global `app.vault`; callers holding an injected vault
+ * (e.g. a service given `plugin.app`) pass it so folder creation and the
+ * subsequent file write target the same vault instance.
  */
-export async function ensureFolderExists(folderPath: string): Promise<void> {
+export async function ensureFolderExists(
+	folderPath: string,
+	vault: Vault = app.vault,
+): Promise<void> {
 	const segments = folderPath.split("/").filter(Boolean);
 
 	let current = "";
 	for (const segment of segments) {
 		current = current ? `${current}/${segment}` : segment;
-		if (app.vault.getAbstractFileByPath(current)) {
+		if (vault.getAbstractFileByPath(current)) {
 			continue;
 		}
 
 		try {
-			await app.vault.createFolder(current);
+			await vault.createFolder(current);
 		} catch (error) {
 			const alreadyExists =
 				error instanceof Error && /already exists/i.test(error.message);
@@ -32,7 +41,7 @@ export async function ensureFolderExists(folderPath: string): Promise<void> {
 			// concurrent create can leave the folder present even though the
 			// pre-check missed it. Only a genuine failure (still absent and not an
 			// "already exists" error) is propagated.
-			if (!alreadyExists && !app.vault.getAbstractFileByPath(current)) {
+			if (!alreadyExists && !vault.getAbstractFileByPath(current)) {
 				throw error;
 			}
 		}

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -355,3 +355,20 @@ export const requestUrl = async () => ({
 });
 
 export const htmlToMarkdown = (value: string) => value;
+
+// Mutable so tests can simulate a specific OS (e.g. set isMacOS=false, isLinux=true).
+// Defaults to a desktop macOS profile, matching the typical dev environment.
+export const Platform = {
+	isDesktop: true,
+	isMobile: false,
+	isDesktopApp: true,
+	isMobileApp: false,
+	isPhone: false,
+	isTablet: false,
+	isWin: false,
+	isMacOS: true,
+	isLinux: false,
+	isIosApp: false,
+	isAndroidApp: false,
+	isSafari: false,
+};


### PR DESCRIPTION
## Summary

Creating notes for podcasts with very long titles silently failed: the generated path's **filename component** exceeded the OS limit, so `app.vault.create` threw `ENAMETOOLONG` and the user only saw "Failed to create note" (#22). Separately, note creation could fail spuriously with a console `Folder already exists` (#87).

This PR caps generated paths safely (platform-aware) and hardens folder creation, across **every** path the plugin builds from a title.

Closes #22.
Closes #87.

## What changed

**New `src/utility/enforceMaxPathLength.ts`** — caps each path component at the platform's real per-component limit, detected via Obsidian's native `Platform`:
- **NTFS / APFS / HFS+** (Windows, macOS, iOS) → **255 UTF-16 code units**
- **ext4 / F2FS** (Linux, Android) → **255 bytes**

It truncates only the title (the base name) on **code-point boundaries** (never splitting a surrogate pair), preserves the extension, substitutes `Untitled` when a title sanitizes to nothing, trims trailing dots/spaces a cut exposes, and drops empty path segments. The limit is injectable for testing.

> APFS counting **UTF-16 units, not bytes** was verified empirically (a 255-unit / ~759-byte CJK name is accepted; 256 is rejected). A fixed byte cap over-truncated CJK titles on macOS; the platform-aware cap uses the full legal length on each OS.

**Applied everywhere a path is built from a title** (each via a single shared resolver, so the existence-check and the write always agree on the capped path):
- episode notes (`createPodcastNote`)
- feed notes (`createFeedNote`) **and** the `{{podcastlink}}` wikilink that targets them (`getFeedNoteWikilink`)
- transcripts (`TranscriptionService`, extension taken from the user's template — not forced to `.md`)
- downloads (`downloadEpisode`, shared by the pre-download check and the write)

**Folder creation hardened** — `ensureFolderExists` now tolerates `Folder already exists` (thrown when a case-sensitive lookup misses an existing folder on a case-insensitive FS, or on a concurrent create) while still rethrowing genuine errors. This is #87's root cause. `TranscriptionService`'s hand-rolled loop was replaced with it (passing its injected vault), and `createFeedNote`/`downloadEpisode` are transitively hardened.

## Runtime verification (real Obsidian vault on macOS)

Driven through the actual commands:

| Case | Result |
|------|--------|
| 303-char filename, raw `app.vault.create` | `ENAMETOOLONG` (baseline) |
| 382-char ASCII / 600-byte CJK / emoji episode titles | created, valid ≤-limit notes, no split surrogate ✓ |
| CJK title on macOS | now uses full **255 UTF-16 units (759 bytes)**, not over-truncated ✓ |
| all-illegal-character title | `Untitled.md` ✓ |
| `createFolder` on existing folder / lookup miss | created, 0 errors ✓ |
| `{{podcastlink}}` for a 400-char feed title | emits **252-char capped** link matching the feed note ✓ |

`dev:errors` clean throughout.

## Tests & gates

New `enforceMaxPathLength.test.ts` (both platform modes, multibyte, surrogate safety, fallback, edge-trim, deterministic collision, `lastSegmentExtension` guard) and extended tests for `ensureFolderExists` (already-exists tolerance, injected vault), `createFeedNote` (cap), `downloadEpisode` (`safeDownloadFilePath`), and `getFeedNoteWikilink` (cap). Gates: `lint` ✓ `format:check` ✓ `typecheck` ✓ `build` ✓ `test` ✓ (404 passing). `docs:build` not run (mkdocs not installed locally).

## Review

Three rounds of an ultracode multi-lens workflow + opposite-model (Codex) adversarial reviewers. Round 1 → byte-vs-char cap (made platform-aware). Round 2 → `{{podcastlink}}` mismatch, transcript extension, vault-instance split, short-folder trim (all fixed). Round 3 → a dotted-title-as-pseudo-extension edge (fixed); workflow 0 findings, architect PASS.

## Design notes / out of scope

- **Local-OS maximum, not sync-portable:** the cap uses the *current* device's limit. A vault synced from a UTF-16-limit OS (macOS/Windows) to a byte-limit OS (Android/Linux) could, for heavily multibyte titles, exceed the destination's per-component limit. The byte mode is the portable floor.
- **Per-component only:** total path length (Windows legacy `MAX_PATH`) is not bounded (it needs the absolute vault root); a long title trips the per-component limit, which is what this fixes.
- **Pre-existing, separate:** Windows reserved device names (`CON`, `PRN`, …) remain unhandled by the sanitizer; downloads keep their existing `episode` fallback (#183). Deterministic collisions (two titles sharing the capped prefix) resolve to the same note and open the existing one (no data loss) — matching the issue's deterministic-naming goal.
