### PR TITLE
fix(view): reliably reveal PodNotes view via command + ribbon icon (#55)

### DIFF
--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -3,7 +3,7 @@ Opens the PodNotes pane and brings it into focus.
 
 If the pane already exists but is hidden — for example in a collapsed sidebar or out of view because the right sidebar has too many icons — this command reveals it. If it does not exist yet, the command creates it in the right sidebar. You can run it from the command palette or bind it to a hotkey.
 
-You can also open PodNotes from the **podcast icon in the left ribbon**, which is always visible and is the most reliable way to reopen the pane.
+PodNotes also adds a **podcast icon to the left ribbon** as a reliable way to reopen the pane. On mobile it appears in the ribbon menu, and you can hide it via Obsidian's *Manage ribbon actions* if you prefer to use the command instead.
 
 If you are having issues with PodNotes not being shown, feel free to create an [issue](https://github.com/chhoumann/PodNotes/issues/new).
 

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -1,9 +1,11 @@
 ## Show PodNotes
-This command is only accessible if there doesn't exist a pane with PodNotes already.
+Opens the PodNotes pane and brings it into focus.
 
-Activating it will spawn a new pane with PodNotes in the right sidebar.
+If the pane already exists but is hidden — for example in a collapsed sidebar or out of view because the right sidebar has too many icons — this command reveals it. If it does not exist yet, the command creates it in the right sidebar. You can run it from the command palette or bind it to a hotkey.
 
-If you are having issues with PodNotes not being shown, feel free to create an [issue](https://github.com/chhoumann/PodNotes/issues/new). However, do make sure to check that the icon isn't just out of view by scrolling on the right sidebar.
+You can also open PodNotes from the **podcast icon in the left ribbon**, which is always visible and is the most reliable way to reopen the pane.
+
+If you are having issues with PodNotes not being shown, feel free to create an [issue](https://github.com/chhoumann/PodNotes/issues/new).
 
 ## Play Podcast
 This will start playback if the current episode is paused.

--- a/src/main.activateView.test.ts
+++ b/src/main.activateView.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PodNotes from "./main";
+import { VIEW_TYPE } from "./constants";
+
+// Regression coverage for #55: "Show PodNotes" / the ribbon icon must reliably
+// surface the view. The bug was that the command was gated on the leaf NOT
+// existing and never revealed it, so an already-open-but-hidden view (collapsed
+// or overflowing sidebar) could not be brought back. activateView reuses the
+// existing leaf when present and always reveals it.
+
+function makeLeaf() {
+	return {
+		setViewState: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function setupPlugin({
+	existingLeaves = [] as ReturnType<typeof makeLeaf>[],
+	rightLeaf = makeLeaf() as ReturnType<typeof makeLeaf> | null,
+} = {}) {
+	const workspace = {
+		getLeavesOfType: vi.fn().mockReturnValue(existingLeaves),
+		getRightLeaf: vi.fn().mockReturnValue(rightLeaf),
+		revealLeaf: vi.fn().mockResolvedValue(undefined),
+	};
+
+	// Build a bare instance so we exercise activateView without running the full
+	// onload() side effects (store wiring, command registration, etc.).
+	const plugin = Object.create(PodNotes.prototype) as PodNotes;
+	(plugin as unknown as { app: { workspace: typeof workspace } }).app = {
+		workspace,
+	};
+
+	return { plugin, workspace, rightLeaf };
+}
+
+describe("PodNotes.activateView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("reuses an existing leaf and reveals it without creating a new one", async () => {
+		const existing = makeLeaf();
+		const { plugin, workspace } = setupPlugin({ existingLeaves: [existing] });
+
+		await plugin.activateView();
+
+		expect(workspace.getRightLeaf).not.toHaveBeenCalled();
+		expect(existing.setViewState).not.toHaveBeenCalled();
+		expect(workspace.revealLeaf).toHaveBeenCalledTimes(1);
+		expect(workspace.revealLeaf).toHaveBeenCalledWith(existing);
+	});
+
+	it("creates a right-sidebar leaf when none exists, then reveals it", async () => {
+		const { plugin, workspace, rightLeaf } = setupPlugin();
+
+		await plugin.activateView();
+
+		expect(workspace.getRightLeaf).toHaveBeenCalledWith(false);
+		expect(rightLeaf?.setViewState).toHaveBeenCalledWith({
+			type: VIEW_TYPE,
+			active: true,
+		});
+		expect(workspace.revealLeaf).toHaveBeenCalledWith(rightLeaf);
+	});
+
+	it("does not throw or reveal when no right leaf is available", async () => {
+		const { plugin, workspace } = setupPlugin({ rightLeaf: null });
+
+		await expect(plugin.activateView()).resolves.toBeUndefined();
+		expect(workspace.revealLeaf).not.toHaveBeenCalled();
+	});
+});

--- a/src/main.activateView.test.ts
+++ b/src/main.activateView.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PodNotes from "./main";
 import { VIEW_TYPE } from "./constants";
 
@@ -69,5 +69,98 @@ describe("PodNotes.activateView", () => {
 
 		await expect(plugin.activateView()).resolves.toBeUndefined();
 		expect(workspace.revealLeaf).not.toHaveBeenCalled();
+	});
+});
+
+// Locks the actual #55 wiring (not just activateView's internals): the
+// "Show PodNotes" command must stay always-available (a plain callback, never
+// a leaf-gated checkCallback) and the ribbon icon must route to activateView.
+// A refactor that reintroduced the old checkCallback gate or unwired the ribbon
+// would reproduce the bug while activateView's own unit tests stayed green.
+describe("PodNotes onload wiring (#55)", () => {
+	// onload() wires real module-level stores to controllers; unload them after
+	// each test so leaked subscriptions don't fire into a disposed plugin.
+	const loaded: PodNotes[] = [];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		for (const p of loaded.splice(0)) {
+			p.onunload();
+		}
+		vi.restoreAllMocks();
+	});
+
+	async function loadPlugin() {
+		const activateSpy = vi
+			.spyOn(PodNotes.prototype, "activateView")
+			.mockResolvedValue(undefined);
+
+		const commands: Array<Record<string, unknown>> = [];
+		const ribbonCalls: Array<{
+			icon: string;
+			title: string;
+			handler: (evt: unknown) => unknown;
+		}> = [];
+
+		const plugin = Object.create(PodNotes.prototype) as PodNotes;
+		Object.assign(plugin, {
+			loadData: vi.fn().mockResolvedValue({}),
+			saveData: vi.fn().mockResolvedValue(undefined),
+			addCommand: vi.fn((cmd: Record<string, unknown>) => {
+				commands.push(cmd);
+				return cmd;
+			}),
+			addRibbonIcon: vi.fn(
+				(icon: string, title: string, handler: (evt: unknown) => unknown) => {
+					ribbonCalls.push({ icon, title, handler });
+					return document.createElement("div");
+				},
+			),
+			addSettingTab: vi.fn(),
+			registerView: vi.fn(),
+			registerObsidianProtocolHandler: vi.fn(),
+			registerEvent: vi.fn(),
+			app: {
+				workspace: {
+					onLayoutReady: vi.fn(),
+					on: vi.fn(() => ({})),
+					getLeavesOfType: vi.fn(() => []),
+					getRightLeaf: vi.fn(() => null),
+					revealLeaf: vi.fn(),
+					detachLeavesOfType: vi.fn(),
+				},
+			},
+		});
+
+		await plugin.onload();
+		loaded.push(plugin);
+
+		return { commands, ribbonCalls, activateSpy };
+	}
+
+	it("registers Show PodNotes as an always-available callback, not a leaf-gated checkCallback", async () => {
+		const { commands } = await loadPlugin();
+
+		const showCmd = commands.find((c) => c.id === "podnotes-show-leaf");
+		expect(showCmd).toBeDefined();
+		expect(typeof showCmd?.callback).toBe("function");
+		expect(showCmd?.checkCallback).toBeUndefined();
+	});
+
+	it("Show PodNotes command and ribbon icon both route to activateView", async () => {
+		const { commands, ribbonCalls, activateSpy } = await loadPlugin();
+
+		const showCmd = commands.find((c) => c.id === "podnotes-show-leaf");
+		(showCmd?.callback as () => void)();
+		expect(activateSpy).toHaveBeenCalledTimes(1);
+
+		const ribbon = ribbonCalls.find((r) => r.title === "Show PodNotes");
+		expect(ribbon).toBeDefined();
+		expect(ribbon?.icon).toBe("podcast");
+		ribbon?.handler(new MouseEvent("click"));
+		expect(activateSpy).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,14 +155,13 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			id: "podnotes-show-leaf",
 			name: "Show PodNotes",
 			icon: "podcast" as IconType,
-			checkCallback: (checking: boolean) => {
-				if (checking) {
-					return !this.app.workspace.getLeavesOfType(VIEW_TYPE).length;
-				}
-
-				this.app.workspace.getRightLeaf(false)?.setViewState({
-					type: VIEW_TYPE,
-				});
+			// Always available, and always reveals the view. The previous
+			// checkCallback hid this command whenever a leaf already existed, so
+			// once the view was open-but-hidden (collapsed sidebar, sidebar
+			// overflow, dragged out of sight) there was no way to bring it back
+			// (#55). activateView reuses the existing leaf and reveals it.
+			callback: () => {
+				void this.activateView();
 			},
 		});
 
@@ -377,6 +376,14 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			return this.view;
 		});
 
