### PR TITLE
chore(e2e): stop and reap leaked isolated Obsidian E2E instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,13 @@ Two layers keep instances from leaking, so you rarely need to run `stop` by hand
   `orca worktree rm --worktree <selector> --run-hooks` so the hook fires (Orca
   skips archive hooks without `--run-hooks`).
 - **Reap on next start** — `start:e2e-obsidian` and `obsidian:e2e` reap any
-  orphaned instance (one whose backing vault no longer exists, i.e. its worktree
-  was removed) before launching. An idle instance for a worktree that still
-  exists is left alone so concurrent workers can reuse it.
+  orphaned instance (one whose backing worktree no longer exists on disk, i.e.
+  it was removed) before launching, even if its Obsidian is still running. An
+  idle instance for a worktree that still exists is left alone so concurrent
+  workers can reuse it. Reaping scans the default profile root
+  (`/tmp/podnotes-obsidian-e2e`); instances started under a custom
+  `--profile-root` are only reaped by a start that uses that same root, so stop
+  those explicitly.
 
 ## Documentation
 Docs live in `docs/docs/` and are configured by `docs/mkdocs.yml`. Update docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,36 @@ npm run obsidian:e2e -- dev:errors
   `main.js` to exist). `start:e2e-obsidian` reloads PodNotes when it reuses a
   running instance, so the exported instance is never stale.
 
+### Stopping an isolated instance (avoid leaks)
+
+Each started instance is a real Obsidian process tree plus a private profile
+directory under `/private/tmp/podnotes-obsidian-e2e/<vault>-<hash>/`. Removing a
+worktree does **not** stop it, so a finished worktree would leak an Obsidian
+process tree and a `/private/tmp` directory. Stop it explicitly:
+
+```bash
+npm run stop:e2e-obsidian            # stop THIS worktree's instance + remove its tmp dir
+npm run stop:e2e-obsidian -- --dry-run   # show what would be stopped/removed
+npm run stop:e2e-obsidian -- --prune     # also reap orphaned instances (worktree gone)
+```
+
+The teardown identifies only this worktree's instance by its private
+`--user-data-dir` token (which contains a per-worktree hash), terminates that
+process tree (SIGTERM, then SIGKILL for stragglers), and removes its profile
+directory. It never touches the shared `dev` vault, other worktrees, or quickadd
+instances.
+
+Two layers keep instances from leaking, so you rarely need to run `stop` by hand:
+
+- **Orca archive hook** — `orca.yaml` defines a `scripts.archive` hook that runs
+  this teardown for the worktree being removed. Remove worktrees with
+  `orca worktree rm --worktree <selector> --run-hooks` so the hook fires (Orca
+  skips archive hooks without `--run-hooks`).
+- **Reap on next start** — `start:e2e-obsidian` and `obsidian:e2e` reap any
+  orphaned instance (one whose backing vault no longer exists, i.e. its worktree
+  was removed) before launching. An idle instance for a worktree that still
+  exists is left alone so concurrent workers can reuse it.
+
 ## Documentation
 Docs live in `docs/docs/` and are configured by `docs/mkdocs.yml`. Update docs
 with user-facing behavior changes, new commands, API changes, template syntax,

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,22 @@
+# Orca worktree lifecycle hooks for PodNotes.
+# See AGENTS.md > "Isolated worktree vault" for the full workflow.
+#
+# `archive` runs on `orca worktree rm --run-hooks`, before the worktree is
+# removed, with the cwd set to the worktree and $ORCA_WORKTREE_PATH pointing at
+# it. It stops this worktree's isolated Obsidian E2E instance and removes its
+# /private/tmp profile directory, so a merged or deleted worktree never leaks an
+# Obsidian process tree or vault dir. It targets only this worktree's instance
+# (matched by its private --user-data-dir token); the shared dev vault, other
+# worktrees, and quickadd instances are untouched.
+#
+# Notes:
+# - Orca skips this hook unless `--run-hooks` is passed; `start:e2e-obsidian`
+#   also reaps orphaned instances on the next start as a safety net.
+# - A failed archive hook is logged by Orca but never blocks removal. `|| true`
+#   keeps the archive log clean when no instance was ever started.
+# - This assumes the default per-worktree vault name (podnotes-<worktree>). If
+#   you started an instance with a custom --vault, stop it with the matching
+#   `npm run stop:e2e-obsidian -- --vault <name>` before removing the worktree.
+scripts:
+  archive: |
+    node scripts/stop-obsidian-e2e-instance.mjs --worktree "$ORCA_WORKTREE_PATH" || true

--- a/orca.yaml
+++ b/orca.yaml
@@ -14,9 +14,15 @@
 #   also reaps orphaned instances on the next start as a safety net.
 # - A failed archive hook is logged by Orca but never blocks removal. `|| true`
 #   keeps the archive log clean when no instance was ever started.
-# - This assumes the default per-worktree vault name (podnotes-<worktree>). If
-#   you started an instance with a custom --vault, stop it with the matching
-#   `npm run stop:e2e-obsidian -- --vault <name>` before removing the worktree.
+# - This assumes the default per-worktree vault name (podnotes-<worktree>) and
+#   profile root. If you started an instance with a custom --vault or
+#   --profile-root, stop it with the matching
+#   `npm run stop:e2e-obsidian -- --vault <name> [--profile-root <path>]` before
+#   removing the worktree.
+# - The hook needs `node` on the GUI app's PATH (Orca runs it via non-login
+#   /bin/bash). It is guarded with `command -v node` so a missing node degrades
+#   to a no-op (the reap-on-next-start safety net then handles cleanup) instead
+#   of erroring.
 scripts:
   archive: |
-    node scripts/stop-obsidian-e2e-instance.mjs --worktree "$ORCA_WORKTREE_PATH" || true
+    command -v node >/dev/null 2>&1 && node scripts/stop-obsidian-e2e-instance.mjs --worktree "$ORCA_WORKTREE_PATH" || true

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"obsidian:e2e": "node scripts/obsidian-e2e-cli.mjs",
 		"provision:e2e-vault": "node scripts/provision-obsidian-e2e-vault.mjs",
 		"start:e2e-obsidian": "node scripts/start-obsidian-e2e-instance.mjs",
+		"stop:e2e-obsidian": "node scripts/stop-obsidian-e2e-instance.mjs",
 		"check:a11y": "svelte-check --fail-on-warnings",
 		"docs:build": "mkdocs build -f docs/mkdocs.yml -d site",
 		"docs:deploy": "npm run docs:build && npx wrangler pages deploy docs/site --project-name podnotes --branch master"

