### PR TITLE
fix(player): open and reveal the PodNotes view from "Play with PodNotes" (#84)

### DIFF
--- a/src/getContextMenuHandler.test.ts
+++ b/src/getContextMenuHandler.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TFile } from "obsidian";
+import { get } from "svelte/store";
+import getContextMenuHandler from "./getContextMenuHandler";
+import { VIEW_TYPE } from "./constants";
+import { currentEpisode, viewState } from "./store";
+import { ViewState } from "./types/ViewState";
+
+// `tsc` resolves `obsidian` to the real typings while Vitest aliases it to
+// tests/mocks/obsidian.ts. Build a TFile (so `file instanceof TFile` holds in
+// the handler) carrying the fields the handler reads off an audio file.
+function audioFile(path: string): TFile {
+	const file = new TFile();
+	Object.assign(file as unknown as Record<string, unknown>, {
+		path,
+		extension: path.split(".").pop(),
+		basename: path.split("/").pop()?.replace(/\.[^.]+$/, ""),
+		stat: { ctime: 0, mtime: 0, size: 1024 },
+	});
+	return file;
+}
+
+type CapturedItem = {
+	title: string;
+	icon: string;
+	onClick: (() => Promise<void> | void) | null;
+};
+
+// Minimal Menu stand-in: records the item the handler adds and exposes its
+// click callback so the test can invoke "Play with PodNotes".
+function fakeMenu() {
+	const items: CapturedItem[] = [];
+	const menu = {
+		items,
+		addItem(cb: (item: unknown) => void) {
+			const captured: CapturedItem = { title: "", icon: "", onClick: null };
+			const item = {
+				setIcon(icon: string) {
+					captured.icon = icon;
+					return item;
+				},
+				setTitle(title: string) {
+					captured.title = title;
+					return item;
+				},
+				setSection() {
+					return item;
+				},
+				onClick(fn: () => Promise<void> | void) {
+					captured.onClick = fn;
+					return item;
+				},
+			};
+			cb(item);
+			items.push(captured);
+			return menu;
+		},
+	};
+	return menu;
+}
+
+function setupWorkspace(openLeaves: unknown[]) {
+	const newLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
+	const workspace = {
+		_fileMenuHandler: null as
+			| ((menu: unknown, file: unknown, source: string) => void)
+			| null,
+		on(event: string, cb: (menu: unknown, file: unknown, source: string) => void) {
+			if (event === "file-menu") workspace._fileMenuHandler = cb;
+			return { event } as unknown;
+		},
+		getLeavesOfType: vi.fn(() => openLeaves),
+		getRightLeaf: vi.fn(() => newLeaf),
+		revealLeaf: vi.fn(),
+	};
+	return { workspace, newLeaf };
+}
+
+function makeApp(workspace: unknown, file: TFile) {
+	const vault = {
+		getAbstractFileByPath: vi.fn(() => file),
+		getResourcePath: vi.fn((f: TFile) => `app://resource/${f.path}?1`),
+	};
+	// createMediaUrlObjectFromFilePath reads the global `app`.
+	(globalThis as { app?: unknown }).app = { vault };
+	return {
+		workspace,
+		vault,
+		fileManager: { generateMarkdownLink: vi.fn(() => `[[${file.path}]]`) },
+	};
+}
+
+async function playFile(app: unknown, workspace: { _fileMenuHandler: unknown }, file: TFile) {
+	getContextMenuHandler(app as never);
+	const menu = fakeMenu();
+	(
+		workspace._fileMenuHandler as (
+			menu: unknown,
+			file: unknown,
+			source: string,
+		) => void
+	)(menu, file, "file-explorer-context-menu");
+	const play = menu.items.find((i) => i.title === "Play with PodNotes");
+	expect(play).toBeTruthy();
+	await play?.onClick?.();
+	return menu;
+}
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+	vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+	currentEpisode.set(undefined as never);
+	viewState.set(ViewState.PodcastGrid);
+});
+
+describe("getContextMenuHandler — Play with PodNotes", () => {
+	it("offers the item for audio files and sets it as the current episode", async () => {
+		const file = audioFile("Audio/tone.mp3");
+		const { workspace } = setupWorkspace([{}]);
+		const app = makeApp(workspace, file);
+
+		const menu = await playFile(app, workspace, file);
+
+		const play = menu.items.find((i) => i.title === "Play with PodNotes");
+		expect(play?.icon).toBe("play");
+		expect(get(currentEpisode)).toMatchObject({
+			title: "tone",
+			podcastName: "local file",
+			filePath: "Audio/tone.mp3",
+			streamUrl: "app://resource/Audio/tone.mp3?1",
+		});
+		expect(get(viewState)).toBe(ViewState.Player);
+	});
+
+	it("does not offer the item for non-audio files", () => {
+		const { workspace } = setupWorkspace([{}]);
+		const file = audioFile("Notes/page.md");
+		const app = makeApp(workspace, file);
+
+		getContextMenuHandler(app as never);
+		const menu = fakeMenu();
+		workspace._fileMenuHandler?.(menu, file, "file-explorer-context-menu");
+
+		expect(menu.items.find((i) => i.title === "Play with PodNotes")).toBeUndefined();
+	});
+
+	it("reveals the existing player leaf instead of opening a new one (issue #84)", async () => {
+		const existingLeaf = { id: "existing" };
+		const { workspace, newLeaf } = setupWorkspace([existingLeaf]);
+		const file = audioFile("Audio/already-open.mp3");
+		const app = makeApp(workspace, file);
+
+		await playFile(app, workspace, file);
+
+		expect(workspace.getRightLeaf).not.toHaveBeenCalled();
+		expect(newLeaf.setViewState).not.toHaveBeenCalled();
+		expect(workspace.revealLeaf).toHaveBeenCalledWith(existingLeaf);
+	});
+
+	it("opens and reveals the player when no leaf is present (issue #84)", async () => {
+		const { workspace, newLeaf } = setupWorkspace([]);
+		const file = audioFile("Audio/closed-pane.mp3");
+		const app = makeApp(workspace, file);
+
+		await playFile(app, workspace, file);
+
+		expect(workspace.getRightLeaf).toHaveBeenCalledWith(false);
+		expect(newLeaf.setViewState).toHaveBeenCalledWith({
+			type: VIEW_TYPE,
+			active: true,
+		});
+		expect(workspace.revealLeaf).toHaveBeenCalledWith(newLeaf);
+	});
+});

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -1,6 +1,7 @@
-import type { App, EventRef, Menu, TAbstractFile } from "obsidian";
+import type { App, EventRef, Menu, TAbstractFile, WorkspaceLeaf } from "obsidian";
 import { TFile } from "obsidian";
 import { get } from "svelte/store";