+		// Persistent, discoverable entry point in the left ribbon. The right
+		// sidebar header can overflow and hide the view's tab icon (the original
+		// report in #55), but the ribbon is always reachable, so users can always
+		// reopen PodNotes.
+		this.addRibbonIcon("podcast" as IconType, "Show PodNotes", () => {
+			void this.activateView();
+		});
+
 		this.app.workspace.onLayoutReady(this.onLayoutReady.bind(this));
 
 		this.registerObsidianProtocolHandler("podnotes", (action) =>
@@ -412,6 +419,26 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			leaf.setViewState({
 				type: VIEW_TYPE,
 			});
+		}
+	}
+
+	// Reveal the PodNotes view, creating its leaf when needed. Reusing an
+	// existing leaf (instead of gating on its absence) plus revealLeaf is what
+	// makes "Show PodNotes" and the ribbon icon reliably surface the view even
+	// when it is already open but hidden in a collapsed/overflowing sidebar (#55).
+	async activateView(): Promise<void> {
+		const { workspace } = this.app;
+
+		const existing = workspace.getLeavesOfType(VIEW_TYPE);
+		let leaf: WorkspaceLeaf | null = existing[0] ?? null;
+
+		if (!leaf) {
+			leaf = workspace.getRightLeaf(false);
+			await leaf?.setViewState({ type: VIEW_TYPE, active: true });
+		}
+
+		if (leaf) {
+			await workspace.revealLeaf(leaf);
 		}
 	}
 


