### PR TITLE
feat(player): scale episode title font size to its length (#81)

### DIFF
--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -54,6 +54,9 @@
 	$: showQueue =
 		$plugin?.settings?.autoQueue !== false || $queue.episodes.length > 0;
 
+	// Title length feeds the CSS length-based downscaling on .podcast-title (issue #81).
+	$: titleCharCount = $currentEpisode?.title?.length ?? 0;
+
 	let isHoveringArtwork: boolean = false;
 	let isLoading: boolean = true;
 	let playerVolume: number = 1;
@@ -364,7 +367,7 @@
 		</button>
 	</div>
 
-	<h2 class="podcast-title">{$currentEpisode.title}</h2>
+	<h2 class="podcast-title" style="--title-char-count: {titleCharCount}">{$currentEpisode.title}</h2>
 
 	{#await srcPromise then src}
 		<audio
@@ -544,7 +547,21 @@
 	}
 
 	.podcast-title {
-		font-size: 1.125rem;
+		/*
+		 * Scale the title down as it gets longer (issue #81) so a long episode
+		 * title no longer renders at one large fixed size. Titles up to ~40
+		 * characters render at the 1rem base; beyond that the size eases down
+		 * (0.0025rem per extra character) toward a readable 0.875rem floor,
+		 * reached around ~90 characters. --title-char-count is an approximate
+		 * length signal (UTF-16 code units, set from the title in the markup), so
+		 * it only loosely tracks rendered width for non-Latin scripts;
+		 * word-break: break-word below is what actually keeps any title contained.
+		 */
+		font-size: clamp(
+			0.875rem,
+			calc(1rem - (var(--title-char-count, 0) - 40) * 0.0025rem),
+			1rem
+		);
 		font-weight: 600;
 		line-height: 1.4;
 		margin: 0 0 0.75rem;


### PR DESCRIPTION
## Summary

The player rendered every episode title at a fixed `1.125rem`, so long podcast titles dominated the player pane (issue #81). This reduces the base size to `1rem` and eases the title size down as the title grows, toward a readable `0.875rem` floor, so short titles stay comfortable and long ones stay contained.

## How it works

The episode title length feeds a `--title-char-count` CSS custom property on the `.podcast-title` heading, and the font size is a `clamp()`:

```css
font-size: clamp(
  0.875rem,
  calc(1rem - (var(--title-char-count, 0) - 40) * 0.0025rem),
  1rem
);
```

- Titles up to ~40 characters render at the `1rem` base.
- Beyond that, the size eases down 0.0025rem per extra character.
- It bottoms out at a readable `0.875rem` floor, reached around ~90 characters.

`--title-char-count` is an approximate length signal (UTF-16 code units), so it only loosely tracks rendered width for non-Latin scripts. The existing `word-break: break-word` remains the actual mechanism that keeps any title contained.

## Verification

Runtime checked in a real Obsidian instance (isolated worktree vault) with the production bundle. Measured computed `font-size` on `.podcast-title`:

| Title length | Computed size |
| --- | --- |
| 17 chars | 16px (1rem base) |
| 47 chars | 15.72px (eased) |
| 137 chars | 14px (0.875rem floor) |

The long title wrapped cleanly across lines, stayed centered, and did not overflow the pane.

Local gates (Node 22):

- `npm run lint` pass
- `npm run format:check` pass
- `npm run typecheck` pass
- `npm run check:a11y` pass (0 errors, 0 warnings)
- `npm run build` pass
- `npm run test` pass (486 tests)

(`docs:build` not run: no user-facing docs impact for a visual sizing change.)

## Review

Reviewed with a multi-agent pass plus two adversarial reviewers on the opposing model. No correctness or accessibility blockers were found. Acted-on feedback: dropped the overstated "never overflow" wording in favor of an honest note that `word-break` is the containment backstop, removed a duplicate comment block, and kept the heading markup on a single line to match the rest of the file.

Closes #81
