### PR TITLE
docs(templates): document the {{stream}} note template tag (#120, #121)

### DIFF
--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -29,6 +29,7 @@ This template will be used to create the note text. You can use the following sy
 
 - `{{podcast}}`: The name of the podcast.
 - `{{url}}`: The URL of the podcast episode.
+- `{{stream}}`: The direct URL of the episode's audio file — the RSS `<enclosure>` URL for podcast feeds, or the underlying audio source for Pocket Casts and local-file episodes. Handy for embedding the raw audio or linking to the source. An empty string is used in the rare case no audio URL is available. Available in episode note templates only.
 - `{{date}}`: The publish date of the podcast episode.
 	- You can use `{{date:format}}` to specify a custom [Moment.js](https://momentjs.com) format. E.g. `{{date:YYYY-MM-DD}}`.
 - `{{currentDate}}`: The current date — i.e. when the note is created — as opposed to `{{date}}`, which is the episode's publish date. Useful for a "captured on" metadata field.


### PR DESCRIPTION
## Summary
Documents the `{{stream}}` note-template tag in the template reference. The tag was implemented in #120 (commit `208e783`) but never documented — that documentation is the one genuinely-missing piece of #121, ported here with attribution to @Portugapt.

Adds a single entry to the **Note template** tag list in `docs/docs/templates.md`:

> `{{stream}}`: The direct URL of the episode's audio file — the RSS `<enclosure>` URL for podcast feeds, or the underlying audio source for Pocket Casts and local-file episodes. … Available in episode note templates only.

## Supersedes #121
PR #121 (@Portugapt) touched three files; this PR carries over only the part not already on `master`:

| File in #121 | Status |
|---|---|
| `docs/docs/templates.md` | **Missing → ported here** (with attribution) |
| `src/TemplateEngine.ts` (`episode.streamUrl ?? ""`) | **Redundant** — the tag already ships on `master` (`src/TemplateEngine.ts:123`); `Episode.streamUrl` is a required `string` (parsers default it to `""` / refuse to build without it), so the guard is a no-op |
| `src/ui/settings/PodNotesSettingsTab.ts` | **Dropped** — a trailing comma made the added lines a second argument to `setPlaceholder()`, which fails strict typecheck (`TS2554`); the hint is also marginal vs. the docs |

Credit to @Portugapt (via `Co-authored-by` on the commit) for both the original `{{stream}}` tag (#120) and flagging that it needed docs (#121). #121 will be closed separately with a comment explaining this.

## Verification
- Gates: `lint`, `format:check`, `typecheck`, `build`, `test` (430/430), `docs:build` all pass; the new entry renders into the built HTML.
- **Runtime (real Obsidian, isolated vault):** a note created from a template containing `{{stream}}` expands to the episode's audio URL with no raw tag left, and no console errors.
- Reviewed by an automated comprehensive + 2 adversarial passes; the `<enclosure>`-only over-generalization they caught is fixed in the wording above.