### PR DESCRIPTION
## What & why

Fixes #55. For some users the PodNotes pane never appears, and once the view exists but is hidden there was no way to bring it back.

Reproduced in real Obsidian (this checkout's build, isolated vault):

| State | `Show PodNotes` in palette | After invoking | Result |
|---|---|---|---|
| Leaf exists, sidebar collapsed (the reported case) | **Unavailable** | sidebar **stays collapsed** | view never shown |
| No leaf, sidebar collapsed | available | leaf created but sidebar **stays collapsed** | view never shown |

Root cause in `src/main.ts`:

- The `Show PodNotes` command used a `checkCallback` that returned `false` (hiding the command) whenever a leaf of the view type already existed. So once the view was open-but-hidden (collapsed sidebar, right-sidebar icon overflow, dragged out of sight), the command disappeared from the palette and did nothing when bound to a hotkey.
- Even when it ran, it called `setViewState` but never `revealLeaf`, so the leaf was never surfaced.
- There was no ribbon icon, so the only entry point was the overflow-prone right-sidebar header — exactly the scenario in the original report.

## Change

- Add `activateView()`: reuse an existing leaf when present, otherwise create one in the right sidebar, then **always `revealLeaf`** it.
- Switch `Show PodNotes` from `checkCallback` to a plain, always-available `callback` that calls `activateView()` — so it works from the palette and as a hotkey regardless of current state.
- Add a left-ribbon **podcast** icon ("Show PodNotes") as a persistent, overflow-proof entry point (addresses the sidebar-overflow hypothesis from the issue thread).
- `onLayoutReady` is unchanged: startup still creates the leaf without force-revealing, so launches stay non-intrusive.
- Update `docs/docs/commands.md`.

## Verification

Real Obsidian (isolated worktree vault), after the fix:

- Leaf exists + collapsed sidebar → `activateView()` reuses the leaf and reveals it (`rightCollapsed: true → false`, leaf count stays 1).
- No leaf + collapsed sidebar → creates **and** reveals (leaf count 1, `rightCollapsed: false`).
- Ribbon **podcast** icon now present in the left ribbon; the `Show PodNotes` command is always available in the palette.
- Sequential **and** concurrent double-activation both converge to exactly 1 leaf (no duplicate-leaf race); `onunload` still detaches leaves on disable/enable.

Gates (Node 22): `lint` clean · `format:check` clean · `typecheck` clean · `check:a11y` 0 errors/0 warnings · `build` ok · `test` **458 passed**, including new `src/main.activateView.test.ts` (activateView reuse/reveal/null-safety + an `onload` wiring test that locks the command-is-a-callback-not-checkCallback and ribbon→activateView regression).

## Review

Ran a deep correctness/security pass plus two adversarial reviewers (incompleteness + regression lenses), each finding adversarially verified. No blockers; the two confirmed nits are folded into the second commit:
- a wiring test that locks the actual gate-removal/ribbon regression (not just `activateView`'s internals), and
- softened ribbon docs (the icon is hideable via *Manage ribbon actions* and lives in the ribbon menu on mobile).

## Visible change

A **podcast icon in the left ribbon** (label "Show PodNotes"). Clicking it — or running the command, or its hotkey — reliably reveals the PodNotes pane, including when it is already open but hidden.

## Scope note

This targets the reproducible failure mode: discoverability and reliably revealing the view. The 2023 report also mentioned choppy direct-file playback with no controls; that predates the Svelte 5 view rewrite and isn't reproducible on current master, so it's out of scope here.