+import { VIEW_TYPE } from "./constants";
 import {
 	downloadedEpisodes,
 	playedEpisodes,
@@ -74,8 +75,39 @@ export default function getContextMenuHandler(app: App): EventRef {
 
 						currentEpisode.set(localEpisode);
 						viewState.set(ViewState.Player);
+
+						// Setting the stores above only updates an already-mounted
+						// PodNotes view. When the view is closed (or hidden in a
+						// collapsed sidebar) nothing reacts, so "Play with PodNotes"
+						// silently did nothing — the file played to no visible player
+						// (issue #84). Open the view if needed and reveal it so the
+						// player surfaces with the just-selected episode.
+						await revealPodcastView(app);
 					})
 			);
 		}
 	);
+}
+
+/**
+ * Ensures the PodNotes player view is open and brought into view.
+ *
+ * Mirrors the "Show PodNotes" command and onLayoutReady: reuse an existing leaf
+ * when present, otherwise open the view in the right sidebar. revealLeaf also
+ * surfaces a leaf that exists but is hidden inside a collapsed sidebar.
+ */
+async function revealPodcastView(app: App): Promise<void> {
+	const { workspace } = app;
+
+	let leaf: WorkspaceLeaf | null =
+		workspace.getLeavesOfType(VIEW_TYPE)[0] ?? null;
+
+	if (!leaf) {
+		leaf = workspace.getRightLeaf(false);
+		if (!leaf) return;
+
+		await leaf.setViewState({ type: VIEW_TYPE, active: true });
+	}
+
+	await workspace.revealLeaf(leaf);
 }