--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -7,6 +7,7 @@ import {
 	launchObsidianInstance,
 	parseArgs as parseInstanceArgs,
 	prepareObsidianProfile,
+	reapStaleInstances,
 	reloadPodNotes,
 	resolveInstanceOptions,
 	trustVaultAndVerifyPodNotes,
@@ -165,6 +166,7 @@ async function main() {
 	const options = resolveInstanceOptions(
 		parseInstanceArgs(parsed.instanceArgs),
 	);
+	await reapStaleInstances(options);
 	await ensureObsidianInstance(options);
 	process.exitCode = await spawnObsidian(options, parsed.commandArgs);
 }

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -14,6 +14,10 @@ import {
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_PROFILE_ROOT = "/tmp/podnotes-obsidian-e2e";
+// Sidecar written at the instance root recording which worktree the instance
+// belongs to. The teardown reaper reads it to reap an instance only once its
+// worktree is gone (a removed/merged worktree) — the reliable leak signal.
+export const INSTANCE_MARKER_FILE = "podnotes-e2e-instance.json";
 const DEFAULT_OBSIDIAN_APP = "Obsidian";
 const DEFAULT_OBSIDIAN_BIN = "obsidian";
 const READY_TIMEOUT_MS = 30_000;
@@ -166,6 +170,14 @@ export async function prepareObsidianProfile(options) {
 				ts: Date.now(),
 			},
 		},
+	});
+
+	// Record which worktree this instance belongs to so the teardown reaper can
+	// reap it once that worktree is removed (see INSTANCE_MARKER_FILE).
+	await writeJson(path.join(options.instancePath, INSTANCE_MARKER_FILE), {
+		worktreePath: options.worktreePath,
+		vaultName: options.vaultName,
+		vaultPath: options.vaultPath,
 	});
 
 	return {

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -406,6 +406,29 @@ function shellQuote(value) {
 	return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
 
+// Self-healing safety net: before launching our own instance, reap any leaked
+// instances whose backing worktree is gone (e.g. removed on merge without the
+// orca archive hook running). Best-effort — a reap failure must never block a
+// start. The reaper is imported lazily so the static module graph stays acyclic
+// (the stop module imports our option resolver; we only need its reaper at
+// runtime). Logs go to stderr so `--print-env` keeps stdout to `export …` lines.
+export async function reapStaleInstances(options) {
+	try {
+		const { reapOrphanedInstances } = await import(
+			"./stop-obsidian-e2e-instance.mjs"
+		);
+		await reapOrphanedInstances({
+			profileRoot: options.profileRoot,
+			exceptInstancePath: options.instancePath,
+			log: console.error,
+		});
+	} catch (error) {
+		console.error(
+			`Skipping stale-instance reap: ${error instanceof Error ? error.message : error}`,
+		);
+	}
+}
+
 async function main() {
 	const rawOptions = parseArgs(process.argv.slice(2));
 	if (rawOptions.help) {
@@ -414,6 +437,7 @@ async function main() {
 	}
 
 	const options = resolveInstanceOptions(rawOptions);
+	await reapStaleInstances(options);
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
 	options.userDataPath = profileResult.userDataPath;

--- a/scripts/stop-obsidian-e2e-instance.mjs
+++ b/scripts/stop-obsidian-e2e-instance.mjs
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
-import { resolveInstanceOptions } from "./start-obsidian-e2e-instance.mjs";
+import {
+	INSTANCE_MARKER_FILE,
+	resolveInstanceOptions,
+} from "./start-obsidian-e2e-instance.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -108,10 +111,14 @@ export function commandMatchesInstance(command, instancePath) {
 		stripped,
 		stripped.replace(/^\//, "/private/"),
 	]);
-	// Every real reference is a directory prefix (e.g. --user-data-dir=<path>/home/…),
-	// so require a trailing separator: it avoids matching a sibling instance whose
-	// id merely shares this one as a leading string.
-	return [...variants].some((variant) => command.includes(`${variant}/`));
+	// Seed only on the Obsidian `--user-data-dir=` flag whose value is THIS
+	// instance's profile dir (with a trailing separator). Scoping to the flag, not
+	// a bare substring, means an unrelated process that merely mentions the path —
+	// a log tail, an editor, a grep — is never pulled into the kill set. The
+	// trailing slash stops a sibling whose id shares this one as a leading string.
+	return [...variants].some((variant) =>
+		command.includes(`--user-data-dir=${variant}/`),
+	);
 }
 
 export function parsePsOutput(stdout) {
@@ -161,7 +168,7 @@ export function collectInstancePids(processes, instancePath, options = {}) {
 	return [...collected].sort((a, b) => a - b);
 }
 
-function assertSafeInstancePath(instancePath) {
+function assertSafeInstancePath(instancePath, profileRoot) {
 	if (!instancePath || !path.isAbsolute(instancePath)) {
 		throw new Error(
 			`Refusing to remove non-absolute instance path: ${instancePath}`,
@@ -177,6 +184,17 @@ function assertSafeInstancePath(instancePath) {
 	// reject anything shallow enough to be a system root.
 	if (instancePath.split(path.sep).filter(Boolean).length < 2) {
 		throw new Error(`Refusing to remove shallow path: ${instancePath}`);
+	}
+	// Containment guard: when the caller knows the profile root, the dir we remove
+	// must be a direct child of it. Real callers always do, so a bad --profile-root
+	// can never make us rm a path outside the e2e profile tree.
+	if (
+		profileRoot &&
+		path.resolve(path.dirname(instancePath)) !== path.resolve(profileRoot)
+	) {
+		throw new Error(
+			`Refusing to remove ${instancePath}: not a direct child of profile root ${profileRoot}.`,
+		);
 	}
 }
 
@@ -204,6 +222,12 @@ function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// kill(2) errors we tolerate so one stubborn pid never aborts tearing down the
+// rest of the tree (and never blocks the subsequent dir removal): ESRCH (already
+// exited between discovery and signalling), EPERM (a pid we no longer own — e.g.
+// recycled by a foreign process; skip rather than touch it), ENOENT (defensive).
+const IGNORABLE_KILL_CODES = new Set(["ESRCH", "EPERM", "ENOENT"]);
+
 function signalPids(pids, signal, kill) {
 	const signalled = [];
 	for (const pid of pids) {
@@ -211,8 +235,7 @@ function signalPids(pids, signal, kill) {
 			kill(pid, signal);
 			signalled.push(pid);
 		} catch (error) {
-			// ESRCH: the process already exited between discovery and signalling.
-			if (error?.code !== "ESRCH") throw error;
+			if (!IGNORABLE_KILL_CODES.has(error?.code)) throw error;
 		}
 	}
 	return signalled;
@@ -231,9 +254,10 @@ export async function stopInstance(instancePath, options = {}) {
 		selfPid = process.pid,
 		graceMs = TERM_GRACE_MS,
 		pollMs = TERM_POLL_MS,
+		profileRoot,
 	} = options;
 
-	assertSafeInstancePath(instancePath);
+	assertSafeInstancePath(instancePath, profileRoot);
 
 	const processes = parsePsOutput(await runPs());
 	const pids = collectInstancePids(processes, instancePath, { selfPid });
@@ -291,12 +315,32 @@ async function pathExists(target) {
 	}
 }
 
-// An instance is "orphaned" once every vault it was created for is gone from
-// disk — the signature of a worktree that was removed on merge. We deliberately
-// do NOT treat "no process running" as orphaned: an idle-but-valid instance for
-// a live worktree must survive so a concurrent worker can reuse it.
+// Reads the instance marker that start writes (worktreePath/vaultName/vaultPath).
+// Returns null when it is missing/unreadable so callers can fall back.
+export async function readInstanceMarker(instancePath, deps = {}) {
+	const readFile = deps.readFile ?? ((file) => fs.readFile(file, "utf8"));
+	try {
+		return JSON.parse(
+			await readFile(path.join(instancePath, INSTANCE_MARKER_FILE)),
+		);
+	} catch {
+		return null;
+	}
+}
+
+// An instance is "orphaned" once the worktree it belongs to is gone from disk —
+// the signature of a worktree removed on merge. We reap it even if its Obsidian
+// process is still running: a leaked-but-running instance is exactly what must be
+// cleaned up. We do NOT use "no process running" or "a single vault leaf missing"
+// as the signal — an idle-but-valid instance for a live worktree, or a vault on a
+// momentarily-unmounted volume, must survive. The worktree path is read from the
+// marker; pre-marker instances fall back to "every registered vault path is gone".
 export async function isInstanceOrphaned(instancePath, deps = {}) {
 	const exists = deps.exists ?? pathExists;
+	const marker = await readInstanceMarker(instancePath, deps);
+	if (marker && typeof marker.worktreePath === "string") {
+		return !(await exists(marker.worktreePath));
+	}
 	const vaultPaths = await readInstanceVaultPaths(instancePath, deps);
 	if (vaultPaths === null || vaultPaths.length === 0) return false;
 	for (const vaultPath of vaultPaths) {
@@ -338,9 +382,21 @@ export async function reapOrphanedInstances(options = {}) {
 		if (except && path.resolve(instancePath) === except) continue;
 		scanned += 1;
 		if (!(await isInstanceOrphaned(instancePath, deps))) continue;
-		log(`Reaping orphaned E2E instance ${entry.name} (backing vault is gone).`);
-		if (!dryRun) await stopInstance(instancePath, { ...deps, dryRun: false });
-		reaped.push(instancePath);
+		log(`Reaping orphaned E2E instance ${entry.name} (worktree is gone).`);
+		if (dryRun) {
+			reaped.push(instancePath);
+			continue;
+		}
+		// Isolate each teardown so one stubborn orphan (e.g. a permission error)
+		// never aborts reaping the rest of the scan.
+		try {
+			await stopInstance(instancePath, { ...deps, profileRoot, dryRun: false });
+			reaped.push(instancePath);
+		} catch (error) {
+			log(
+				`Failed to reap ${entry.name}: ${error instanceof Error ? error.message : error}`,
+			);
+		}
 	}
 
 	return { scanned, reaped };
@@ -362,6 +418,7 @@ async function main() {
 	const options = resolveInstanceOptions(rawOptions);
 	const summary = await stopInstance(options.instancePath, {
 		dryRun: rawOptions.dryRun,
+		profileRoot: options.profileRoot,
 	});
 
 	let pruneResult = { scanned: 0, reaped: [] };

--- a/scripts/stop-obsidian-e2e-instance.mjs
+++ b/scripts/stop-obsidian-e2e-instance.mjs
@@ -1,0 +1,405 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { resolveInstanceOptions } from "./start-obsidian-e2e-instance.mjs";
+
+const execFileAsync = promisify(execFile);
+
+// Window we give a SIGTERM'd Obsidian tree to exit cleanly before escalating to
+// SIGKILL. Electron tears down its helper processes in well under a second.
+const TERM_GRACE_MS = 3_000;
+const TERM_POLL_MS = 100;
+
+// Every per-worktree instance dir is `<profile-root>/<vaultName>-<12 hex>` (see
+// stableInstanceId in start-obsidian-e2e-instance.mjs). The trailing hash makes
+// the dir name globally unique and is the guard that stops us ever removing a
+// non-instance directory (the shared dev vault, a quickadd profile, `/tmp`, …).
+const INSTANCE_DIR_PATTERN = /-[0-9a-f]{12}$/;
+
+const VALUE_OPTIONS = new Set([
+	"--vault",
+	"--root",
+	"--worktree",
+	"--data",
+	"--profile-root",
+	"--obsidian-app",
+	"--obsidian-bin",
+]);
+
+function printUsage() {
+	console.log(`Usage: node scripts/stop-obsidian-e2e-instance.mjs [options]
+
+Stops the worktree-local Obsidian E2E instance: it finds the Obsidian process
+tree bound to this worktree's private HOME / --user-data-dir, terminates it, and
+removes the instance's /tmp profile directory. It never touches the shared dev
+vault, other worktrees, or quickadd instances.
+
+Options:
+  --vault <name>        Vault/profile name. Defaults to podnotes-<worktree>.
+  --root <path>         Directory that contains provisioned vaults. Defaults to .obsidian-e2e-vaults.
+  --worktree <path>     PodNotes worktree the instance belongs to. Defaults to cwd.
+  --profile-root <path> Directory for per-vault Obsidian HOME profiles. Defaults to /tmp/podnotes-obsidian-e2e.
+  --prune               Also reap orphaned instances whose backing vault is gone.
+  --dry-run             Report what would be stopped/removed without doing it.
+  --json                Print a machine-readable summary.
+  --help                Show this help.
+`);
+}
+
+export function parseArgs(argv) {
+	const options = { dryRun: false, json: false, prune: false };
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--":
+				break;
+			case "--dry-run":
+				options.dryRun = true;
+				break;
+			case "--prune":
+				options.prune = true;
+				break;
+			case "--json":
+				options.json = true;
+				break;
+			case "--help":
+				options.help = true;
+				break;
+			default: {
+				if (!VALUE_OPTIONS.has(arg)) {
+					throw new Error(`Unknown option: ${arg}`);
+				}
+				const value = argv[index + 1];
+				if (!value || value.startsWith("--")) {
+					throw new Error(`${arg} requires a value.`);
+				}
+				options[toOptionKey(arg)] = value;
+				index += 1;
+			}
+		}
+	}
+
+	return options;
+}
+
+function toOptionKey(arg) {
+	if (arg === "--profile-root") return "profileRoot";
+	if (arg === "--obsidian-app") return "obsidianApp";
+	if (arg === "--obsidian-bin") return "obsidianBin";
+	return arg.slice(2);
+}
+
+// macOS firmlinks /tmp, /var, and /etc under /private. Obsidian's main process
+// keeps the literal `--user-data-dir` we pass (e.g. /tmp/...), while Electron
+// canonicalizes the same flag to /private/tmp/... for its helper processes.
+// Strip a leading /private so one instance path matches the whole process tree.
+function stripPrivatePrefix(value) {
+	return value.replace(/^\/private(?=\/)/, "");
+}
+
+export function commandMatchesInstance(command, instancePath) {
+	const stripped = stripPrivatePrefix(instancePath);
+	const variants = new Set([
+		instancePath,
+		stripped,
+		stripped.replace(/^\//, "/private/"),
+	]);
+	// Every real reference is a directory prefix (e.g. --user-data-dir=<path>/home/…),
+	// so require a trailing separator: it avoids matching a sibling instance whose
+	// id merely shares this one as a leading string.
+	return [...variants].some((variant) => command.includes(`${variant}/`));
+}
+
+export function parsePsOutput(stdout) {
+	const processes = [];
+	for (const line of stdout.split("\n")) {
+		const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*\S)\s*$/);
+		if (!match) continue;
+		processes.push({
+			pid: Number(match[1]),
+			ppid: Number(match[2]),
+			command: match[3],
+		});
+	}
+	return processes;
+}
+
+// Returns the pids of the Obsidian process tree bound to `instancePath`: the
+// seed processes whose argv references the instance profile, plus every
+// descendant. The descendant walk is belt-and-suspenders — Electron helpers
+// already carry --user-data-dir, but this also reaps any grandchild a helper
+// spawned that does not echo the flag.
+export function collectInstancePids(processes, instancePath, options = {}) {
+	const selfPid = options.selfPid ?? process.pid;
+	const childrenByParent = new Map();
+	for (const proc of processes) {
+		const siblings = childrenByParent.get(proc.ppid) ?? [];
+		siblings.push(proc);
+		childrenByParent.set(proc.ppid, siblings);
+	}
+
+	const collected = new Set();
+	const stack = processes
+		.filter((proc) => commandMatchesInstance(proc.command, instancePath))
+		.map((proc) => proc.pid);
+	while (stack.length > 0) {
+		const pid = stack.pop();
+		if (collected.has(pid)) continue;
+		collected.add(pid);
+		for (const child of childrenByParent.get(pid) ?? []) {
+			stack.push(child.pid);
+		}
+	}
+
+	// Never signal ourselves, init, or the kernel — defensive, the token would
+	// not match these anyway.
+	for (const guarded of [selfPid, 0, 1]) collected.delete(guarded);
+	return [...collected].sort((a, b) => a - b);
+}
+
+function assertSafeInstancePath(instancePath) {
+	if (!instancePath || !path.isAbsolute(instancePath)) {
+		throw new Error(
+			`Refusing to remove non-absolute instance path: ${instancePath}`,
+		);
+	}
+	const base = path.basename(instancePath);
+	if (!INSTANCE_DIR_PATTERN.test(base)) {
+		throw new Error(
+			`Refusing to remove ${instancePath}: not an Obsidian E2E instance directory.`,
+		);
+	}
+	// A real instance dir is several levels deep (e.g. /tmp/podnotes-obsidian-e2e/<id>);
+	// reject anything shallow enough to be a system root.
+	if (instancePath.split(path.sep).filter(Boolean).length < 2) {
+		throw new Error(`Refusing to remove shallow path: ${instancePath}`);
+	}
+}
+
+async function defaultRunPs() {
+	const { stdout } = await execFileAsync(
+		"ps",
+		["-axww", "-o", "pid=,ppid=,command="],
+		{ maxBuffer: 16 * 1024 * 1024 },
+	);
+	return stdout;
+}
+
+function pidAlive(pid, kill) {
+	try {
+		kill(pid, 0);
+		return true;
+	} catch (error) {
+		// EPERM means the process exists but is owned by someone else; for our own
+		// instances that should not happen, but treat it as alive to be safe.
+		return error?.code === "EPERM";
+	}
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function signalPids(pids, signal, kill) {
+	const signalled = [];
+	for (const pid of pids) {
+		try {
+			kill(pid, signal);
+			signalled.push(pid);
+		} catch (error) {
+			// ESRCH: the process already exited between discovery and signalling.
+			if (error?.code !== "ESRCH") throw error;
+		}
+	}
+	return signalled;
+}
+
+// Stop a single instance: terminate its process tree (SIGTERM, then SIGKILL for
+// stragglers) and remove its profile directory. Safe to call when nothing is
+// running — it then just removes a leftover directory. All side effects are
+// injectable so the orchestration is unit-testable without real processes.
+export async function stopInstance(instancePath, options = {}) {
+	const {
+		dryRun = false,
+		kill = process.kill.bind(process),
+		runPs = defaultRunPs,
+		removeDir = (dir) => fs.rm(dir, { recursive: true, force: true }),
+		selfPid = process.pid,
+		graceMs = TERM_GRACE_MS,
+		pollMs = TERM_POLL_MS,
+	} = options;
+
+	assertSafeInstancePath(instancePath);
+
+	const processes = parsePsOutput(await runPs());
+	const pids = collectInstancePids(processes, instancePath, { selfPid });
+
+	if (dryRun) {
+		return { instancePath, pids, terminated: [], killed: [], removed: false };
+	}
+
+	signalPids(pids, "SIGTERM", kill);
+
+	let survivors = pids;
+	const deadline = monotonicNow() + graceMs;
+	while (survivors.length > 0 && monotonicNow() < deadline) {
+		await sleep(pollMs);
+		survivors = survivors.filter((pid) => pidAlive(pid, kill));
+	}
+	const killed =
+		survivors.length > 0 ? signalPids(survivors, "SIGKILL", kill) : [];
+
+	await removeDir(instancePath);
+
+	return { instancePath, pids, terminated: pids, killed, removed: true };
+}
+
+// Reads the vault paths an instance registered in its private obsidian.json.
+// Returns null when the registration is unreadable (so callers can stay
+// conservative and not reap an instance they cannot reason about).
+export async function readInstanceVaultPaths(instancePath, deps = {}) {
+	const readFile = deps.readFile ?? ((file) => fs.readFile(file, "utf8"));
+	const jsonPath = path.join(
+		instancePath,
+		"home",
+		"Library",
+		"Application Support",
+		"obsidian",
+		"obsidian.json",
+	);
+	try {
+		const parsed = JSON.parse(await readFile(jsonPath));
+		return Object.values(parsed?.vaults ?? {})
+			.map((vault) => vault?.path)
+			.filter((vaultPath) => typeof vaultPath === "string");
+	} catch {
+		return null;
+	}
+}
+
+async function pathExists(target) {
+	try {
+		await fs.lstat(target);
+		return true;
+	} catch (error) {
+		if (error?.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+// An instance is "orphaned" once every vault it was created for is gone from
+// disk — the signature of a worktree that was removed on merge. We deliberately
+// do NOT treat "no process running" as orphaned: an idle-but-valid instance for
+// a live worktree must survive so a concurrent worker can reuse it.
+export async function isInstanceOrphaned(instancePath, deps = {}) {
+	const exists = deps.exists ?? pathExists;
+	const vaultPaths = await readInstanceVaultPaths(instancePath, deps);
+	if (vaultPaths === null || vaultPaths.length === 0) return false;
+	for (const vaultPath of vaultPaths) {
+		if (await exists(vaultPath)) return false;
+	}
+	return true;
+}
+
+// Scans the profile root and tears down every orphaned instance. Used as a
+// self-healing safety net on the next `start:e2e-obsidian` so leaks survive even
+// when a worktree is removed without the orca archive hook (`--run-hooks`).
+export async function reapOrphanedInstances(options = {}) {
+	const {
+		profileRoot,
+		exceptInstancePath,
+		dryRun = false,
+		log = () => {},
+		readdir = (dir) => fs.readdir(dir, { withFileTypes: true }),
+		...deps
+	} = options;
+
+	if (!profileRoot) return { scanned: 0, reaped: [] };
+
+	let entries;
+	try {
+		entries = await readdir(profileRoot);
+	} catch (error) {
+		if (error?.code === "ENOENT") return { scanned: 0, reaped: [] };
+		throw error;
+	}
+
+	const reaped = [];
+	let scanned = 0;
+	const except = exceptInstancePath ? path.resolve(exceptInstancePath) : null;
+	for (const entry of entries) {
+		if (!entry.isDirectory() || !INSTANCE_DIR_PATTERN.test(entry.name))
+			continue;
+		const instancePath = path.join(profileRoot, entry.name);
+		if (except && path.resolve(instancePath) === except) continue;
+		scanned += 1;
+		if (!(await isInstanceOrphaned(instancePath, deps))) continue;
+		log(`Reaping orphaned E2E instance ${entry.name} (backing vault is gone).`);
+		if (!dryRun) await stopInstance(instancePath, { ...deps, dryRun: false });
+		reaped.push(instancePath);
+	}
+
+	return { scanned, reaped };
+}
+
+// setTimeout-based polling needs a monotonic clock; Date.now is adequate here and
+// keeps the helper trivially mockable in tests via the injected clock.
+function monotonicNow() {
+	return Date.now();
+}
+
+async function main() {
+	const rawOptions = parseArgs(process.argv.slice(2));
+	if (rawOptions.help) {
+		printUsage();
+		return;
+	}
+
+	const options = resolveInstanceOptions(rawOptions);
+	const summary = await stopInstance(options.instancePath, {
+		dryRun: rawOptions.dryRun,
+	});
+
+	let pruneResult = { scanned: 0, reaped: [] };
+	if (rawOptions.prune) {
+		pruneResult = await reapOrphanedInstances({
+			profileRoot: options.profileRoot,
+			exceptInstancePath: options.instancePath,
+			dryRun: rawOptions.dryRun,
+			log: rawOptions.json ? () => {} : console.error,
+		});
+	}
+
+	const result = {
+		...summary,
+		vaultName: options.vaultName,
+		prune: pruneResult,
+	};
+	if (rawOptions.json) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+
+	const verb = rawOptions.dryRun ? "Would stop" : "Stopped";
+	console.log(`${verb} Obsidian E2E instance ${options.vaultName}`);
+	console.log(`Instance dir: ${options.instancePath}`);
+	console.log(
+		summary.pids.length > 0
+			? `Process tree: ${summary.pids.join(", ")}`
+			: "Process tree: none running",
+	);
+	if (rawOptions.prune && pruneResult.reaped.length > 0) {
+		console.log(`Reaped ${pruneResult.reaped.length} orphaned instance(s).`);
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/stop-obsidian-e2e-instance.test.ts
+++ b/scripts/stop-obsidian-e2e-instance.test.ts
@@ -1,0 +1,371 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	collectInstancePids,
+	commandMatchesInstance,
+	isInstanceOrphaned,
+	parseArgs,
+	parsePsOutput,
+	readInstanceVaultPaths,
+	reapOrphanedInstances,
+	stopInstance,
+} from "./stop-obsidian-e2e-instance.mjs";
+
+const tempRoots: string[] = [];
+
+async function makeTempDir(name: string) {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots
+			.splice(0)
+			.map((dir) => fs.rm(dir, { recursive: true, force: true })),
+	);
+});
+
+const INSTANCE = "/tmp/podnotes-obsidian-e2e/podnotes-wt-abc123def456";
+const UDD = `--user-data-dir=${INSTANCE}/home/Library/Application Support/obsidian`;
+
+// Mirrors the real `ps -axww -o pid=,ppid=,command=` shape captured from a live
+// run: the main process keeps the literal /tmp path we passed, Electron helpers
+// canonicalize it to /private/tmp, and unrelated Obsidians (the shared dev vault,
+// a sibling worktree, a quickadd instance) use different user-data-dirs.
+const PS_FIXTURE = [
+	`  100     1 /Applications/Obsidian.app/Contents/MacOS/Obsidian ${UDD} --password-store=basic`,
+	`  101   100 /Applications/Obsidian.app/Contents/Frameworks/Obsidian Helper (GPU).app/Contents/MacOS/Obsidian Helper (GPU) --type=gpu-process --user-data-dir=/private/tmp/podnotes-obsidian-e2e/podnotes-wt-abc123def456/home/Library/Application Support/obsidian`,
+	`  102   100 /Applications/Obsidian.app/Contents/Frameworks/Obsidian Helper (Renderer).app/Contents/MacOS/Obsidian Helper (Renderer) --type=renderer --user-data-dir=/private/tmp/podnotes-obsidian-e2e/podnotes-wt-abc123def456/home/Library/Application Support/obsidian`,
+	"  103   102 /a/grandchild/process/with/no/token --type=worker",
+	"  200     1 /Applications/Obsidian.app/Contents/MacOS/Obsidian",
+	"  201   200 /Applications/Obsidian.app/Contents/Frameworks/Obsidian Helper (Renderer).app/Contents/MacOS/Obsidian Helper (Renderer) --type=renderer --user-data-dir=/Users/christian/Library/Application Support/obsidian",
+	"  300     1 /Applications/Obsidian.app/Contents/MacOS/Obsidian --user-data-dir=/tmp/quickadd-obsidian-e2e/quickadd-x-000000000000/home/Library/Application Support/obsidian --password-store=basic",
+	"  400     1 /Applications/Obsidian.app/Contents/MacOS/Obsidian --user-data-dir=/tmp/podnotes-obsidian-e2e/podnotes-other-111111111111/home/Library/Application Support/obsidian --password-store=basic",
+].join("\n");
+
+function makeKillSpy({ alive = false }: { alive?: boolean } = {}) {
+	const calls: Array<{ pid: number; signal: string | number }> = [];
+	const kill = (pid: number, signal: string | number) => {
+		calls.push({ pid, signal });
+		// signal 0 is the liveness probe: throw ESRCH to report "dead" unless the
+		// test wants the process to survive SIGTERM (to exercise the SIGKILL path).
+		if (signal === 0 && !alive) {
+			throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+		}
+	};
+	return { calls, kill };
+}
+
+describe("stop-obsidian-e2e-instance args", () => {
+	it("parses value options and boolean flags", () => {
+		const options = parseArgs([
+			"--vault",
+			"podnotes-a",
+			"--profile-root",
+			"/tmp/profiles",
+			"--prune",
+			"--dry-run",
+			"--json",
+		]);
+		expect(options).toMatchObject({
+			vault: "podnotes-a",
+			profileRoot: "/tmp/profiles",
+			prune: true,
+			dryRun: true,
+			json: true,
+		});
+	});
+
+	it("rejects unknown options and missing values", () => {
+		expect(() => parseArgs(["--nope"])).toThrow(/Unknown option/);
+		expect(() => parseArgs(["--vault"])).toThrow(/requires a value/);
+	});
+});
+
+describe("commandMatchesInstance", () => {
+	it("matches both the /tmp and /private/tmp forms of the instance path", () => {
+		expect(commandMatchesInstance(`x ${UDD}`, INSTANCE)).toBe(true);
+		expect(
+			commandMatchesInstance(
+				"x --user-data-dir=/private/tmp/podnotes-obsidian-e2e/podnotes-wt-abc123def456/home/x",
+				INSTANCE,
+			),
+		).toBe(true);
+	});
+
+	it("does not match the dev vault, quickadd, or a sibling worktree", () => {
+		expect(
+			commandMatchesInstance(
+				"--user-data-dir=/Users/christian/Library/Application Support/obsidian",
+				INSTANCE,
+			),
+		).toBe(false);
+		expect(
+			commandMatchesInstance(
+				"--user-data-dir=/tmp/quickadd-obsidian-e2e/quickadd-x-000000000000/home/x",
+				INSTANCE,
+			),
+		).toBe(false);
+		expect(
+			commandMatchesInstance(
+				"--user-data-dir=/tmp/podnotes-obsidian-e2e/podnotes-other-111111111111/home/x",
+				INSTANCE,
+			),
+		).toBe(false);
+	});
+
+	it("does not match a sibling whose id merely shares this one as a prefix", () => {
+		expect(
+			commandMatchesInstance(
+				`--user-data-dir=${INSTANCE}-extra/home/x`,
+				INSTANCE,
+			),
+		).toBe(false);
+	});
+});
+
+describe("parsePsOutput / collectInstancePids", () => {
+	it("parses pid, ppid and command, skipping non-matching lines", () => {
+		const procs = parsePsOutput(`bogus header line\n${PS_FIXTURE}`);
+		expect(procs).toContainEqual({
+			pid: 100,
+			ppid: 1,
+			command: expect.stringContaining(UDD),
+		});
+		expect(procs.find((p) => p.pid === 103)?.ppid).toBe(102);
+	});
+
+	it("collects the instance tree (incl. token-less descendants) and nothing else", () => {
+		const pids = collectInstancePids(parsePsOutput(PS_FIXTURE), INSTANCE, {
+			selfPid: 999999,
+		});
+		// 100 main + 101/102 helpers (matched by token) + 103 grandchild (matched
+		// only by the descendant walk). 200/201 dev vault, 300 quickadd, 400 sibling
+		// worktree are all excluded.
+		expect(pids).toEqual([100, 101, 102, 103]);
+	});
+
+	it("never includes our own pid", () => {
+		const procs = parsePsOutput(`  100     1 x ${UDD} y`);
+		expect(collectInstancePids(procs, INSTANCE, { selfPid: 100 })).toEqual([]);
+	});
+});
+
+describe("stopInstance", () => {
+	const runPs = async () => PS_FIXTURE;
+
+	it("SIGTERMs the whole tree and removes the instance dir when it exits", async () => {
+		const { calls, kill } = makeKillSpy({ alive: false });
+		const removed: string[] = [];
+		const result = await stopInstance(INSTANCE, {
+			runPs,
+			kill,
+			removeDir: async (dir: string) => {
+				removed.push(dir);
+			},
+			selfPid: 999999,
+			pollMs: 1,
+			graceMs: 20,
+		});
+
+		const termed = calls
+			.filter((c) => c.signal === "SIGTERM")
+			.map((c) => c.pid);
+		expect(termed).toEqual([100, 101, 102, 103]);
+		expect(calls.some((c) => c.signal === "SIGKILL")).toBe(false);
+		expect(removed).toEqual([INSTANCE]);
+		expect(result).toMatchObject({ killed: [], removed: true });
+	});
+
+	it("escalates to SIGKILL for survivors of SIGTERM", async () => {
+		const { calls, kill } = makeKillSpy({ alive: true });
+		const result = await stopInstance(INSTANCE, {
+			runPs,
+			kill,
+			removeDir: async () => {},
+			selfPid: 999999,
+			pollMs: 1,
+			graceMs: 5,
+		});
+		const killed = calls
+			.filter((c) => c.signal === "SIGKILL")
+			.map((c) => c.pid);
+		expect(killed).toEqual([100, 101, 102, 103]);
+		expect(result.killed).toEqual([100, 101, 102, 103]);
+	});
+
+	it("dry-run reports the tree without signalling or removing", async () => {
+		const { calls, kill } = makeKillSpy();
+		let removeCalled = false;
+		const result = await stopInstance(INSTANCE, {
+			runPs,
+			kill,
+			removeDir: async () => {
+				removeCalled = true;
+			},
+			selfPid: 999999,
+			dryRun: true,
+		});
+		expect(calls).toEqual([]);
+		expect(removeCalled).toBe(false);
+		expect(result).toMatchObject({
+			pids: [100, 101, 102, 103],
+			removed: false,
+		});
+	});
+
+	it("refuses to remove a path that is not an instance directory", async () => {
+		for (const unsafe of ["/tmp", "relative/path", `${INSTANCE}-no-hash`]) {
+			await expect(
+				stopInstance(unsafe, {
+					runPs,
+					kill: () => {},
+					removeDir: async () => {},
+				}),
+			).rejects.toThrow(/Refusing to remove/);
+		}
+	});
+
+	it("still removes a leftover dir when no process is running", async () => {
+		const { calls, kill } = makeKillSpy();
+		const removed: string[] = [];
+		await stopInstance(INSTANCE, {
+			runPs: async () => "",
+			kill,
+			removeDir: async (dir: string) => {
+				removed.push(dir);
+			},
+			selfPid: 999999,
+		});
+		expect(calls).toEqual([]);
+		expect(removed).toEqual([INSTANCE]);
+	});
+});
+
+describe("orphan detection", () => {
+	async function seedInstance(
+		profileRoot: string,
+		id: string,
+		vaultPath: string,
+	) {
+		const udd = path.join(
+			profileRoot,
+			id,
+			"home",
+			"Library",
+			"Application Support",
+			"obsidian",
+		);
+		await fs.mkdir(udd, { recursive: true });
+		await fs.writeFile(
+			path.join(udd, "obsidian.json"),
+			JSON.stringify({ vaults: { v1: { path: vaultPath, open: true } } }),
+		);
+		return path.join(profileRoot, id);
+	}
+
+	it("reads the registered vault paths", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const instance = await seedInstance(
+			root,
+			"podnotes-a-aaaaaaaaaaaa",
+			"/x/y",
+		);
+		await expect(readInstanceVaultPaths(instance)).resolves.toEqual(["/x/y"]);
+	});
+
+	it("is orphaned only when every backing vault is gone", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const liveVault = await makeTempDir("live-vault");
+		const live = await seedInstance(
+			root,
+			"podnotes-live-bbbbbbbbbbbb",
+			liveVault,
+		);
+		const gone = await seedInstance(
+			root,
+			"podnotes-gone-cccccccccccc",
+			"/does/not/exist",
+		);
+
+		await expect(isInstanceOrphaned(live)).resolves.toBe(false);
+		await expect(isInstanceOrphaned(gone)).resolves.toBe(true);
+	});
+
+	it("stays conservative when the registration is unreadable", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const bare = path.join(root, "podnotes-bare-dddddddddddd");
+		await fs.mkdir(bare, { recursive: true });
+		await expect(isInstanceOrphaned(bare)).resolves.toBe(false);
+	});
+});
+
+describe("reapOrphanedInstances", () => {
+	async function seedInstance(
+		profileRoot: string,
+		id: string,
+		vaultPath: string,
+	) {
+		const udd = path.join(
+			profileRoot,
+			id,
+			"home",
+			"Library",
+			"Application Support",
+			"obsidian",
+		);
+		await fs.mkdir(udd, { recursive: true });
+		await fs.writeFile(
+			path.join(udd, "obsidian.json"),
+			JSON.stringify({ vaults: { v1: { path: vaultPath, open: true } } }),
+		);
+		return path.join(profileRoot, id);
+	}
+
+	it("reaps only orphaned instances, skipping live ones, the exception, and non-instance dirs", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const liveVault = await makeTempDir("live-vault");
+		const live = await seedInstance(
+			root,
+			"podnotes-live-bbbbbbbbbbbb",
+			liveVault,
+		);
+		const orphan = await seedInstance(
+			root,
+			"podnotes-gone-cccccccccccc",
+			"/does/not/exist",
+		);
+		const current = await seedInstance(
+			root,
+			"podnotes-current-dddddddddddd",
+			"/also/gone",
+		);
+		await fs.mkdir(path.join(root, "not-an-instance"), { recursive: true });
+
+		const removed: string[] = [];
+		const result = await reapOrphanedInstances({
+			profileRoot: root,
+			exceptInstancePath: current,
+			runPs: async () => "",
+			kill: () => {},
+			removeDir: async (dir: string) => {
+				removed.push(dir);
+			},
+		});
+
+		expect(result.reaped).toEqual([orphan]);
+		expect(removed).toEqual([orphan]);
+		expect(removed).not.toContain(live);
+		expect(removed).not.toContain(current);
+	});
+
+	it("returns an empty result when the profile root does not exist", async () => {
+		await expect(
+			reapOrphanedInstances({ profileRoot: "/no/such/profile/root" }),
+		).resolves.toEqual({ scanned: 0, reaped: [] });
+	});
+});

--- a/scripts/stop-obsidian-e2e-instance.test.ts
+++ b/scripts/stop-obsidian-e2e-instance.test.ts
@@ -126,6 +126,14 @@ describe("commandMatchesInstance", () => {
 			),
 		).toBe(false);
 	});
+
+	it("does not match a process that mentions the path outside the --user-data-dir flag", () => {
+		// e.g. a log tail or editor referencing a file under the instance dir must
+		// never be pulled into the kill set.
+		expect(
+			commandMatchesInstance(`tail -f ${INSTANCE}/home/obsidian.log`, INSTANCE),
+		).toBe(false);
+	});
 });
 
 describe("parsePsOutput / collectInstancePids", () => {
@@ -244,6 +252,39 @@ describe("stopInstance", () => {
 		expect(calls).toEqual([]);
 		expect(removed).toEqual([INSTANCE]);
 	});
+
+	it("tolerates EPERM from kill (recycled foreign pid) and still removes the dir", async () => {
+		const removed: string[] = [];
+		const kill = (_pid: number, signal: string | number) => {
+			if (signal === 0) return; // liveness probe: report alive
+			throw Object.assign(new Error("operation not permitted"), {
+				code: "EPERM",
+			});
+		};
+		const result = await stopInstance(INSTANCE, {
+			runPs,
+			kill,
+			removeDir: async (dir: string) => {
+				removed.push(dir);
+			},
+			selfPid: 999999,
+			pollMs: 1,
+			graceMs: 5,
+		});
+		expect(removed).toEqual([INSTANCE]);
+		expect(result.removed).toBe(true);
+	});
+
+	it("refuses to remove a dir that is not a child of the given profile root", async () => {
+		await expect(
+			stopInstance(INSTANCE, {
+				runPs,
+				kill: () => {},
+				removeDir: async () => {},
+				profileRoot: "/some/other/root",
+			}),
+		).rejects.toThrow(/not a direct child of profile root/);
+	});
 });
 
 describe("orphan detection", () => {
@@ -294,6 +335,36 @@ describe("orphan detection", () => {
 
 		await expect(isInstanceOrphaned(live)).resolves.toBe(false);
 		await expect(isInstanceOrphaned(gone)).resolves.toBe(true);
+	});
+
+	it("prefers the worktree marker: worktree-gone reaps even with a live vault; worktree-alive spares even with a missing vault", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const liveWorktree = await makeTempDir("live-worktree");
+
+		// marker worktree alive, but the vault leaf is gone -> NOT orphaned
+		const spared = await seedInstance(
+			root,
+			"podnotes-m1-aaaaaaaaaaaa",
+			"/vault/leaf/gone",
+		);
+		await fs.writeFile(
+			path.join(spared, "podnotes-e2e-instance.json"),
+			JSON.stringify({ worktreePath: liveWorktree }),
+		);
+
+		// marker worktree gone, but the vault still exists -> orphaned (leaked)
+		const leaked = await seedInstance(
+			root,
+			"podnotes-m2-bbbbbbbbbbbb",
+			liveWorktree,
+		);
+		await fs.writeFile(
+			path.join(leaked, "podnotes-e2e-instance.json"),
+			JSON.stringify({ worktreePath: "/worktree/removed/on/merge" }),
+		);
+
+		await expect(isInstanceOrphaned(spared)).resolves.toBe(false);
+		await expect(isInstanceOrphaned(leaked)).resolves.toBe(true);
 	});
 
 	it("stays conservative when the registration is unreadable", async () => {
@@ -361,6 +432,37 @@ describe("reapOrphanedInstances", () => {
 		expect(removed).toEqual([orphan]);
 		expect(removed).not.toContain(live);
 		expect(removed).not.toContain(current);
+	});
+
+	it("continues reaping the rest of the scan when one orphan's teardown fails", async () => {
+		const root = await makeTempDir("podnotes-profiles");
+		const bad = await seedInstance(
+			root,
+			"podnotes-bad-aaaaaaaaaaaa",
+			"/gone/1",
+		);
+		const good = await seedInstance(
+			root,
+			"podnotes-good-bbbbbbbbbbbb",
+			"/gone/2",
+		);
+		const removed: string[] = [];
+		const logs: string[] = [];
+
+		const result = await reapOrphanedInstances({
+			profileRoot: root,
+			runPs: async () => "",
+			kill: () => {},
+			removeDir: async (dir: string) => {
+				if (dir === bad) throw new Error("boom");
+				removed.push(dir);
+			},
+			log: (message: string) => logs.push(message),
+		});
+
+		expect(removed).toEqual([good]);
+		expect(result.reaped).toEqual([good]);
+		expect(logs.some((m) => m.includes("Failed to reap"))).toBe(true);
 	});
 
 	it("returns an empty result when the profile root does not exist", async () => {


### PR DESCRIPTION
## Summary

The per-worktree Obsidian E2E isolation wrapper (PR #188) **starts** a private-`HOME` Obsidian instance per worktree (profile dir under `/private/tmp/podnotes-obsidian-e2e/<vault>-<hash>/`) but nothing **stopped** it. When a worktree was removed on merge, every completed worker leaked an Obsidian process tree and a `/private/tmp` vault dir. This adds a reliable teardown.

This is DevX tooling only — **no plugin runtime / user-facing behavior changes**.

## What's added

- **`scripts/stop-obsidian-e2e-instance.mjs` + `npm run stop:e2e-obsidian`** — identifies *this* worktree's instance by its private `--user-data-dir=<instance>/` token (handles the macOS `/tmp` ↔ `/private/tmp` firmlink so the whole Electron tree is matched), terminates that process tree (SIGTERM, then SIGKILL for stragglers), and removes its profile dir behind a safe-path + profile-root containment guard. Supports `--dry-run`, `--json`, `--prune`.
- **Orca archive hook (`orca.yaml`)** — `scripts.archive` runs the teardown on `orca worktree rm --run-hooks` (cwd = worktree, `$ORCA_WORKTREE_PATH`), guarded with `command -v node`. A failed hook is logged by Orca but never blocks removal.
- **Reap-on-start safety net** — `start:e2e-obsidian` and `obsidian:e2e` reap orphaned instances (those whose **worktree** is gone, recorded via a new `podnotes-e2e-instance.json` marker) before launching, so leaks are cleaned even when a worktree is removed without `--run-hooks`. An idle instance for a worktree that still exists is left alone so concurrent workers reuse it.
- **Docs** — AGENTS.md "Stopping an isolated instance" subsection.
- **Tests** — `scripts/stop-obsidian-e2e-instance.test.ts` (23 cases): process-tree matching across `/tmp` vs `/private/tmp`, flag-scoped seeding, descendant walk, SIGTERM→SIGKILL, safe-path/containment guards, marker-based orphan detection, and reap isolation.

### Safety invariants (held)
The teardown only ever targets the current worktree's instance. The shared `dev` vault (real `$HOME`, no `/tmp` token), other worktrees (distinct per-worktree hash), and all quickadd instances (`/tmp/quickadd-obsidian-e2e/...`) are never touched.

## Runtime verification (real Obsidian, this worktree)

- Started an isolated instance → `verifiedPodNotes: true`; the marker recorded the worktree path.
- `stop --dry-run` listed exactly the instance's 4 pids and removed nothing.
- `stop` terminated exactly those pids and removed the profile dir, while a **live sibling worktree instance, 3 quickadd instances, and the shared `dev` vault all stayed alive** and the sibling's dir was intact.
- Synthetic worktree-gone orphan → reaped; live sibling spared.

## Review

Ran a 3-reviewer pass (1 comprehensive + 2 adversarial), each finding independently verified against the code: 13 raised, 10 confirmed, **0 must-fix**. Addressed the high-value confirmed items in the second commit (flag-scoped matcher, worktree-marker orphan signal, EPERM tolerance, per-orphan isolation, containment guard, hook `node` guard).

## Commands run (Node 22)

`npm run lint` · `npm run format:check` · `npm run typecheck` · `npm run build` · `npm run test` (453 passing). `docs:build` skipped (no `docs/` changes; mkdocs not installed locally).

## Release / migration impact

None. Tooling/scripts only; no plugin code, settings, storage, API, or URI behavior changes.

## Note on hook activation

Orca reads `orca.yaml` from the registered repo root (`/Users/christian/Developer/PodNotes`), so the archive hook becomes active for future worktree removals once this merges to `master`. The `stop:e2e-obsidian` script and reap-on-start net work immediately regardless.
