### PR TITLE
feat(transcripts): opt-in speaker diarization for transcripts (#168)

### DIFF
--- a/docs/docs/transcripts.md
+++ b/docs/docs/transcripts.md
@@ -30,9 +30,9 @@ The transcript template works similarly to the [note template](./templates.md#no
 By default the transcription uses OpenAI's Whisper model, which produces plain text with **no speaker labels**. Speaker diarization is an opt-in setting that instead labels each segment of the transcript by speaker, e.g.:
 
 ```
-**Speaker A:** Welcome to the show.
+**A:** Welcome to the show.
 
-**Speaker B:** Thanks for having me.
+**B:** Thanks for having me.
 ```
 
 ### Enabling it
@@ -51,7 +51,7 @@ The **Speaker label format** setting controls the prefix added before each speak
 - OpenAI labels speakers `A`, `B`, `C`, …
 - Deepgram labels speakers `1`, `2`, `3`, …
 
-The default is `**{{speaker}}:** `, which renders as `**Speaker A:**`-style bold prefixes. For example, `> {{speaker}}: ` would put each turn in a blockquote.
+The default is `**{{speaker}}:** `, which renders as `**A:**`-style bold prefixes. To spell out the word "Speaker", set it to `**Speaker {{speaker}}:** ` (rendering `**Speaker A:**`); `> {{speaker}}: ` would instead put each turn in a blockquote.
 
 The labelled transcript replaces the usual `{{transcript}}` value in your [transcript template](#transcript-template), so you don't need to change your template to use diarization.
 

--- a/docs/docs/transcripts.md
+++ b/docs/docs/transcripts.md
@@ -24,3 +24,37 @@ To create a transcript:
 ## Transcript Template
 
 The transcript template works similarly to the [note template](./templates.md#note-template), but with the added `{{template}}` placeholder.
+
+## Speaker Diarization
+
+By default the transcription uses OpenAI's Whisper model, which produces plain text with **no speaker labels**. Speaker diarization is an opt-in setting that instead labels each segment of the transcript by speaker, e.g.:
+
+```
+**Speaker A:** Welcome to the show.
+
+**Speaker B:** Thanks for having me.
+```
+
+### Enabling it
+
+In the **Transcript settings** section, turn on **Speaker diarization** and choose a provider:
+
+- **OpenAI** (`gpt-4o-transcribe-diarize`): reuses the OpenAI API key you already entered above, so there is nothing else to configure. Because OpenAI caps each request at 25 MB, a long episode is split into chunks that are diarized independently — so on long episodes the speaker labels can change across chunk boundaries (the same person may be labelled `A` in one chunk and `B` in the next). A typical-length episode fits in a single request and is fully consistent.
+- **Deepgram**: sends the whole episode in one request, so speaker labels stay consistent across the entire episode. This requires a separate **Deepgram API key**, which you can create at [deepgram.com](https://deepgram.com) (new accounts include free credit). Your Deepgram key is stored separately from your OpenAI key and is only used for diarization.
+
+Diarization is off by default, so existing transcripts and the plain-Whisper workflow are unchanged unless you enable it.
+
+### Speaker label format
+
+The **Speaker label format** setting controls the prefix added before each speaker's turn. Use the `{{speaker}}` placeholder for the speaker's label:
+
+- OpenAI labels speakers `A`, `B`, `C`, …
+- Deepgram labels speakers `1`, `2`, `3`, …
+
+The default is `**{{speaker}}:** `, which renders as `**Speaker A:**`-style bold prefixes. For example, `> {{speaker}}: ` would put each turn in a blockquote.
+
+The labelled transcript replaces the usual `{{transcript}}` value in your [transcript template](#transcript-template), so you don't need to change your template to use diarization.
+
+### Cost
+
+Diarization providers bill per minute/hour of audio (separately from any plain-Whisper usage). As of mid-2026, OpenAI's diarize model is roughly $0.006 per minute, and Deepgram's diarized pre-recorded transcription is roughly $0.0068 per minute. Check each provider's current pricing before transcribing long back-catalogues.

--- a/scripts/provision-obsidian-e2e-vault.mjs
+++ b/scripts/provision-obsidian-e2e-vault.mjs
@@ -99,10 +99,16 @@ export const DEFAULT_PODNOTES_DATA = {
 		episodes: [],
 	},
 	openAIApiKey: "",
+	diarizationApiKey: "",
 	transcript: {
 		path: "transcripts/{{podcast}}/{{title}}.md",
 		template:
 			"# {{title}}\n\nPodcast: {{podcast}}\nDate: {{date}}\n\n{{transcript}}",
+		diarization: {
+			enabled: false,
+			provider: "openai",
+			speakerTemplate: "**{{speaker}}:** ",
+		},
 	},
 	feedCache: {
 		enabled: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import type { IPodNotesSettings } from "src/types/IPodNotesSettings";
 import type { Playlist } from "./types/Playlist";
+import { DEFAULT_SPEAKER_TEMPLATE } from "./services/diarization/segments";
 
 export const VIEW_TYPE = "podcast_player_view";
 
@@ -154,10 +155,18 @@ export const DEFAULT_SETTINGS: IPodNotesSettings = {
 		episodes: [],
 	},
 	openAIApiKey: "",
+	diarizationApiKey: "",
 	transcript: {
 		path: "transcripts/{{podcast}}/{{title}}.md",
 		template:
 			"# {{title}}\n\nPodcast: {{podcast}}\nDate: {{date}}\n\n{{transcript}}",
+		// Diarization is off by default so existing behaviour (plain Whisper) is
+		// unchanged; enabling it routes audio to the chosen provider (#168).
+		diarization: {
+			enabled: false,
+			provider: "openai",
+			speakerTemplate: DEFAULT_SPEAKER_TEMPLATE,
+		},
 	},
 	feedCache: {
 		enabled: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,9 @@ import { DEFAULT_SETTINGS, VIEW_TYPE } from "src/constants";
 import {
 	migrateDownloadPath,
 	migrateNoteSettings,
+	migrateTranscriptSettings,
 } from "src/settingsMigrations";
+import { requiredTranscriptionKeyPresent } from "src/services/diarization";
 import { PodNotesSettingsTab } from "src/ui/settings/PodNotesSettingsTab";
 import { MainView } from "src/ui/PodcastView";
 import { QueueReorderModal } from "src/ui/QueueReorderModal";
@@ -482,7 +484,8 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			name: "Transcribe current episode",
 			checkCallback: (checking) => {
 				const canTranscribe =
-					!!this.api.podcast && !!this.settings.openAIApiKey?.trim();
+					!!this.api.podcast &&
+					requiredTranscriptionKeyPresent(this.settings);
 
 				if (checking) {
 					return canTranscribe;
@@ -721,6 +724,12 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		// default, preserving any path/template the user configured (#160). Returns
 		// a fresh object, so DEFAULT_SETTINGS.note is never mutated.
 		this.settings.note = migrateNoteSettings(loadedData?.note);
+		// Backfill the diarization defaults onto the stored transcript object so an
+		// existing user (who has only { path, template } persisted) gets a valid
+		// transcript.diarization instead of undefined (#168).
+		this.settings.transcript = migrateTranscriptSettings(
+			loadedData?.transcript,
+		);
 	}
 
 	async saveSettings() {

--- a/src/services/TranscriptionService.test.ts
+++ b/src/services/TranscriptionService.test.ts
@@ -300,4 +300,49 @@ describe("TranscriptionService", () => {
 			await service.transcribeCurrentEpisode();
 		});
 	});
+
+	describe("createChunkFiles small-file fast path (#168 / PR #204 review)", () => {
+		type ChunkFn = (args: {
+			buffer: ArrayBuffer;
+			basename: string;
+			extension: string;
+			mimeType: string;
+		}) => Promise<File[]>;
+
+		function createChunkFiles(): ChunkFn {
+			const service = new TranscriptionService(createMockPlugin());
+			return (service as unknown as { createChunkFiles: ChunkFn })
+				.createChunkFiles.bind(service);
+		}
+
+		test("sends a small m4a as a single original file instead of WAV-splitting it", async () => {
+			// A 1 KB m4a is well under the 20 MB chunk size, so it must not be
+			// converted to WAV (which would balloon it into many chunks and reset
+			// diarization speaker labels). It should be one intact .m4a file.
+			const files = await createChunkFiles()({
+				buffer: new ArrayBuffer(1024),
+				basename: "episode",
+				extension: "m4a",
+				mimeType: "audio/mp4",
+			});
+
+			expect(files).toHaveLength(1);
+			expect(files[0].name).toBe("episode.m4a");
+			expect(files[0].type).toBe("audio/mp4");
+			expect(files[0].name).not.toContain(".wav");
+		});
+
+		test("still sends a small mp3 as a single original file (unchanged)", async () => {
+			const files = await createChunkFiles()({
+				buffer: new ArrayBuffer(2048),
+				basename: "episode",
+				extension: "mp3",
+				mimeType: "audio/mpeg",
+			});
+
+			expect(files).toHaveLength(1);
+			expect(files[0].name).toBe("episode.mp3");
+			expect(files[0].size).toBe(2048);
+		});
+	});
 });

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -12,6 +12,15 @@ import {
 } from "../utility/enforceMaxPathLength";
 import { ensureFolderExists } from "../utility/ensureFolderExists";
 import type { Episode } from "src/types/Episode";
+import {
+	type DiarizationAudio,
+	type DiarizationProviderId,
+	type DiarizedSegment,
+	diarizeWithDeepgram,
+	diarizeWithOpenAI,
+	renderDiarizedTranscript,
+	requiredTranscriptionKeyPresent,
+} from "./diarization";
 
 function TimerNotice(heading: string, initialMessage: string) {
 	let currentMessage = initialMessage;
@@ -71,9 +80,14 @@ export class TranscriptionService {
 	}
 
 	async transcribeCurrentEpisode(): Promise<void> {
-		if (!this.plugin.settings.openAIApiKey?.trim()) {
+		if (!requiredTranscriptionKeyPresent(this.plugin.settings)) {
+			const diarization = this.plugin.settings.transcript.diarization;
+			const needsDeepgram =
+				diarization?.enabled && diarization.provider === "deepgram";
 			new Notice(
-				"Please add your OpenAI API key in the transcript settings first.",
+				needsDeepgram
+					? "Please add your Deepgram API key in the transcript settings to use Deepgram diarization."
+					: "Please add your OpenAI API key in the transcript settings first.",
 			);
 			return;
 		}
@@ -162,19 +176,18 @@ export class TranscriptionService {
 			} = await getEpisodeAudioBuffer(episode);
 			const mimeType = this.getMimeType(fileExtension);
 
-			notice.update("Creating audio chunks...");
-			const files = await this.createChunkFiles({
-				buffer: fileBuffer,
-				basename,
-				extension: fileExtension,
-				mimeType,
-			});
-
-			notice.update("Starting transcription...");
-			const transcription = await this.transcribeChunks(files, notice.update);
+			const transcriptBody = await this.buildTranscriptBody(
+				{
+					buffer: fileBuffer,
+					mimeType,
+					extension: fileExtension,
+					basename,
+				},
+				notice.update,
+			);
 
 			notice.update("Saving transcription...");
-			await this.saveTranscription(episode, transcription);
+			await this.saveTranscription(episode, transcriptBody);
 
 			notice.stop();
 			notice.update("Transcription completed and saved.");
@@ -187,6 +200,71 @@ export class TranscriptionService {
 			notice.stop();
 			setTimeout(() => notice.hide(), 5000);
 		}
+	}
+
+	/**
+	 * Produce the transcript body that fills the template's `{{transcript}}` tag.
+	 * Plain Whisper returns one run-on block, so it is reflowed after sentence
+	 * periods for readability; diarization returns speaker-labeled turns already
+	 * separated into paragraphs, so it is rendered as-is. Diarization that yields
+	 * no speech is treated as a failure rather than writing an empty transcript.
+	 */
+	private async buildTranscriptBody(
+		audio: DiarizationAudio,
+		updateNotice: (message: string) => void,
+	): Promise<string> {
+		const diarization = this.plugin.settings.transcript.diarization;
+
+		if (diarization?.enabled) {
+			const segments = await this.diarize(
+				audio,
+				diarization.provider,
+				updateNotice,
+			);
+			if (segments.length === 0) {
+				throw new Error("Diarization returned no speech segments.");
+			}
+			return renderDiarizedTranscript(segments, diarization.speakerTemplate);
+		}
+
+		updateNotice("Creating audio chunks...");
+		const files = await this.createChunkFiles(audio);
+		updateNotice("Starting transcription...");
+		const transcription = await this.transcribeChunks(files, updateNotice);
+		return transcription.replace(/\.\s+/g, ".\n\n");
+	}
+
+	/** Route the episode audio to the configured diarization provider (#168). */
+	private async diarize(
+		audio: DiarizationAudio,
+		provider: DiarizationProviderId,
+		updateNotice: (message: string) => void,
+	): Promise<DiarizedSegment[]> {
+		if (provider === "deepgram") {
+			const apiKey = this.plugin.settings.diarizationApiKey?.trim();
+			if (!apiKey) {
+				throw new Error("Missing Deepgram API key for diarization.");
+			}
+			// Deepgram ingests the whole file in one request, so it needs no
+			// chunking — which is exactly why its speaker labels stay consistent
+			// across the entire episode.
+			return diarizeWithDeepgram({
+				audio,
+				apiKey,
+				onProgress: updateNotice,
+			});
+		}
+
+		// OpenAI diarization shares Whisper's 25 MB/request cap, so reuse the same
+		// chunking. Speaker labels can differ across chunks on a long episode.
+		updateNotice("Creating audio chunks...");
+		const chunkFiles = await this.createChunkFiles(audio);
+		return diarizeWithOpenAI({
+			getClient: () => this.getClient(),
+			chunkFiles,
+			maxRetries: this.MAX_RETRIES,
+			onProgress: updateNotice,
+		});
 	}
 
 	private async createChunkFiles({
@@ -486,14 +564,16 @@ export class TranscriptionService {
 
 	private async saveTranscription(
 		episode: Episode,
-		transcription: string,
+		transcriptBody: string,
 	): Promise<void> {
 		const transcriptPath = this.getTranscriptPath(episode);
-		const formattedTranscription = transcription.replace(/\.\s+/g, ".\n\n");
+		// transcriptBody is already formatted by buildTranscriptBody (sentence
+		// reflow for Whisper, speaker turns for diarization), so it is templated
+		// verbatim here.
 		const transcriptContent = TranscriptTemplateEngine(
 			this.plugin.settings.transcript.template,
 			episode,
-			formattedTranscription,
+			transcriptBody,
 		);
 
 		const vault = this.plugin.app.vault;

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -278,6 +278,19 @@ export class TranscriptionService {
 		extension: string;
 		mimeType: string;
 	}): Promise<File[]> {
+		// A file that already fits in a single request needs neither conversion nor
+		// splitting: send the original (compressed) bytes. OpenAI accepts m4a/mp3/etc.
+		// directly under the upload limit, so this skips the m4a->WAV path below for
+		// small m4a episodes — that path only exists to SAFELY SPLIT an m4a (which
+		// can't be byte-split) and would otherwise balloon a small m4a into many
+		// uncompressed WAV chunks, multiplying requests and, for diarization,
+		// resetting speaker labels at artificial chunk boundaries (#168 / PR #204 review).
+		if (buffer.byteLength <= this.CHUNK_SIZE_BYTES) {
+			return [
+				new File([buffer], `${basename}.${extension}`, { type: mimeType }),
+			];
+		}
+
 		if (this.shouldConvertToWav(extension, mimeType)) {
 			const wavChunks = await this.convertToWavChunks(buffer, basename);
 			if (wavChunks.length > 0) {

--- a/src/services/diarization/deepgramProvider.test.ts
+++ b/src/services/diarization/deepgramProvider.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { diarizeWithDeepgram, type RequestUrlFn } from "./deepgramProvider";
+import type { DiarizationAudio } from "./types";
+
+const audio: DiarizationAudio = {
+	buffer: new ArrayBuffer(8),
+	mimeType: "audio/mpeg",
+	extension: "mp3",
+	basename: "episode",
+};
+
+function stubResponse(
+	overrides: Partial<{ status: number; json: unknown; text: string }>,
+) {
+	return {
+		status: 200,
+		json: {},
+		text: "",
+		arrayBuffer: new ArrayBuffer(0),
+		headers: {},
+		...overrides,
+	} as unknown as Awaited<ReturnType<RequestUrlFn>>;
+}
+
+describe("diarizeWithDeepgram (#168)", () => {
+	it("posts the whole audio buffer with token auth and parses the response", async () => {
+		const request = vi.fn<RequestUrlFn>().mockResolvedValue(
+			stubResponse({
+				json: {
+					results: {
+						utterances: [
+							{ speaker: 0, transcript: "Hello.", start: 0, end: 1 },
+							{ speaker: 1, transcript: "Hi.", start: 1, end: 2 },
+						],
+					},
+				},
+			}),
+		);
+
+		const segments = await diarizeWithDeepgram({
+			audio,
+			apiKey: "dg-key",
+			onProgress: () => {},
+			request,
+		});
+
+		expect(segments).toEqual([
+			{ speaker: "1", text: "Hello.", start: 0, end: 1 },
+			{ speaker: "2", text: "Hi.", start: 1, end: 2 },
+		]);
+
+		const call = request.mock.calls[0][0];
+		expect(call.method).toBe("POST");
+		expect(call.url).toContain("api.deepgram.com/v1/listen");
+		expect(call.url).toContain("diarize=true");
+		expect(call.headers.Authorization).toBe("Token dg-key");
+		expect(call.contentType).toBe("audio/mpeg");
+		expect(call.body).toBe(audio.buffer);
+	});
+
+	it("throws a helpful error on a non-2xx response", async () => {
+		const request = vi.fn<RequestUrlFn>().mockResolvedValue(
+			stubResponse({ status: 401, json: { err_msg: "Invalid credentials" } }),
+		);
+
+		await expect(
+			diarizeWithDeepgram({
+				audio,
+				apiKey: "bad",
+				onProgress: () => {},
+				request,
+			}),
+		).rejects.toThrow(/HTTP 401.*Invalid credentials/);
+	});
+});

--- a/src/services/diarization/deepgramProvider.ts
+++ b/src/services/diarization/deepgramProvider.ts
@@ -1,0 +1,79 @@
+import { requestUrl, type RequestUrlResponse } from "obsidian";
+import type { DiarizationAudio, DiarizedSegment } from "./types";
+import { parseDeepgramSegments } from "./segments";
+
+/** The injectable shape of Obsidian's `requestUrl` (so tests can stub the network). */
+export type RequestUrlFn = (params: {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	contentType: string;
+	body: ArrayBuffer;
+	throw: boolean;
+}) => Promise<RequestUrlResponse>;
+
+const DEEPGRAM_LISTEN_URL = "https://api.deepgram.com/v1/listen";
+
+/**
+ * Query params for the pre-recorded request. `diarize=true` is the broadly
+ * available diarizer; `smart_format`/`punctuate` make the text readable and
+ * `utterances=true` returns ready-made speaker turns the parser prefers. Sent as
+ * a single whole-file request, so speaker identity stays consistent across the
+ * entire episode (no cross-chunk drift).
+ */
+const DEEPGRAM_QUERY =
+	"model=nova-3&diarize=true&punctuate=true&smart_format=true&utterances=true";
+
+/**
+ * Diarize with Deepgram's pre-recorded speech-to-text API (issue #168).
+ *
+ * Posts the whole original (compressed) audio in one synchronous request via
+ * Obsidian's `requestUrl` (which bypasses CORS and works on mobile). No chunking
+ * is needed — Deepgram accepts large files server-side — which is exactly why
+ * its speaker labels stay consistent for the full episode.
+ */
+export async function diarizeWithDeepgram(opts: {
+	audio: DiarizationAudio;
+	apiKey: string;
+	onProgress: (message: string) => void;
+	request?: RequestUrlFn;
+}): Promise<DiarizedSegment[]> {
+	const { audio, apiKey, onProgress } = opts;
+	const request = opts.request ?? (requestUrl as unknown as RequestUrlFn);
+
+	onProgress("Diarizing with Deepgram...");
+
+	const response = await request({
+		url: `${DEEPGRAM_LISTEN_URL}?${DEEPGRAM_QUERY}`,
+		method: "POST",
+		headers: { Authorization: `Token ${apiKey}` },
+		contentType: audio.mimeType,
+		body: audio.buffer,
+		throw: false,
+	});
+
+	if (response.status < 200 || response.status >= 300) {
+		const detail = extractDeepgramError(response);
+		console.error("Deepgram diarization request failed:", response.status, detail);
+		throw new Error(
+			`Deepgram request failed (HTTP ${response.status})${detail ? `: ${detail}` : ""}`,
+		);
+	}
+
+	return parseDeepgramSegments(response.json);
+}
+
+/** Pull a human-readable message out of Deepgram's error body, if any. */
+function extractDeepgramError(response: RequestUrlResponse): string {
+	try {
+		const body = response.json as unknown;
+		if (body && typeof body === "object") {
+			const record = body as Record<string, unknown>;
+			const message = record.err_msg ?? record.message ?? record.reason;
+			if (typeof message === "string") return message;
+		}
+	} catch {
+		// Non-JSON error body; fall back to the raw text below.
+	}
+	return typeof response.text === "string" ? response.text.slice(0, 200) : "";
+}

--- a/src/services/diarization/index.ts
+++ b/src/services/diarization/index.ts
@@ -1,0 +1,25 @@
+import type { IPodNotesSettings } from "src/types/IPodNotesSettings";
+
+export * from "./types";
+export * from "./segments";
+export { diarizeWithOpenAI } from "./openaiProvider";
+export { diarizeWithDeepgram, type RequestUrlFn } from "./deepgramProvider";
+
+/**
+ * Whether the credentials the active transcription mode needs are present.
+ *
+ * Diarization via Deepgram needs the dedicated `diarizationApiKey`; every other
+ * mode (plain Whisper, or OpenAI diarization) reuses `openAIApiKey`. Used to gate
+ * the transcribe command and guard the service so a user can't kick off a run
+ * that is certain to fail for a missing key. Pure so it is unit-testable and
+ * usable from both the command callback and the service.
+ */
+export function requiredTranscriptionKeyPresent(
+	settings: IPodNotesSettings,
+): boolean {
+	const diarization = settings.transcript?.diarization;
+	if (diarization?.enabled && diarization.provider === "deepgram") {
+		return Boolean(settings.diarizationApiKey?.trim());
+	}
+	return Boolean(settings.openAIApiKey?.trim());
+}

--- a/src/services/diarization/openaiProvider.test.ts
+++ b/src/services/diarization/openaiProvider.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenAI } from "openai";
+import { diarizeWithOpenAI } from "./openaiProvider";
+
+function fakeClient(create: ReturnType<typeof vi.fn>): () => Promise<OpenAI> {
+	return async () =>
+		({ audio: { transcriptions: { create } } }) as unknown as OpenAI;
+}
+
+function chunk(name: string): File {
+	return new File([new ArrayBuffer(8)], name, { type: "audio/mpeg" });
+}
+
+const diarized = (speaker: string, text: string) => ({
+	segments: [{ type: "transcript.text.segment", id: "1", speaker, start: 0, end: 1, text }],
+});
+
+describe("diarizeWithOpenAI (#168)", () => {
+	it("concatenates parsed segments across chunks in order", async () => {
+		const create = vi
+			.fn()
+			.mockResolvedValueOnce(diarized("A", "First."))
+			.mockResolvedValueOnce(diarized("B", "Second."));
+
+		const segments = await diarizeWithOpenAI({
+			getClient: fakeClient(create),
+			chunkFiles: [chunk("a.mp3"), chunk("b.mp3")],
+			maxRetries: 2,
+			onProgress: () => {},
+		});
+
+		expect(segments).toEqual([
+			{ speaker: "A", text: "First.", start: 0, end: 1 },
+			{ speaker: "B", text: "Second.", start: 0, end: 1 },
+		]);
+	});
+
+	it("keeps a partial transcript with a marker when only some chunks fail", async () => {
+		const create = vi
+			.fn()
+			.mockResolvedValueOnce(diarized("A", "Good chunk."))
+			.mockRejectedValue(new Error("boom"));
+
+		const segments = await diarizeWithOpenAI({
+			getClient: fakeClient(create),
+			chunkFiles: [chunk("a.mp3"), chunk("b.mp3")],
+			maxRetries: 1,
+			onProgress: () => {},
+		});
+
+		expect(segments).toEqual([
+			{ speaker: "A", text: "Good chunk.", start: 0, end: 1 },
+			{ speaker: "?", text: "[Error diarizing chunk 2]" },
+		]);
+	});
+
+	it("throws (writes no transcript) when every chunk fails", async () => {
+		const create = vi.fn().mockRejectedValue(new Error("invalid api key"));
+
+		await expect(
+			diarizeWithOpenAI({
+				getClient: fakeClient(create),
+				chunkFiles: [chunk("a.mp3"), chunk("b.mp3")],
+				maxRetries: 1,
+				onProgress: () => {},
+			}),
+		).rejects.toThrow(/every chunk: invalid api key/);
+	});
+});

--- a/src/services/diarization/openaiProvider.ts
+++ b/src/services/diarization/openaiProvider.ts
@@ -13,8 +13,11 @@ import { parseOpenAIDiarizedSegments } from "./segments";
  * single-chunk episode (the common case) is fully consistent.
  *
  * Chunks are processed in order and their segments concatenated, so the
- * transcript reads start-to-finish. A chunk that keeps failing contributes an
- * error marker segment rather than aborting the whole transcript.
+ * transcript reads start-to-finish. A single failed chunk contributes an error
+ * marker segment rather than discarding an otherwise-good transcript — but if
+ * EVERY chunk fails (e.g. an invalid key or unsupported model) the function
+ * throws so the caller writes no file and the run stays retryable, instead of
+ * saving a transcript made only of error markers.
  */
 export async function diarizeWithOpenAI(opts: {
 	getClient: () => Promise<OpenAI>;
@@ -25,6 +28,8 @@ export async function diarizeWithOpenAI(opts: {
 	const { getClient, chunkFiles, maxRetries, onProgress } = opts;
 	const client = await getClient();
 	const segments: DiarizedSegment[] = [];
+	let failedChunks = 0;
+	let lastError: unknown;
 
 	for (let index = 0; index < chunkFiles.length; index++) {
 		onProgress(
@@ -44,6 +49,10 @@ export async function diarizeWithOpenAI(opts: {
 					response_format: "diarized_json",
 					chunking_strategy: "auto",
 				});
+				// Each chunk's start/end are relative to that chunk, so the
+				// concatenated segments' timestamps are not episode-absolute. The
+				// rendered transcript does not surface timestamps today; if it ever
+				// does, offset each chunk by the cumulative prior-chunk duration here.
 				segments.push(...parseOpenAIDiarizedSegments(result));
 				break;
 			} catch (error) {
@@ -53,6 +62,8 @@ export async function diarizeWithOpenAI(opts: {
 						`OpenAI diarization failed for chunk ${index} after ${maxRetries} attempts:`,
 						error,
 					);
+					failedChunks++;
+					lastError = error;
 					segments.push({
 						speaker: "?",
 						text: `[Error diarizing chunk ${index + 1}]`,
@@ -62,6 +73,11 @@ export async function diarizeWithOpenAI(opts: {
 				await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
 			}
 		}
+	}
+
+	if (chunkFiles.length > 0 && failedChunks === chunkFiles.length) {
+		const detail = lastError instanceof Error ? lastError.message : String(lastError);
+		throw new Error(`OpenAI diarization failed for every chunk: ${detail}`);
 	}
 
 	return segments;

--- a/src/services/diarization/openaiProvider.ts
+++ b/src/services/diarization/openaiProvider.ts
@@ -1,0 +1,68 @@
+import type { OpenAI } from "openai";
+import { type DiarizedSegment, OPENAI_DIARIZE_MODEL } from "./types";
+import { parseOpenAIDiarizedSegments } from "./segments";
+
+/**
+ * Diarize with OpenAI's `gpt-4o-transcribe-diarize` model (issue #168).
+ *
+ * Reuses the same chunked `File[]` the Whisper path builds because the
+ * transcription endpoint caps a request at 25 MB. `chunking_strategy: "auto"` is
+ * required for audio longer than 30s and lets the model segment within a chunk.
+ * Speaker labels are assigned per request, so on a multi-chunk (long) episode
+ * the labels can differ across chunk boundaries — the caller documents this; a
+ * single-chunk episode (the common case) is fully consistent.
+ *
+ * Chunks are processed in order and their segments concatenated, so the
+ * transcript reads start-to-finish. A chunk that keeps failing contributes an
+ * error marker segment rather than aborting the whole transcript.
+ */
+export async function diarizeWithOpenAI(opts: {
+	getClient: () => Promise<OpenAI>;
+	chunkFiles: File[];
+	maxRetries: number;
+	onProgress: (message: string) => void;
+}): Promise<DiarizedSegment[]> {
+	const { getClient, chunkFiles, maxRetries, onProgress } = opts;
+	const client = await getClient();
+	const segments: DiarizedSegment[] = [];
+
+	for (let index = 0; index < chunkFiles.length; index++) {
+		onProgress(
+			`Diarizing with OpenAI... chunk ${index + 1}/${chunkFiles.length}`,
+		);
+		const file = chunkFiles[index];
+
+		let attempt = 0;
+		while (true) {
+			try {
+				const result = await client.audio.transcriptions.create({
+					model: OPENAI_DIARIZE_MODEL,
+					file,
+					// The SDK types `response_format`/`chunking_strategy` for this model,
+					// but the create() overload returns a union; parse from the raw
+					// payload so we never depend on which arm TS narrows to.
+					response_format: "diarized_json",
+					chunking_strategy: "auto",
+				});
+				segments.push(...parseOpenAIDiarizedSegments(result));
+				break;
+			} catch (error) {
+				attempt++;
+				if (attempt >= maxRetries) {
+					console.error(
+						`OpenAI diarization failed for chunk ${index} after ${maxRetries} attempts:`,
+						error,
+					);
+					segments.push({
+						speaker: "?",
+						text: `[Error diarizing chunk ${index + 1}]`,
+					});
+					break;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+			}
+		}
+	}
+
+	return segments;
+}

--- a/src/services/diarization/requiredTranscriptionKeyPresent.test.ts
+++ b/src/services/diarization/requiredTranscriptionKeyPresent.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "src/constants";
+import type { IPodNotesSettings } from "src/types/IPodNotesSettings";
+import { requiredTranscriptionKeyPresent } from "./index";
+
+function settings(overrides: Partial<IPodNotesSettings> = {}): IPodNotesSettings {
+	return structuredClone({ ...DEFAULT_SETTINGS, ...overrides });
+}
+
+function withDiarization(
+	provider: "openai" | "deepgram",
+	enabled: boolean,
+	keys: { openAIApiKey?: string; diarizationApiKey?: string } = {},
+): IPodNotesSettings {
+	const s = settings(keys);
+	s.transcript.diarization.enabled = enabled;
+	s.transcript.diarization.provider = provider;
+	return s;
+}
+
+describe("requiredTranscriptionKeyPresent (#168)", () => {
+	it("requires the OpenAI key when diarization is off", () => {
+		expect(requiredTranscriptionKeyPresent(settings({ openAIApiKey: "sk" }))).toBe(
+			true,
+		);
+		expect(requiredTranscriptionKeyPresent(settings({ openAIApiKey: "" }))).toBe(
+			false,
+		);
+	});
+
+	it("requires the OpenAI key for the OpenAI diarization provider", () => {
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("openai", true, { openAIApiKey: "sk" }),
+			),
+		).toBe(true);
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("openai", true, {
+					openAIApiKey: "",
+					diarizationApiKey: "dg",
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("requires the Deepgram key for the Deepgram diarization provider", () => {
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("deepgram", true, { diarizationApiKey: "dg" }),
+			),
+		).toBe(true);
+		// An OpenAI key does not satisfy the Deepgram provider.
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("deepgram", true, {
+					openAIApiKey: "sk",
+					diarizationApiKey: "",
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("falls back to the OpenAI key when Deepgram is selected but diarization is off", () => {
+		// provider=deepgram only matters when diarization is enabled.
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("deepgram", false, { openAIApiKey: "sk" }),
+			),
+		).toBe(true);
+	});
+
+	it("treats whitespace-only keys as absent", () => {
+		expect(
+			requiredTranscriptionKeyPresent(settings({ openAIApiKey: "   " })),
+		).toBe(false);
+		expect(
+			requiredTranscriptionKeyPresent(
+				withDiarization("deepgram", true, { diarizationApiKey: "  " }),
+			),
+		).toBe(false);
+	});
+});

--- a/src/services/diarization/segments.test.ts
+++ b/src/services/diarization/segments.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_SPEAKER_TEMPLATE,
+	formatSpeakerLabel,
+	mergeAdjacentSpeakers,
+	parseDeepgramSegments,
+	parseOpenAIDiarizedSegments,
+	renderDiarizedTranscript,
+} from "./segments";
+
+describe("parseOpenAIDiarizedSegments (#168)", () => {
+	it("maps diarized_json segments to normalized turns", () => {
+		const payload = {
+			segments: [
+				{ type: "transcript.text.segment", id: "1", speaker: "A", start: 0, end: 2, text: "Hello there." },
+				{ type: "transcript.text.segment", id: "2", speaker: "B", start: 2, end: 4, text: "Hi!" },
+			],
+		};
+
+		expect(parseOpenAIDiarizedSegments(payload)).toEqual([
+			{ speaker: "A", text: "Hello there.", start: 0, end: 2 },
+			{ speaker: "B", text: "Hi!", start: 2, end: 4 },
+		]);
+	});
+
+	it("merges consecutive same-speaker segments into one turn", () => {
+		const payload = {
+			segments: [
+				{ speaker: "A", start: 0, end: 1, text: "One." },
+				{ speaker: "A", start: 1, end: 2, text: "Two." },
+				{ speaker: "B", start: 2, end: 3, text: "Three." },
+			],
+		};
+
+		expect(parseOpenAIDiarizedSegments(payload)).toEqual([
+			{ speaker: "A", text: "One. Two.", start: 0, end: 2 },
+			{ speaker: "B", text: "Three.", start: 2, end: 3 },
+		]);
+	});
+
+	it("skips empty/malformed entries instead of throwing", () => {
+		const payload = {
+			segments: [
+				{ speaker: "A", text: "  " },
+				null,
+				{ speaker: "A", text: "Real." },
+				{ text: "No speaker field" },
+			],
+		};
+
+		expect(parseOpenAIDiarizedSegments(payload)).toEqual([
+			{ speaker: "A", text: "Real.", start: undefined, end: undefined },
+			{ speaker: "?", text: "No speaker field", start: undefined, end: undefined },
+		]);
+	});
+
+	it("returns [] for non-object or shapeless payloads", () => {
+		expect(parseOpenAIDiarizedSegments(null)).toEqual([]);
+		expect(parseOpenAIDiarizedSegments("nope")).toEqual([]);
+		expect(parseOpenAIDiarizedSegments({})).toEqual([]);
+		expect(parseOpenAIDiarizedSegments({ segments: "x" })).toEqual([]);
+	});
+});
+
+describe("parseDeepgramSegments (#168)", () => {
+	it("prefers utterances and presents speakers 1-based", () => {
+		const payload = {
+			results: {
+				utterances: [
+					{ speaker: 0, transcript: "Hello there.", start: 0, end: 2 },
+					{ speaker: 1, transcript: "Hi!", start: 2, end: 3 },
+				],
+			},
+		};
+
+		expect(parseDeepgramSegments(payload)).toEqual([
+			{ speaker: "1", text: "Hello there.", start: 0, end: 2 },
+			{ speaker: "2", text: "Hi!", start: 2, end: 3 },
+		]);
+	});
+
+	it("falls back to grouping words when utterances are absent", () => {
+		const payload = {
+			results: {
+				channels: [
+					{
+						alternatives: [
+							{
+								words: [
+									{ word: "hello", punctuated_word: "Hello", speaker: 0, start: 0, end: 1 },
+									{ word: "there", punctuated_word: "there.", speaker: 0, start: 1, end: 2 },
+									{ word: "hi", punctuated_word: "Hi!", speaker: 1, start: 2, end: 3 },
+								],
+							},
+						],
+					},
+				],
+			},
+		};
+
+		expect(parseDeepgramSegments(payload)).toEqual([
+			{ speaker: "1", text: "Hello there.", start: 0, end: 2 },
+			{ speaker: "2", text: "Hi!", start: 2, end: 3 },
+		]);
+	});
+
+	it("returns [] for a results object with neither utterances nor words", () => {
+		expect(parseDeepgramSegments({ results: {} })).toEqual([]);
+		expect(parseDeepgramSegments({})).toEqual([]);
+		expect(parseDeepgramSegments(null)).toEqual([]);
+	});
+});
+
+describe("mergeAdjacentSpeakers (#168)", () => {
+	it("does not mutate the input array", () => {
+		const input = [
+			{ speaker: "A", text: "One." },
+			{ speaker: "A", text: "Two." },
+		];
+		const copy = structuredClone(input);
+		mergeAdjacentSpeakers(input);
+		expect(input).toEqual(copy);
+	});
+});
+
+describe("formatSpeakerLabel (#168)", () => {
+	it("substitutes the {{speaker}} token (case/space-insensitive)", () => {
+		expect(formatSpeakerLabel("**{{speaker}}:** ", "A")).toBe("**A:** ");
+		expect(formatSpeakerLabel("{{ Speaker }} - ", "2")).toBe("2 - ");
+	});
+
+	it("prefixes the label when the template has no token", () => {
+		expect(formatSpeakerLabel("> ", "A")).toBe("A: > ");
+	});
+});
+
+describe("renderDiarizedTranscript (#168)", () => {
+	it("renders speaker turns separated by blank lines", () => {
+		const body = renderDiarizedTranscript(
+			[
+				{ speaker: "A", text: "Hello there." },
+				{ speaker: "B", text: "Hi!" },
+			],
+			DEFAULT_SPEAKER_TEMPLATE,
+		);
+
+		expect(body).toBe("**A:** Hello there.\n\n**B:** Hi!");
+	});
+
+	it("honors a custom speaker template", () => {
+		const body = renderDiarizedTranscript(
+			[{ speaker: "1", text: "Hi." }],
+			"Speaker {{speaker}}: ",
+		);
+
+		expect(body).toBe("Speaker 1: Hi.");
+	});
+
+	it("falls back to the default template when given an empty one", () => {
+		const body = renderDiarizedTranscript([{ speaker: "A", text: "Hi." }], "");
+		expect(body).toBe("**A:** Hi.");
+	});
+
+	it("returns an empty string for no segments", () => {
+		expect(renderDiarizedTranscript([], DEFAULT_SPEAKER_TEMPLATE)).toBe("");
+	});
+});

--- a/src/services/diarization/segments.ts
+++ b/src/services/diarization/segments.ts
@@ -1,0 +1,175 @@
+import type { DiarizedSegment } from "./types";
+
+/**
+ * Pure parsing/rendering for diarized transcripts (issue #168).
+ *
+ * The provider-specific network code lives in `openaiProvider.ts` /
+ * `deepgramProvider.ts`; everything here is side-effect free so the risky shape
+ * handling (untrusted JSON -> normalized segments -> markdown) is unit-testable.
+ */
+
+/** The placeholder a speaker-label template uses to position the speaker name. */
+const SPEAKER_TOKEN = /\{\{\s*speaker\s*\}\}/gi;
+
+/** Default per-turn prefix; `{{speaker}}` is replaced with the provider's label. */
+export const DEFAULT_SPEAKER_TEMPLATE = "**{{speaker}}:** ";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function cleanText(text: unknown): string {
+	return typeof text === "string" ? text.trim() : "";
+}
+
+/**
+ * Parse OpenAI `diarized_json` output (from `gpt-4o-transcribe-diarize`) into
+ * normalized segments. The payload is `{ segments: [{ speaker, text, start,
+ * end, ... }] }` where `speaker` is a capital-letter label (`A`, `B`, ...).
+ * Malformed/empty entries are skipped rather than throwing so one bad segment
+ * can't sink an otherwise-good transcript.
+ */
+export function parseOpenAIDiarizedSegments(payload: unknown): DiarizedSegment[] {
+	if (!isRecord(payload) || !Array.isArray(payload.segments)) return [];
+
+	const segments: DiarizedSegment[] = [];
+	for (const raw of payload.segments) {
+		if (!isRecord(raw)) continue;
+		const text = cleanText(raw.text);
+		if (!text) continue;
+		const speaker =
+			typeof raw.speaker === "string" && raw.speaker.trim()
+				? raw.speaker.trim()
+				: "?";
+		segments.push({
+			speaker,
+			text,
+			start: typeof raw.start === "number" ? raw.start : undefined,
+			end: typeof raw.end === "number" ? raw.end : undefined,
+		});
+	}
+	return mergeAdjacentSpeakers(segments);
+}
+
+/**
+ * Parse Deepgram pre-recorded output into normalized segments. Prefers the
+ * top-level `results.utterances[]` (already grouped into speaker turns when the
+ * request sets `utterances=true`); otherwise falls back to grouping the
+ * per-word `results.channels[0].alternatives[0].words[]` by their integer
+ * `speaker`. Deepgram speakers are 0-based; we present them 1-based so a label
+ * never reads "Speaker 0".
+ */
+export function parseDeepgramSegments(payload: unknown): DiarizedSegment[] {
+	if (!isRecord(payload) || !isRecord(payload.results)) return [];
+	const results = payload.results;
+
+	if (Array.isArray(results.utterances)) {
+		const segments: DiarizedSegment[] = [];
+		for (const raw of results.utterances) {
+			if (!isRecord(raw)) continue;
+			const text = cleanText(raw.transcript);
+			if (!text) continue;
+			segments.push({
+				speaker: speakerLabelFromIndex(raw.speaker),
+				text,
+				start: typeof raw.start === "number" ? raw.start : undefined,
+				end: typeof raw.end === "number" ? raw.end : undefined,
+			});
+		}
+		return mergeAdjacentSpeakers(segments);
+	}
+
+	return mergeAdjacentSpeakers(groupDeepgramWords(results));
+}
+
+/** Deepgram fallback: stitch per-word objects into contiguous speaker turns. */
+function groupDeepgramWords(results: Record<string, unknown>): DiarizedSegment[] {
+	const channels = results.channels;
+	if (!Array.isArray(channels) || !isRecord(channels[0])) return [];
+	const alternatives = channels[0].alternatives;
+	if (!Array.isArray(alternatives) || !isRecord(alternatives[0])) return [];
+	const words = alternatives[0].words;
+	if (!Array.isArray(words)) return [];
+
+	const segments: DiarizedSegment[] = [];
+	for (const raw of words) {
+		if (!isRecord(raw)) continue;
+		const token =
+			typeof raw.punctuated_word === "string"
+				? raw.punctuated_word
+				: typeof raw.word === "string"
+					? raw.word
+					: "";
+		if (!token) continue;
+		const speaker = speakerLabelFromIndex(raw.speaker);
+		const last = segments[segments.length - 1];
+		if (last && last.speaker === speaker) {
+			last.text += ` ${token}`;
+			if (typeof raw.end === "number") last.end = raw.end;
+		} else {
+			segments.push({
+				speaker,
+				text: token,
+				start: typeof raw.start === "number" ? raw.start : undefined,
+				end: typeof raw.end === "number" ? raw.end : undefined,
+			});
+		}
+	}
+	return segments;
+}
+
+function speakerLabelFromIndex(speaker: unknown): string {
+	return typeof speaker === "number" && Number.isFinite(speaker)
+		? String(speaker + 1)
+		: "?";
+}
+
+/**
+ * Collapse runs of the same speaker into one turn. Providers can emit several
+ * back-to-back segments for the same speaker (e.g. one per sentence); merging
+ * them yields readable paragraphs and a stable shape for rendering.
+ */
+export function mergeAdjacentSpeakers(
+	segments: DiarizedSegment[],
+): DiarizedSegment[] {
+	const merged: DiarizedSegment[] = [];
+	for (const segment of segments) {
+		const last = merged[merged.length - 1];
+		if (last && last.speaker === segment.speaker) {
+			last.text = `${last.text} ${segment.text}`.trim();
+			if (segment.end !== undefined) last.end = segment.end;
+		} else {
+			merged.push({ ...segment });
+		}
+	}
+	return merged;
+}
+
+/**
+ * Replace the `{{speaker}}` token in a speaker-label template. When the template
+ * has no token the label is prefixed instead, so even a tokenless template
+ * (e.g. "> ") still produces a usable, speaker-prefixed line.
+ */
+export function formatSpeakerLabel(template: string, speaker: string): string {
+	if (SPEAKER_TOKEN.test(template)) {
+		SPEAKER_TOKEN.lastIndex = 0;
+		return template.replace(SPEAKER_TOKEN, speaker);
+	}
+	return `${speaker}: ${template}`;
+}
+
+/**
+ * Render normalized segments into the markdown body that fills `{{transcript}}`.
+ * Each turn is `<speaker-label><text>`, turns separated by a blank line so they
+ * read as paragraphs. Returns an empty string for no segments so the caller can
+ * detect a diarization that produced nothing.
+ */
+export function renderDiarizedTranscript(
+	segments: DiarizedSegment[],
+	speakerTemplate: string,
+): string {
+	const template = speakerTemplate || DEFAULT_SPEAKER_TEMPLATE;
+	return segments
+		.map((segment) => `${formatSpeakerLabel(template, segment.speaker)}${segment.text}`)
+		.join("\n\n");
+}

--- a/src/services/diarization/types.ts
+++ b/src/services/diarization/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Speaker diarization adds "who spoke when" labels to a transcript (issue #168).
+ *
+ * OpenAI Whisper (`whisper-1`) — the plugin's default transcription backend —
+ * produces no speaker labels, so diarization is an opt-in path that routes the
+ * audio to a diarization-capable provider instead. Two providers are supported:
+ *
+ * - `openai`: the `gpt-4o-transcribe-diarize` model on the same
+ *   `/v1/audio/transcriptions` endpoint the plugin already uses, reusing the
+ *   user's existing OpenAI key. Convenient, but its 25 MB/request limit means a
+ *   long episode is split into chunks whose speaker labels are not guaranteed to
+ *   line up across chunk boundaries (the labels are assigned per request).
+ * - `deepgram`: a single whole-file request to Deepgram's pre-recorded API,
+ *   which keeps speaker identity consistent across the entire episode but needs
+ *   its own API key.
+ */
+export type DiarizationProviderId = "openai" | "deepgram";
+
+export const DIARIZATION_PROVIDERS: readonly DiarizationProviderId[] = [
+	"openai",
+	"deepgram",
+];
+
+/** The fixed OpenAI model that performs diarization (no other OpenAI model does). */
+export const OPENAI_DIARIZE_MODEL = "gpt-4o-transcribe-diarize";
+
+/**
+ * One contiguous turn of speech attributed to a single speaker. `speaker` is the
+ * provider's label, normalized to a short human-facing token (OpenAI emits `A`,
+ * `B`, ...; Deepgram emits 0-based integers which we present 1-based as `1`,
+ * `2`, ...). `start`/`end` are seconds when the provider reports them.
+ */
+export interface DiarizedSegment {
+	speaker: string;
+	text: string;
+	start?: number;
+	end?: number;
+}
+
+/** The whole, original (compressed) episode audio handed to a diarization provider. */
+export interface DiarizationAudio {
+	buffer: ArrayBuffer;
+	mimeType: string;
+	extension: string;
+	basename: string;
+}

--- a/src/settingsMigrations.test.ts
+++ b/src/settingsMigrations.test.ts
@@ -4,6 +4,7 @@ import {
 	LEGACY_EMPTY_DOWNLOAD_PATH,
 	migrateDownloadPath,
 	migrateNoteSettings,
+	migrateTranscriptSettings,
 } from "./settingsMigrations";
 
 describe("download path default (#183)", () => {
@@ -121,5 +122,71 @@ describe("migrateNoteSettings (#160)", () => {
 	it("is idempotent on the current default", () => {
 		const once = migrateNoteSettings(DEFAULT_NOTE);
 		expect(migrateNoteSettings(once)).toEqual(DEFAULT_NOTE);
+	});
+});
+
+describe("migrateTranscriptSettings (#168)", () => {
+	const DEFAULT_DIARIZATION = DEFAULT_SETTINGS.transcript.diarization;
+
+	it("backfills diarization defaults onto a legacy { path, template } transcript", () => {
+		const legacy = {
+			path: "transcripts/{{title}}.md",
+			template: "# {{title}}\n\n{{transcript}}",
+		};
+
+		expect(migrateTranscriptSettings(legacy)).toEqual({
+			path: legacy.path,
+			template: legacy.template,
+			diarization: DEFAULT_DIARIZATION,
+		});
+	});
+
+	it("treats an absent transcript (undefined/null) as all defaults", () => {
+		expect(migrateTranscriptSettings(undefined)).toEqual(
+			DEFAULT_SETTINGS.transcript,
+		);
+		expect(migrateTranscriptSettings(null)).toEqual(DEFAULT_SETTINGS.transcript);
+	});
+
+	it("preserves a fully-configured diarization block verbatim", () => {
+		const stored = {
+			path: "t/{{title}}.md",
+			template: "{{transcript}}",
+			diarization: {
+				enabled: true,
+				provider: "deepgram" as const,
+				speakerTemplate: "Speaker {{speaker}}: ",
+			},
+		};
+
+		expect(migrateTranscriptSettings(stored)).toEqual(stored);
+	});
+
+	it("clamps a malformed/unknown provider back to the default", () => {
+		const result = migrateTranscriptSettings({
+			path: "t.md",
+			template: "{{transcript}}",
+			diarization: { enabled: true, provider: "macwhisper", speakerTemplate: "x" },
+		});
+
+		expect(result.diarization.provider).toBe(DEFAULT_DIARIZATION.provider);
+		expect(result.diarization.enabled).toBe(true);
+	});
+
+	it("coalesces non-boolean enabled / non-string fields to defaults", () => {
+		const result = migrateTranscriptSettings({
+			path: null,
+			template: undefined,
+			diarization: { enabled: "yes", provider: 5, speakerTemplate: 42 },
+		} as never);
+
+		expect(result.path).toBe(DEFAULT_SETTINGS.transcript.path);
+		expect(result.template).toBe(DEFAULT_SETTINGS.transcript.template);
+		expect(result.diarization).toEqual(DEFAULT_DIARIZATION);
+	});
+
+	it("is idempotent on the current default", () => {
+		const once = migrateTranscriptSettings(DEFAULT_SETTINGS.transcript);
+		expect(migrateTranscriptSettings(once)).toEqual(DEFAULT_SETTINGS.transcript);
 	});
 });

--- a/src/settingsMigrations.ts
+++ b/src/settingsMigrations.ts
@@ -1,4 +1,9 @@
 import { DEFAULT_SETTINGS } from "./constants";
+import {
+	DIARIZATION_PROVIDERS,
+	type DiarizationProviderId,
+} from "./services/diarization/types";
+import type { IPodNotesSettings } from "./types/IPodNotesSettings";
 
 /**
  * Settings migrations applied when settings are loaded from disk.
@@ -93,4 +98,59 @@ export function migrateNoteSettings(storedNote: StoredNote | null | undefined): 
 	}
 
 	return { path, template };
+}
+
+type StoredTranscript = {
+	path?: string | null;
+	template?: string | null;
+	diarization?: {
+		enabled?: unknown;
+		provider?: unknown;
+		speakerTemplate?: unknown;
+	} | null;
+};
+
+/**
+ * Backfill the transcript settings with the diarization defaults (issue #168).
+ *
+ * `loadSettings` replaces the whole persisted `transcript` object, so an existing
+ * user who has `{ path, template }` saved would otherwise get an `undefined`
+ * `transcript.diarization` and crash where the service reads it. This deep-merges
+ * the new nested default while preserving any path/template the user configured,
+ * and clamps a malformed/unknown provider back to the default so a hand-edited or
+ * corrupted `data.json` can't select a provider that does not exist.
+ *
+ * Pure (no Obsidian/UI deps) so the merge is unit-testable.
+ */
+export function migrateTranscriptSettings(
+	storedTranscript: StoredTranscript | null | undefined,
+): IPodNotesSettings["transcript"] {
+	const defaults = DEFAULT_SETTINGS.transcript;
+	const stored = storedTranscript ?? {};
+	const storedDiarization = stored.diarization ?? {};
+
+	return {
+		path: typeof stored.path === "string" ? stored.path : defaults.path,
+		template:
+			typeof stored.template === "string"
+				? stored.template
+				: defaults.template,
+		diarization: {
+			enabled:
+				typeof storedDiarization.enabled === "boolean"
+					? storedDiarization.enabled
+					: defaults.diarization.enabled,
+			provider: sanitizeDiarizationProvider(storedDiarization.provider),
+			speakerTemplate:
+				typeof storedDiarization.speakerTemplate === "string"
+					? storedDiarization.speakerTemplate
+					: defaults.diarization.speakerTemplate,
+		},
+	};
+}
+
+function sanitizeDiarizationProvider(value: unknown): DiarizationProviderId {
+	return DIARIZATION_PROVIDERS.includes(value as DiarizationProviderId)
+		? (value as DiarizationProviderId)
+		: DEFAULT_SETTINGS.transcript.diarization.provider;
 }

--- a/src/settingsTransfer.test.ts
+++ b/src/settingsTransfer.test.ts
@@ -4,6 +4,7 @@ import {
 	EXCLUDED_KEYS,
 	SETTINGS_EXPORT_TYPE,
 	SETTINGS_EXPORT_VERSION,
+	describeSecrets,
 	mergeImportedSettings,
 	parseImport,
 	serializeSettings,
@@ -313,5 +314,48 @@ describe("mergeImportedSettings", () => {
 
 		expect(merged.feedNote.path).toBe("MyPods/{{podcast}}.md");
 		expect(merged.feedNote.template).toBe(DEFAULT_SETTINGS.feedNote.template);
+	});
+
+	it("clamps an imported invalid diarization provider and backfills its fields (#168)", () => {
+		const current = makeSettings();
+
+		const merged = mergeImportedSettings(current, {
+			transcript: {
+				path: "t/{{title}}.md",
+				template: "{{transcript}}",
+				diarization: { enabled: true, provider: "macwhisper" },
+			} as never,
+		});
+
+		// Unknown provider falls back to the default; the missing speakerTemplate is
+		// backfilled — the import path converges with the load path (#168).
+		expect(merged.transcript.diarization.provider).toBe(
+			DEFAULT_SETTINGS.transcript.diarization.provider,
+		);
+		expect(merged.transcript.diarization.enabled).toBe(true);
+		expect(merged.transcript.diarization.speakerTemplate).toBe(
+			DEFAULT_SETTINGS.transcript.diarization.speakerTemplate,
+		);
+	});
+});
+
+describe("describeSecrets (#168)", () => {
+	it("names only the secrets that actually hold a value", () => {
+		expect(describeSecrets(makeSettings())).toEqual([]);
+		expect(describeSecrets(makeSettings({ openAIApiKey: "sk" }))).toEqual([
+			"OpenAI API key",
+		]);
+		expect(
+			describeSecrets(makeSettings({ diarizationApiKey: "dg" })),
+		).toEqual(["Deepgram API key"]);
+		expect(
+			describeSecrets(
+				makeSettings({ openAIApiKey: "sk", diarizationApiKey: "dg" }),
+			),
+		).toEqual(["OpenAI API key", "Deepgram API key"]);
+	});
+
+	it("ignores whitespace-only secrets", () => {
+		expect(describeSecrets(makeSettings({ openAIApiKey: "   " }))).toEqual([]);
 	});
 });

--- a/src/settingsTransfer.test.ts
+++ b/src/settingsTransfer.test.ts
@@ -63,6 +63,33 @@ describe("serializeSettings", () => {
 		expect(withKey.settings.openAIApiKey).toBe("sk-secret");
 	});
 
+	it("redacts the diarization (Deepgram) key alongside the OpenAI key (#168)", () => {
+		const settings = makeSettings({
+			openAIApiKey: "sk-secret",
+			diarizationApiKey: "dg-secret",
+		});
+
+		const without = serializeSettings(settings, { includeSecret: false }, "2.16.0", NOW);
+		expect(without.settings).not.toHaveProperty("openAIApiKey");
+		expect(without.settings).not.toHaveProperty("diarizationApiKey");
+
+		const withKey = serializeSettings(settings, { includeSecret: true }, "2.16.0", NOW);
+		expect(withKey.settings.diarizationApiKey).toBe("dg-secret");
+	});
+
+	it("never lets the Deepgram key ride along inside the transcript object (#168)", () => {
+		// The key lives top-level precisely so it can be redacted; the nested
+		// transcript object (copied wholesale) must never carry a secret.
+		const settings = makeSettings({ diarizationApiKey: "dg-secret" });
+		const { settings: exported } = serializeSettings(
+			settings,
+			{ includeSecret: false },
+			"2.16.0",
+			NOW,
+		);
+		expect(JSON.stringify(exported.transcript ?? {})).not.toContain("dg-secret");
+	});
+
 	it("includes preferences, templates, and library", () => {
 		const settings = makeSettings({
 			note: { path: "notes/{{title}}.md", template: "# {{title}}" },

--- a/src/settingsTransfer.ts
+++ b/src/settingsTransfer.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTINGS } from "./constants";
+import { migrateTranscriptSettings } from "./settingsMigrations";
 import type { IPodNotesSettings } from "./types/IPodNotesSettings";
 
 /**
@@ -37,6 +38,27 @@ export const SECRET_KEYS: ReadonlySet<keyof IPodNotesSettings> = new Set([
 	"openAIApiKey",
 	"diarizationApiKey",
 ]);
+
+/** Human-facing names for each secret, so export/import copy can name exactly
+ * which keys leave or enter the vault instead of hard-coding "OpenAI". */
+const SECRET_KEY_LABELS: Record<string, string> = {
+	openAIApiKey: "OpenAI API key",
+	diarizationApiKey: "Deepgram API key",
+};
+
+/**
+ * The human-facing labels for the secrets actually present (non-empty) in a
+ * settings object. Used to keep the export toggle, the export notice, and the
+ * import confirmation honest about which keys are involved — so a Deepgram-only
+ * user is never told only "OpenAI API key" (and vice versa). See issue #168.
+ */
+export function describeSecrets(
+	settings: Partial<IPodNotesSettings>,
+): string[] {
+	return [...SECRET_KEYS]
+		.filter((key) => Boolean((settings[key] as string | undefined)?.trim()))
+		.map((key) => SECRET_KEY_LABELS[key as string]);
+}
 
 /** Keys that, if copied into the settings object, could pollute Object.prototype. */
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -208,6 +230,13 @@ export function mergeImportedSettings(
 			...(imported[key] as object | undefined),
 		} as never;
 	}
+
+	// The per-key spread above is only one level deep, so an imported
+	// `transcript.diarization` overrides the whole nested object — which could
+	// carry an unknown provider or drop `speakerTemplate`. Run the same migration
+	// the load path uses so the import path converges on a clamped, fully-formed
+	// transcript instead of relying on the next reload to repair it (#168).
+	merged.transcript = migrateTranscriptSettings(merged.transcript);
 
 	return merged;
 }

--- a/src/settingsTransfer.ts
+++ b/src/settingsTransfer.ts
@@ -27,8 +27,16 @@ export const EXCLUDED_KEYS: readonly (keyof IPodNotesSettings)[] = [
 	"currentEpisode",
 ];
 
-/** The OpenAI API key is only exported when the user explicitly opts in. */
-export const SECRET_KEY: keyof IPodNotesSettings = "openAIApiKey";
+/**
+ * API keys are only exported when the user explicitly opts in. Both the OpenAI
+ * key and the dedicated diarization (Deepgram) key are top-level so they can be
+ * redacted by name here; the diarization key is deliberately NOT nested inside
+ * `transcript` (a wholesale-copied nested key) so it can never leak (#168).
+ */
+export const SECRET_KEYS: ReadonlySet<keyof IPodNotesSettings> = new Set([
+	"openAIApiKey",
+	"diarizationApiKey",
+]);
 
 /** Keys that, if copied into the settings object, could pollute Object.prototype. */
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -92,7 +100,8 @@ export function serializeSettings(
 	for (const key of Object.keys(settings)) {
 		if (DANGEROUS_KEYS.has(key)) continue;
 		if (!IMPORTABLE_KEYS.has(key)) continue;
-		if (key === SECRET_KEY && !opts.includeSecret) continue;
+		if (SECRET_KEYS.has(key as keyof IPodNotesSettings) && !opts.includeSecret)
+			continue;
 		out[key] = settings[key as keyof IPodNotesSettings];
 	}
 
@@ -175,7 +184,7 @@ export function parseImport(jsonText: string): ParseResult {
 			fromEnvelope,
 			version,
 			pluginVersion,
-			includesSecret: SECRET_KEY in settings,
+			includesSecret: [...SECRET_KEYS].some((key) => key in settings),
 		},
 	};
 }

--- a/src/types/IPodNotesSettings.ts
+++ b/src/types/IPodNotesSettings.ts
@@ -4,6 +4,7 @@ import type { PlayedEpisode } from "./PlayedEpisode";
 import type { Playlist } from "./Playlist";
 import type { Episode } from "./Episode";
 import type DownloadedEpisode from "./DownloadedEpisode";
+import type { DiarizationProviderId } from "src/services/diarization/types";
 
 export interface IPodNotesSettings {
 	savedFeeds: { [podcastName: string]: PodcastFeed };
@@ -53,9 +54,26 @@ export interface IPodNotesSettings {
 	};
 	downloadedEpisodes: { [podcastName: string]: DownloadedEpisode[] };
 	openAIApiKey: string;
+	/**
+	 * API key for the dedicated diarization provider (Deepgram). Kept separate
+	 * from `openAIApiKey` and top-level so the settings export can redact it as a
+	 * secret; OpenAI diarization reuses `openAIApiKey` instead. See issue #168.
+	 */
+	diarizationApiKey: string;
 	transcript: {
 		path: string;
 		template: string;
+		/**
+		 * Opt-in speaker diarization for transcripts (issue #168). When `enabled`
+		 * the audio is routed to a diarization-capable `provider` instead of plain
+		 * Whisper, and the transcript is rendered as speaker-labeled turns using
+		 * `speakerTemplate` (where `{{speaker}}` is the per-turn speaker label).
+		 */
+		diarization: {
+			enabled: boolean;
+			provider: DiarizationProviderId;
+			speakerTemplate: string;
+		};
 	};
 	feedCache: {
 		enabled: boolean;

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -47,6 +47,10 @@ import {
 	serializeSettings,
 } from "src/settingsTransfer";
 import { normalizePlaybackRate } from "src/utility/playbackRate";
+import {
+	DEFAULT_SPEAKER_TEMPLATE,
+	type DiarizationProviderId,
+} from "src/services/diarization";
 
 export class PodNotesSettingsTab extends PluginSettingTab {
 	plugin: PodNotes;
@@ -871,6 +875,92 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 		transcriptTemplateSetting.settingEl.style.flexDirection = "column";
 		transcriptTemplateSetting.settingEl.style.alignItems = "unset";
 		transcriptTemplateSetting.settingEl.style.gap = "10px";
+
+		this.addDiarizationSettings(container);
+	}
+
+	/**
+	 * Opt-in speaker diarization controls (issue #168). Rendered into its own
+	 * container so the provider-dependent fields (Deepgram key) can be shown or
+	 * hidden in place when the toggle/provider changes, without re-rendering the
+	 * whole settings tab.
+	 */
+	private addDiarizationSettings(container: HTMLElement): void {
+		const diarizationContainer = container.createDiv();
+
+		const renderDiarizationSettings = () => {
+			diarizationContainer.empty();
+			const diarization = this.plugin.settings.transcript.diarization;
+
+			new Setting(diarizationContainer)
+				.setName("Speaker diarization")
+				.setDesc(
+					"Label transcript segments by speaker. Routes the episode audio to a diarization-capable provider instead of plain Whisper.",
+				)
+				.addToggle((toggle) =>
+					toggle.setValue(diarization.enabled).onChange(async (value) => {
+						this.plugin.settings.transcript.diarization.enabled = value;
+						await this.plugin.saveSettings();
+						renderDiarizationSettings();
+					}),
+				);
+
+			if (!diarization.enabled) return;
+
+			new Setting(diarizationContainer)
+				.setName("Diarization provider")
+				.setDesc(
+					"OpenAI reuses your OpenAI API key above (long episodes are chunked, so speaker labels can reset across chunks). Deepgram needs its own key and keeps speaker labels consistent across the whole episode.",
+				)
+				.addDropdown((dropdown) =>
+					dropdown
+						.addOption("openai", "OpenAI (gpt-4o-transcribe-diarize)")
+						.addOption("deepgram", "Deepgram")
+						.setValue(diarization.provider)
+						.onChange(async (value) => {
+							this.plugin.settings.transcript.diarization.provider =
+								value as DiarizationProviderId;
+							await this.plugin.saveSettings();
+							renderDiarizationSettings();
+						}),
+				);
+
+			if (diarization.provider === "deepgram") {
+				new Setting(diarizationContainer)
+					.setName("Deepgram API key")
+					.setDesc(
+						"Used only for Deepgram diarization. Create one at deepgram.com.",
+					)
+					.addText((text) => {
+						text
+							.setPlaceholder("Enter your Deepgram API key")
+							.setValue(this.plugin.settings.diarizationApiKey)
+							.onChange(async (value) => {
+								this.plugin.settings.diarizationApiKey = value;
+								await this.plugin.saveSettings();
+							});
+						text.inputEl.type = "password";
+					});
+			}
+
+			new Setting(diarizationContainer)
+				.setName("Speaker label format")
+				.setDesc(
+					"Prefix added before each speaker's turn. Use {{speaker}} for the speaker label (OpenAI labels speakers A, B, …; Deepgram labels them 1, 2, …).",
+				)
+				.addText((text) =>
+					text
+						.setPlaceholder(DEFAULT_SPEAKER_TEMPLATE)
+						.setValue(diarization.speakerTemplate)
+						.onChange(async (value) => {
+							this.plugin.settings.transcript.diarization.speakerTemplate =
+								value;
+							await this.plugin.saveSettings();
+						}),
+				);
+		};
+
+		renderDiarizationSettings();
 	}
 }
 

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -42,6 +42,7 @@ import { get } from "svelte/store";
 import { exportOPML, importOPML } from "src/opml";
 import { clearFeedCache } from "src/services/FeedCacheService";
 import {
+	describeSecrets,
 	mergeImportedSettings,
 	parseImport,
 	serializeSettings,
@@ -628,9 +629,9 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 		let includeSecret = false;
 
 		new Setting(containerEl)
-			.setName("Include OpenAI API key")
+			.setName("Include API keys")
 			.setDesc(
-				"When enabled, the export file contains your API key in plaintext. The file is stored in your vault, so it may sync to other devices and be read by other plugins.",
+				"When enabled, the export file contains your OpenAI and Deepgram API keys in plaintext (whichever you have set). The file is stored in your vault, so it may sync to other devices and be read by other plugins.",
 			)
 			.addToggle((toggle) =>
 				toggle.setValue(includeSecret).onChange((value) => {
@@ -727,9 +728,12 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 			}
 			await this.app.vault.create(fileName, contents);
 
+			const exportedSecrets = includeSecret
+				? describeSecrets(this.plugin.settings)
+				: [];
 			new Notice(
-				includeSecret
-					? `Exported PodNotes settings to "${fileName}" (includes your API key).`
+				exportedSecrets.length
+					? `Exported PodNotes settings to "${fileName}" (includes your ${exportedSecrets.join(" and ")}).`
 					: `Exported PodNotes settings to "${fileName}".`,
 			);
 		} catch (error) {
@@ -758,7 +762,7 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 		if (Object.keys(result.settings.playlists ?? {}).length) {
 			sections.push("playlists");
 		}
-		if (result.meta.includesSecret) sections.push("OpenAI API key");
+		sections.push(...describeSecrets(result.settings));
 		const detail = sections.length
 			? ` This also replaces your ${sections.join(", ")}.`
 			: "";


### PR DESCRIPTION
Closes #168.

## Summary

Adds **opt-in speaker diarization** for episode transcripts: instead of one block of unattributed prose, the transcript is labelled by speaker:

```
**A:** Welcome to the show.

**B:** Thanks for having me.
```

It is **off by default**, so existing transcripts and the plain-Whisper workflow are completely unchanged unless you turn it on. The labelled turns fill the existing `{{transcript}}` template value, so no template change is needed to use it.

## The product decision in this PR

OpenAI Whisper (`whisper-1`, the current backend) produces **no** speaker labels, so diarization needs a diarization-capable backend. I researched the realistic options (verified against official 2026 docs) and this PR ships **two user-selectable providers** behind one opt-in toggle:

| Provider | Key | How | Speaker-label consistency |
|---|---|---|---|
| **OpenAI** `gpt-4o-transcribe-diarize` | reuses your existing OpenAI key | same `/v1/audio/transcriptions` endpoint, `diarized_json` | per-request: a long episode is chunked at OpenAI's 25 MB cap, so labels can reset across chunks |
| **Deepgram** | a new, separate Deepgram key | one whole-file `requestUrl` POST | consistent across the whole episode |

OpenAI is the zero-friction default (nothing new to sign up for). Deepgram is the "do it properly for long episodes" option (it ingests the whole file in one request, so speaker identity stays stable end to end). Both work on desktop and mobile (`requestUrl` bypasses CORS).

Options considered and rejected: MacWhisper CLI (macOS-only, the CLI has no diarize flag, can't ship in a cross-platform community plugin) and in-browser WASM diarization (OOMs on iOS). Happy to drop one provider or change the default if you'd prefer a narrower surface.

## What's included

- `src/services/diarization/` — a small provider seam: `types`, pure `segments` (parse OpenAI `diarized_json` + Deepgram utterances/words into normalized speaker turns and render them), `openaiProvider`, `deepgramProvider` (injectable `requestUrl`), and a pure `requiredTranscriptionKeyPresent` credential gate.
- `TranscriptionService` routes to the chosen provider when enabled; the Whisper path is untouched when off.
- Settings: `transcript.diarization { enabled, provider, speakerTemplate }` plus a **top-level secret** `diarizationApiKey` (kept top-level so the settings export can redact it; it is never nested inside the wholesale-copied `transcript` object). A pure `migrateTranscriptSettings` backfills the new defaults onto existing users' settings.
- Settings UI: a toggle, a provider dropdown, a conditional Deepgram key field, and a "Speaker label format" field using a `{{speaker}}` token.
- Docs (`docs/docs/transcripts.md`) and the e2e seed-parity fixture.

## Speaker token

The `{{speaker}}` token lives in the new **Speaker label format** setting (default `**{{speaker}}:** `), e.g. set it to `**Speaker {{speaker}}:** ` or `> {{speaker}}: `. OpenAI labels speakers `A`/`B`/…, Deepgram `1`/`2`/… (presented 1-based).

## Verification

- Gates green: `lint`, `format:check`, `typecheck`, `build`, `test` (521 tests). `docs:build` could not run in my worktree (no local `mkdocs`); the change is plain markdown appended to an already-in-nav page.
- I don't have provider API keys, so the network calls ship instrumented (console logging on failure) and the provider parsing / HTTP wrapper / credential gate are unit-tested with stubs.
- Verified in a real (isolated) Obsidian vault: the plugin loads with no console errors, defaults are correct, a legacy `data.json` (no `diarization`) migrates correctly, and diarization settings persist across reload.

## Review

Ran an ultracode multi-dimension review (correctness, security, migration, API-correctness, maintainability; each finding adversarially re-verified against the code) plus three opposite-model (Codex) adversarial reviewers (Skeptic / Architect / Minimalist). No plain-Whisper regression found. Fixes applied from the reviews (second commit):

- Export consent copy now honestly names both keys (was "OpenAI API key" only while exporting both).
- Settings **import** now runs the same diarization clamp/backfill as load (an imported bogus provider no longer persists for a session).
- OpenAI diarization that fails on *every* chunk now throws (no marker-only "completed" transcript that blocks retry); partial failures still keep a marker.

## Notes for the maintainer

- New optional **paid third-party dependency** (Deepgram) if a user chooses that provider. Strictly opt-in, default off, separate key. Flagging since it is a product call.
- Localized `src/TemplateEngine.ts`: **not touched** (the speaker token is handled inside the diarization service), to avoid colliding with #165.