### PR DESCRIPTION
## Summary

Right-clicking an audio file and choosing **Play with PodNotes** now reliably opens and reveals the PodNotes player and starts playback, even when the PodNotes pane is closed or hidden in a collapsed sidebar.

Closes #84.

## Background

Issue #84 (filed on Obsidian 1.4.1 / PodNotes 2.10.8) reported three symptoms: the action didn't open the player pane, didn't play, and showed a broken miniature with `DOMException: The element has no supported sources`.

The **playback-source** half was already fixed by #100 / #184, which replaced in-memory `blob:` URLs with `app.vault.getResourcePath()` and replaced an extension regex that matched every file with an explicit allow-list. I verified this on current `master` in a real Obsidian instance (isolated e2e vault, real MP3): with the PodNotes pane **already open**, the file plays — valid `app://` src, `audio.error` is `null`, `readyState` 1, real `duration`, `currentTime` advances.

The **remaining half** still reproduced: with the pane **closed**, clicking **Play with PodNotes** did nothing visible — no leaf opened and nothing played:

```
{ "leavesAfterClose": 0, "playItemFound": true,
  "leavesAfterClick": 0, "podcastViewInDomAfterClick": false, "audioPresent": false }
```

Root cause: the handler set the `currentEpisode` and `viewState` stores, but those only update an *already-mounted* Svelte view. When the view was closed (or hidden in a collapsed sidebar) nothing reacted, so the file played to no visible player — exactly the "doesn't open associated pane" symptom.

## The fix

In `src/getContextMenuHandler.ts`, after setting the stores, ensure the player view is open and revealed via a small `revealPodcastView(app)` helper:

- reuse an existing `VIEW_TYPE` leaf when present, otherwise open one in the right sidebar with `getRightLeaf(false).setViewState(...)`;
- `workspace.revealLeaf(leaf)` — which also surfaces a leaf hidden inside a collapsed sidebar.

This mirrors the existing **Show PodNotes** command and `onLayoutReady` in `main.ts`. Setting the stores *before* opening the leaf is what lets a freshly mounted `EpisodePlayer` read `viewState = Player` / `currentEpisode` on first render and autoplay the `app://` resource. **`main.ts` is untouched** — the change stays in the context-menu handler.

## Verification

Post-fix runtime repro (same isolated vault, pane closed before the click):

```
{ "leavesAfterClose": 0, "playItemFound": true,
  "leavesAfterClick": 1, "podcastViewInDomAfterClick": true,
  "audioPresent": true, "audioPlaying": true, "leafIsRevealed": true }
```

The already-open path is unchanged (it falls into the existing-leaf branch and just reveals), so there's no regression there.

- **Local file used:** a 3s 440 Hz sine MP3 (`Audio/test-tone.mp3`) generated with ffmpeg, played from the file-explorer context menu.
- **Runtime:** real Obsidian via the isolated worktree e2e vault (`npm run obsidian:e2e`), triggering the real `file-menu` event and invoking the captured item's `onClick`.

### New tests
`src/getContextMenuHandler.test.ts` covers: the item is offered only for audio files, the current episode is wired with the `app://` resource URL, and both reveal paths (reuse an existing leaf vs. open a new one).

### Gates (Node 22)
`npm run lint`, `format:check`, `typecheck`, `build`, and `test` (457 tests) all pass.

## Release / migration impact
None. No settings, storage, API, or URI changes — purely the context-menu playback flow.
