### PR TITLE
fix(settings): show labelled Add/Remove buttons in podcast search (#109)

### DIFF
--- a/src/ui/settings/PlaylistManager.svelte
+++ b/src/ui/settings/PlaylistManager.svelte
@@ -88,7 +88,12 @@
 	<div class="add-playlist-container">
 		<Dropdown {options} bind:value={icon} on:change={onChangeIcon} />
 		<Text placeholder="Playlist name" bind:value={playlistInput} />
-		<Button icon="plus" cta={true} on:click={onAddPlaylist} />
+		<Button
+			text="Add"
+			cta={true}
+			ariaLabel="Add playlist"
+			on:click={onAddPlaylist}
+		/>
 	</div>
 </div>
 

--- a/src/ui/settings/PlaylistManager.test.ts
+++ b/src/ui/settings/PlaylistManager.test.ts
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+
+import PlaylistManager from "./PlaylistManager.svelte";
+
+describe("PlaylistManager", () => {
+	// Regression test for the #109-class icon-only button: the add-playlist
+	// control previously used an icon-only "+" Button with no text and no
+	// aria-label, so on iPad it rendered as an empty box and was invisible to
+	// screen readers. It must carry a visible text label and an accessible name.
+	test("renders a labelled, accessible 'Add' playlist button", () => {
+		const { getByRole } = render(PlaylistManager);
+
+		const addButton = getByRole("button", { name: "Add playlist" });
+
+		expect(addButton).toBeInTheDocument();
+		expect(addButton.textContent?.trim()).toBe("Add");
+		expect(addButton.classList.contains("mod-cta")).toBe(true);
+	});
+});

--- a/src/ui/settings/PodcastResultCard.svelte
+++ b/src/ui/settings/PodcastResultCard.svelte
@@ -24,13 +24,15 @@
 	<div class="podcast-actions">
 		{#if isSaved}
 			<Button
-				icon="trash"
+				text="Remove"
+				warning
 				ariaLabel={`Remove ${podcast.title} podcast`}
 				on:click={() => dispatch("removePodcast", { podcast })}
 			/>
 		{:else}
 			<Button
-				icon="plus"
+				text="Add"
+				cta
 				ariaLabel={`Add ${podcast.title} podcast`}
 				on:click={() => dispatch("addPodcast", { podcast })}
 			/>
@@ -95,19 +97,16 @@
 		-webkit-box-orient: vertical;
 	}
 
+	/*
+	 * The Add/Remove control uses Obsidian's native call-to-action / warning
+	 * button styling with a text label. A label is always visible and is sized
+	 * correctly per platform (Obsidian renders larger buttons on mobile/iPad),
+	 * unlike the previous icon-only button whose glyph failed to render on iPad
+	 * and left an empty, unrecognisable tap target — the root cause of #109.
+	 */
 	.podcast-actions {
 		display: flex;
 		align-items: center;
 		flex-shrink: 0;
-	}
-
-	:global(.podcast-actions button) {
-		padding: 0.375rem;
-		border-radius: 0.25rem;
-		transition: background-color 120ms ease;
-	}
-
-	:global(.podcast-actions button:hover) {
-		background-color: var(--background-modifier-hover);
 	}
 </style>

--- a/src/ui/settings/PodcastResultCard.test.ts
+++ b/src/ui/settings/PodcastResultCard.test.ts
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+
+import type { PodcastFeed } from "src/types/PodcastFeed";
+import PodcastResultCard from "./PodcastResultCard.svelte";
+
+const podcast: PodcastFeed = {
+	title: "How I Built This",
+	url: "https://example.com/feed.xml",
+	artworkUrl: "https://example.com/artwork.jpg",
+};
+
+// Regression tests for #109: on iPad the icon-only "+"/trash button rendered as
+// an empty box, so users could not find the add control. The action must always
+// carry a visible text label (never an icon glyph alone) and read as a clear,
+// enabled call to action.
+describe("PodcastResultCard", () => {
+	test("renders a visible, enabled 'Add' call-to-action when not saved", () => {
+		const { getByRole } = render(PodcastResultCard, {
+			props: { podcast, isSaved: false },
+		});
+
+		const addButton = getByRole("button", {
+			name: `Add ${podcast.title} podcast`,
+		});
+
+		expect(addButton).toBeInTheDocument();
+		expect(addButton.textContent?.trim()).toBe("Add");
+		expect(addButton).not.toBeDisabled();
+		// Accent-styled so it stands out as the primary action.
+		expect(addButton.classList.contains("mod-cta")).toBe(true);
+	});
+
+	test("renders a visible 'Remove' control when the podcast is saved", () => {
+		const { getByRole } = render(PodcastResultCard, {
+			props: { podcast, isSaved: true },
+		});
+
+		const removeButton = getByRole("button", {
+			name: `Remove ${podcast.title} podcast`,
+		});
+
+		expect(removeButton).toBeInTheDocument();
+		expect(removeButton.textContent?.trim()).toBe("Remove");
+		expect(removeButton).not.toBeDisabled();
+		expect(removeButton.classList.contains("mod-warning")).toBe(true);
+	});
+
+	test("never renders an action without a visible text label", () => {
+		const { getByRole } = render(PodcastResultCard, {
+			props: { podcast, isSaved: false },
+		});
+
+		// Guards the #109 root cause: an icon-only button leaves an empty,
+		// unrecognisable tap target on touch platforms.
+		const button = getByRole("button");
+		expect(button.textContent?.trim().length ?? 0).toBeGreaterThan(0);
+	});
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -140,3 +140,47 @@ if (!(HTMLElement.prototype as unknown as { empty?: () => void }).empty) {
 			}
 		};
 }
+
+// jsdom does not implement the Web Animations API, which Svelte 5 transitions
+// (e.g. transition:fade) rely on. Provide a minimal mock so components that use
+// transitions can be rendered and asserted on in component tests.
+//
+// Known fidelity gaps (acceptable for the current suite, which only renders
+// CSS fade transitions): `onfinish` fires immediately on a microtask rather
+// than after the real duration, `playState` is always "finished", and
+// `finished` is pre-resolved and ignores `cancel()`. If a future test needs to
+// assert mid-transition or outro-timing behaviour, replace this with a fuller
+// fake (e.g. a timer-driven animation) instead of relying on these defaults.
+if (!Element.prototype.animate) {
+	(Element.prototype as unknown as { animate: () => Animation }).animate =
+		function () {
+			let onfinish: (() => void) | null = null;
+			const animation = {
+				cancel() {},
+				finish() {},
+				play() {},
+				pause() {},
+				reverse() {},
+				currentTime: 0,
+				startTime: 0,
+				playbackRate: 1,
+				playState: "finished",
+				finished: Promise.resolve(),
+				effect: null,
+				addEventListener() {},
+				removeEventListener() {},
+				get onfinish() {
+					return onfinish;
+				},
+				set onfinish(fn: (() => void) | null) {
+					onfinish = fn;
+					if (fn) {
+						queueMicrotask(() => fn());
+					}
+				},
+				oncancel: null,
+			};
+
+			return animation as unknown as Animation;
+		};
+}


### PR DESCRIPTION
## Summary

Closes #109.

On iPad, users could not find the **Add** controls in PodNotes settings. The podcast search result cards — and the "add playlist" button — used **icon-only** Obsidian buttons (`setIcon("plus")` / `setIcon("trash")`), and on iPad the icon glyph rendered as an **empty box**: an invisible, unrecognisable tap target. Both reporters' screenshots show this (an empty rounded rectangle where the add control should be; on a light theme, nothing visible at all).

This replaces the icon-only buttons with Obsidian's **native call-to-action / warning buttons carrying visible text labels** — `Add` (`cta`) and `Remove` (`warning`). A text label always renders (it is `textContent`, not an icon glyph), reads unambiguously, and is sized appropriately per platform (Obsidian renders larger buttons on mobile/iPad via `--input-height`). The `aria-label` is preserved.

| Before (iPad, from #109) | After |
| --- | --- |
| Empty box / no visible add control | A clearly-labelled accent **Add** button (and **Remove** for saved feeds) |

## Root cause

- The settings podcast view was redesigned in **2.13.0** to use compact icon-only buttons; the iPad reports (#109, Sep 2024) started right after.
- On iPad the lucide glyph inside Obsidian's `ButtonComponent` did not paint, so the button was an empty box. Obsidian's own toolbar icons rendered fine on the same device — so an icon-only affordance is fragile here, while a text label is guaranteed to render.
- The control was also only ~30×30px with no text, just an `aria-label`.

## Changes

- **`src/ui/settings/PodcastResultCard.svelte`** — icon-only → `text="Add" cta` / `text="Remove" warning`; `aria-label` kept. The control is now a native cta/warning button that supplies its own padding/radius/hover, so the previous custom `:global(.podcast-actions button)` block is removed (a deliberate, minor desktop visual change to native button styling).
- **`src/ui/settings/PlaylistManager.svelte`** — the "add playlist" button had the **same** icon-only failure mode *and* no `aria-label` (so it was also invisible to screen readers). Changed `<Button icon="plus" cta />` → `<Button text="Add" cta ariaLabel="Add playlist" />`.
- **`src/ui/settings/PodcastResultCard.test.ts`** + **`src/ui/settings/PlaylistManager.test.ts`** (new) — Testing-Library regression tests asserting a visible `Add`/`Remove` text label, `mod-cta`/`mod-warning`, an accessible name, and that no action renders without a visible label.
- **`vitest.setup.ts`** — minimal `Element.prototype.animate` (Web Animations API) mock so `transition:fade` components can render under jsdom in component tests; documented its known fidelity gaps.

## Verification

- **Gates (Node 22), all green:** `lint`, `format:check`, `typecheck`, `check:a11y` (0 errors / 0 warnings), `test` (375 passing), `build`.
- **Real Obsidian app (isolated e2e vault):** searched podcasts and inspected the playlist manager; both add controls now render an **"Add"** button with the accent (`mod-cta`) background `rgb(138, 92, 245)` and intact `aria-label`s (`"Add … podcast"`, `"Add playlist"`).

### Notes / caveats

- The iPad-only empty-glyph could **not be reproduced on desktop** (the icon renders fine there). The root cause was confirmed from the two reporters' screenshots + the markup, and the fix targets the failure mode directly: a guaranteed-visible text label with native per-platform sizing.
- The new unit tests assert `mod-cta`/`mod-warning` + visible text via the `obsidian` test mock, not real Obsidian CSS/glyph rendering — they guard against re-introducing a label-less button, while the real-app e2e check validates the visible-label fix.
- **No enforced 44px touch target by design:** Obsidian sizes buttons via `--input-height` (larger on mobile/iPad); native cta/warning sizing is correct per-platform.

## Possible follow-up (out of scope)

The `PlaylistItem` **delete** button (`src/ui/settings/PlaylistItem.svelte`) still uses the icon-only `setIcon` glyph path that is the #109 root cause, so it could also render as an empty box on iPad. It already has an `aria-label` (so it is not screen-reader-invisible), and its stateful trash → confirm-check behaviour makes converting it a larger change. Left out of this `add`-scoped fix; worth a separate issue.
