### PR TITLE
feat(commands): add playback rate and media timestamp controls

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -5,6 +5,7 @@ export interface IAPI {
 	readonly isPlaying: boolean;
 	readonly length: number;
 	currentTime: number;
+	playbackRate: number;
 	volume: number;
 
 	getPodcastTimeFormatted(
@@ -23,6 +24,9 @@ export interface IAPI {
 	togglePlayback(): void;
 	skipBackward(): void;
 	skipForward(): void;
+	increasePlaybackRate(): void;
+	decreasePlaybackRate(): void;
+	resetPlaybackRate(): void;
 }
 ```
 
@@ -52,3 +56,16 @@ If `linkify` is true, the time will be linked to the current episode at the give
 ## `getPodcastSegmentFormatted(format: string, startTime: number, endTime: number, linkify?: boolean)`
 This function returns a formatted `start-end` playback range.
 If `linkify` is true, the range links to the current episode with both `time` and `endTime` parameters so PodNotes starts at `startTime` and pauses at `endTime`.
+
+## `playbackRate`
+Gets or sets the current player playback speed. Values are clamped to the player
+range.
+
+## Playback controls
+`start()`, `stop()`, and `togglePlayback()` control the current episode.
+`skipBackward()` and `skipForward()` use the skip lengths configured in PodNotes
+settings.
+
+`increasePlaybackRate()` and `decreasePlaybackRate()` adjust the current playback
+speed in `0.1x` steps. `resetPlaybackRate()` returns playback to the default
+playback rate configured in settings.

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -41,6 +41,24 @@ When opened, the link seeks to the segment start and pauses playback at the segm
 
 See [timestamps](timestamps.md#capturing-segments) for more information on segment templates and behavior.
 
+On mobile, this command can be added to Obsidian's editor toolbar. PodNotes also
+registers the Media Session `previous track` action for headphone controls: when
+your headphones send that action, PodNotes captures the current timestamp. If a
+markdown editor is active, the timestamp is inserted at the cursor; otherwise it
+is appended to the current episode note. PodNotes does not capture timestamps on
+ordinary pause/play events, because that would create unwanted timestamps every
+time playback is paused.
+
+## Increase playback rate
+This increases the current episode's playback speed by `0.1x`.
+
+## Decrease playback rate
+This decreases the current episode's playback speed by `0.1x`.
+
+## Reset playback rate
+This resets the current episode's playback speed to the default playback rate
+from PodNotes settings.
+
 ## Create episode note
 This will create a note for the currently playing episode.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.7",
+				"@eslint/js": "^9.39.1",
 				"@semantic-release/git": "^10.0.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.1",
 				"@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.7",
+		"@eslint/js": "^9.39.1",
 		"@semantic-release/git": "^10.0.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@testing-library/jest-dom": "^6.9.1",

--- a/src/API/API.test.ts
+++ b/src/API/API.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe, expect, test } from "vitest";
 import { get } from "svelte/store";
+import { beforeEach, describe, expect, test } from "vitest";
+
 import { API } from "./API";
 import {
+	activePlaybackSegment,
 	currentEpisode,
 	currentTime,
-	activePlaybackSegment,
 	downloadedEpisodes,
+	playbackRate,
+	plugin,
 } from "src/store";
 import type { Episode } from "src/types/Episode";
 import type { LocalEpisode } from "src/types/LocalEpisode";
@@ -35,6 +38,12 @@ beforeEach(() => {
 	currentTime.set(0);
 	activePlaybackSegment.set(null);
 	downloadedEpisodes.set({});
+	playbackRate.set(1);
+	plugin.set({
+		settings: {
+			defaultPlaybackRate: 1.8,
+		},
+	} as never);
 });
 
 describe("API.getPodcastSegmentFormatted", () => {
@@ -112,5 +121,39 @@ describe("API.getPodcastSegmentFormatted", () => {
 
 		expect(api.currentTime).toBe(500);
 		expect(get(activePlaybackSegment)).toBeNull();
+	});
+});
+
+describe("API playback rate controls", () => {
+	test("increases and decreases the runtime playback rate in tenth steps", () => {
+		const api = new API();
+
+		api.increasePlaybackRate();
+		expect(get(playbackRate)).toBe(1.1);
+
+		api.decreasePlaybackRate();
+		api.decreasePlaybackRate();
+		expect(get(playbackRate)).toBe(0.9);
+	});
+
+	test("clamps playback rate changes to the player-supported range", () => {
+		const api = new API();
+
+		api.playbackRate = 3.95;
+		api.increasePlaybackRate();
+		expect(api.playbackRate).toBe(4);
+
+		api.playbackRate = 0.55;
+		api.decreasePlaybackRate();
+		expect(api.playbackRate).toBe(0.5);
+	});
+
+	test("resets playback rate to the configured default", () => {
+		const api = new API();
+
+		api.playbackRate = 2.5;
+		api.resetPlaybackRate();
+
+		expect(api.playbackRate).toBe(1.8);
 	});
 });

--- a/src/API/API.ts
+++ b/src/API/API.ts
@@ -8,6 +8,7 @@ import {
 	duration,
 	isPaused,
 	activePlaybackSegment,
+	playbackRate as playbackRateStore,
 	plugin,
 	volume as volumeStore,
 } from "src/store";
@@ -18,6 +19,11 @@ import {
 	formatPodcastSegment,
 	normalizePodcastSegmentTimes,
 } from "src/utility/podcastSegment";
+import {
+	adjustPlaybackRate,
+	normalizePlaybackRate,
+	PLAYBACK_RATE_STEP,
+} from "src/utility/playbackRate";
 
 const clampVolume = (value: number): number =>
 	Math.min(1, Math.max(0, value));
@@ -50,6 +56,14 @@ export class API implements IAPI {
 
 	public set volume(value: number) {
 		volumeStore.set(clampVolume(value));
+	}
+
+	public get playbackRate(): number {
+		return get(playbackRateStore);
+	}
+
+	public set playbackRate(value: number) {
+		playbackRateStore.set(normalizePlaybackRate(value, this.defaultPlaybackRate));
 	}
 
 	/**
@@ -142,7 +156,7 @@ export class API implements IAPI {
 		isPaused.update((_) => true);
 	}
 
-	togglePlayback(): void { 
+	togglePlayback(): void {
 		isPaused.update((isPaused) => !isPaused);
 	}
 
@@ -154,5 +168,25 @@ export class API implements IAPI {
 	skipForward(): void {
 		const skipForwardLen = get(plugin).settings.skipForwardLength;
 		this.currentTime += skipForwardLen;
+	}
+
+	increasePlaybackRate(): void {
+		playbackRateStore.update((rate) =>
+			adjustPlaybackRate(rate, PLAYBACK_RATE_STEP),
+		);
+	}
+
+	decreasePlaybackRate(): void {
+		playbackRateStore.update((rate) =>
+			adjustPlaybackRate(rate, -PLAYBACK_RATE_STEP),
+		);
+	}
+
+	resetPlaybackRate(): void {
+		this.playbackRate = this.defaultPlaybackRate;
+	}
+
+	private get defaultPlaybackRate(): number {
+		return normalizePlaybackRate(get(plugin).settings.defaultPlaybackRate);
 	}
 }

--- a/src/API/IAPI.ts
+++ b/src/API/IAPI.ts
@@ -5,6 +5,7 @@ export interface IAPI {
 	readonly isPlaying: boolean;
 	readonly length: number;
 	currentTime: number;
+	playbackRate: number;
 	volume: number;
 
 	getPodcastTimeFormatted(
@@ -26,4 +27,8 @@ export interface IAPI {
 
 	skipBackward(): void;
 	skipForward(): void;
+
+	increasePlaybackRate(): void;
+	decreasePlaybackRate(): void;
+	resetPlaybackRate(): void;
 }

--- a/src/createPodcastNote.ts
+++ b/src/createPodcastNote.ts
@@ -13,7 +13,7 @@ import { ensureFolderExists } from "./utility/ensureFolderExists";
  * the exact same (length-capped) path — otherwise a truncated note would be
  * re-created on every invocation. See issue #22.
  */
-function getPodcastNotePath(episode: Episode): string {
+export function getPodcastNotePath(episode: Episode): string {
 	const pluginInstance = get(plugin);
 
 	const filePath = FilePathTemplateEngine(
@@ -27,27 +27,27 @@ function getPodcastNotePath(episode: Episode): string {
 export default async function createPodcastNote(
 	episode: Episode
 ): Promise<void> {
-	const pluginInstance = get(plugin);
-
-	const filePathDotMd = getPodcastNotePath(episode);
-
-	const content = NoteTemplateEngine(
-		pluginInstance.settings.note.template,
-		episode
-	);
-
 	try {
-		const file = await createFileIfNotExists(
-			filePathDotMd,
-			content,
-			episode
-		);
+		const file = await createPodcastNoteFileIfNotExists(episode);
 
 		app.workspace.getLeaf().openFile(file);
 	} catch (error) {
 		console.error(error);
-		new Notice(`Failed to create note: "${filePathDotMd}"`);
+		new Notice(`Failed to create note: "${getPodcastNotePath(episode)}"`);
 	}
+}
+
+export async function createPodcastNoteFileIfNotExists(
+	episode: Episode,
+): Promise<TFile> {
+	const pluginInstance = get(plugin);
+	const filePathDotMd = getPodcastNotePath(episode);
+	const content = NoteTemplateEngine(
+		pluginInstance.settings.note.template,
+		episode,
+	);
+
+	return await createFileIfNotExists(filePathDotMd, content, episode);
 }
 
 export function getPodcastNote(episode: Episode): TFile | null {

--- a/src/main.activateView.test.ts
+++ b/src/main.activateView.test.ts
@@ -123,6 +123,7 @@ describe("PodNotes onload wiring (#55)", () => {
 			registerView: vi.fn(),
 			registerObsidianProtocolHandler: vi.fn(),
 			registerEvent: vi.fn(),
+			mediaSessionActions: [],
 			app: {
 				workspace: {
 					onLayoutReady: vi.fn(),
@@ -138,7 +139,7 @@ describe("PodNotes onload wiring (#55)", () => {
 		await plugin.onload();
 		loaded.push(plugin);
 
-		return { commands, ribbonCalls, activateSpy };
+		return { commands, ribbonCalls, activateSpy, plugin };
 	}
 
 	it("registers Show PodNotes as an always-available callback, not a leaf-gated checkCallback", async () => {
@@ -148,6 +149,112 @@ describe("PodNotes onload wiring (#55)", () => {
 		expect(showCmd).toBeDefined();
 		expect(typeof showCmd?.callback).toBe("function");
 		expect(showCmd?.checkCallback).toBeUndefined();
+	});
+
+	it("registers Capture Timestamp as an editor callback so mobile toolbar can add it", async () => {
+		const { commands } = await loadPlugin();
+
+		const captureCmd = commands.find((c) => c.id === "capture-timestamp");
+		expect(captureCmd).toBeDefined();
+		expect(typeof captureCmd?.editorCallback).toBe("function");
+		expect(captureCmd?.editorCheckCallback).toBeUndefined();
+		expect(captureCmd?.checkCallback).toBeUndefined();
+	});
+
+	it("registers playback-rate commands for hotkeys", async () => {
+		const { commands } = await loadPlugin();
+		const commandIds = new Set(commands.map((c) => c.id));
+
+		expect(commandIds.has("increase-playback-rate")).toBe(true);
+		expect(commandIds.has("decrease-playback-rate")).toBe(true);
+		expect(commandIds.has("reset-playback-rate")).toBe(true);
+	});
+
+	it("registers a previous-track Media Session handler for headphone timestamp capture", async () => {
+		const originalMediaSession = Object.getOwnPropertyDescriptor(
+			navigator,
+			"mediaSession",
+		);
+		const calls: Array<{ action: string; hasHandler: boolean }> = [];
+
+		Object.defineProperty(navigator, "mediaSession", {
+			configurable: true,
+			value: {
+				setActionHandler: vi.fn(
+					(action: string, handler: (() => void) | null) => {
+						calls.push({
+							action,
+							hasHandler: typeof handler === "function",
+						});
+					},
+				),
+			},
+		});
+
+		try {
+			await loadPlugin();
+			expect(calls).toContainEqual({
+				action: "previoustrack",
+				hasHandler: true,
+			});
+		} finally {
+			if (originalMediaSession) {
+				Object.defineProperty(
+					navigator,
+					"mediaSession",
+					originalMediaSession,
+				);
+			} else {
+				Reflect.deleteProperty(navigator, "mediaSession");
+			}
+		}
+	});
+
+	it("clears the previous-track Media Session handler on unload", async () => {
+		const originalMediaSession = Object.getOwnPropertyDescriptor(
+			navigator,
+			"mediaSession",
+		);
+		const calls: Array<{ action: string; hasHandler: boolean }> = [];
+
+		Object.defineProperty(navigator, "mediaSession", {
+			configurable: true,
+			value: {
+				setActionHandler: vi.fn(
+					(action: string, handler: (() => void) | null) => {
+						calls.push({
+							action,
+							hasHandler: typeof handler === "function",
+						});
+					},
+				),
+			},
+		});
+
+		try {
+			const { plugin } = await loadPlugin();
+			plugin.onunload();
+			loaded.splice(loaded.indexOf(plugin), 1);
+
+			expect(calls).toContainEqual({
+				action: "previoustrack",
+				hasHandler: true,
+			});
+			expect(calls).toContainEqual({
+				action: "previoustrack",
+				hasHandler: false,
+			});
+		} finally {
+			if (originalMediaSession) {
+				Object.defineProperty(
+					navigator,
+					"mediaSession",
+					originalMediaSession,
+				);
+			} else {
+				Reflect.deleteProperty(navigator, "mediaSession");
+			}
+		}
 	});
 
 	it("Show PodNotes command and ribbon icon both route to activateView", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
 	savedFeeds,
 	hidePlayedEpisodes,
 	sanitizeEpisodeListLimit,
+	playbackRate,
 	volume,
 } from "src/store";
 import { Notice, Plugin, type Editor, type WorkspaceLeaf } from "obsidian";
@@ -44,7 +45,10 @@ import {
 	createRecentPodcastSegment,
 	getSegmentCaptureTemplate,
 } from "./utility/podcastSegment";
-import createPodcastNote from "./createPodcastNote";
+import createPodcastNote, {
+	createPodcastNoteFileIfNotExists,
+	getPodcastNote,
+} from "./createPodcastNote";
 import createFeedNote from "./createFeedNote";
 import { FeedSuggestModal, orderFeedsByCurrent } from "./ui/FeedSuggestModal";
 import downloadEpisodeWithNotice from "./downloadEpisode";
@@ -58,6 +62,18 @@ import getUniversalPodcastLink from "./getUniversalPodcastLink";
 import type { IconType } from "./types/IconType";
 import { TranscriptionService } from "./services/TranscriptionService";
 import { get, type Unsubscriber } from "svelte/store";
+import { normalizePlaybackRate } from "./utility/playbackRate";
+
+type MediaSessionActionName =
+	| "previoustrack"
+	| "play"
+	| "pause"
+	| "stop"
+	| "nexttrack"
+	| "seekbackward"
+	| "seekforward"
+	| "seekto"
+	| "skipad";
 
 export default class PodNotes extends Plugin implements IPodNotes {
 	public api!: IAPI;
@@ -93,6 +109,7 @@ export default class PodNotes extends Plugin implements IPodNotes {
 	private pendingSave: IPodNotesSettings | null = null;
 	private saveScheduled = false;
 	private saveChain: Promise<void> = Promise.resolve();
+	private mediaSessionActions: MediaSessionActionName[] = [];
 
 	override async onload() {
 		plugin.set(this);
@@ -115,6 +132,9 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		episodeListLimit.set(this.settings.episodeListLimit);
 		volume.set(
 			Math.min(1, Math.max(0, this.settings.defaultVolume ?? 1)),
+		);
+		playbackRate.set(
+			normalizePlaybackRate(this.settings.defaultPlaybackRate),
 		);
 
 		this.playedEpisodeController = new EpisodeStatusController(
@@ -310,16 +330,8 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			id: "capture-timestamp",
 			name: "Capture Timestamp",
 			icon: "clock" as IconType,
-			editorCheckCallback: (checking, editor, view) => {
-				if (checking) {
-					return canCaptureTimestamp();
-				}
-
-				const capture = TimestampTemplateEngine(
-					this.settings.timestamp.template,
-				);
-
-				insertCapture(editor, capture);
+			editorCallback: (editor) => {
+				this.captureTimestamp(editor);
 			},
 		});
 
@@ -427,6 +439,45 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		});
 
 		this.addCommand({
+			id: "increase-playback-rate",
+			name: "Increase playback rate",
+			icon: "gauge" as IconType,
+			checkCallback: (checking) => {
+				if (checking) {
+					return !!this.api.podcast;
+				}
+
+				this.api.increasePlaybackRate();
+			},
+		});
+
+		this.addCommand({
+			id: "decrease-playback-rate",
+			name: "Decrease playback rate",
+			icon: "gauge" as IconType,
+			checkCallback: (checking) => {
+				if (checking) {
+					return !!this.api.podcast;
+				}
+
+				this.api.decreasePlaybackRate();
+			},
+		});
+
+		this.addCommand({
+			id: "reset-playback-rate",
+			name: "Reset playback rate",
+			icon: "rotate-ccw" as IconType,
+			checkCallback: (checking) => {
+				if (checking) {
+					return !!this.api.podcast;
+				}
+
+				this.api.resetPlaybackRate();
+			},
+		});
+
+		this.addCommand({
 			id: "podnotes-transcribe",
 			name: "Transcribe current episode",
 			checkCallback: (checking) => {
@@ -465,6 +516,7 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		);
 
 		this.registerEvent(getContextMenuHandler(this.app));
+		this.registerMediaSessionHandlers();
 
 		this.isReady = true;
 	}
@@ -524,7 +576,108 @@ export default class PodNotes extends Plugin implements IPodNotes {
 		return this.transcriptionService;
 	}
 
+	private captureTimestamp(editor: Editor | null | undefined): boolean {
+		if (!editor || !this.api.podcast || !this.settings.timestamp.template) {
+			return false;
+		}
+
+		const capture = TimestampTemplateEngine(this.settings.timestamp.template);
+
+		// Insert with replaceSelection (not getCursor + replaceRange + setCursor):
+		// it drops the text at the live cursor and lets the editor place the caret
+		// after it, which is reliable inside Live Preview table cells where
+		// hand-computed positions land in the wrong cell. Inside a table the capture
+		// is escaped so pipes and newlines don't break the row. See issue #165.
+		const cursor = editor.getCursor("from");
+		const textToInsert = prepareTimestampForInsertion(capture, {
+			getLine: (line) => editor.getLine(line),
+			lineCount: editor.lineCount(),
+			cursorLine: cursor.line,
+		});
+
+		editor.replaceSelection(textToInsert);
+		return true;
+	}
+
+	private captureTimestampInActiveEditor(): boolean {
+		return this.captureTimestamp(this.app.workspace.activeEditor?.editor);
+	}
+
+	private async appendTimestampToEpisodeNote(): Promise<boolean> {
+		if (
+			!this.api.podcast ||
+			!this.settings.timestamp.template ||
+			!this.settings.note.path ||
+			!this.settings.note.template
+		) {
+			return false;
+		}
+
+		const capture = TimestampTemplateEngine(this.settings.timestamp.template);
+		const textToAppend = capture.endsWith("\n") ? capture : `${capture}\n`;
+		const file =
+			getPodcastNote(this.api.podcast) ??
+			(await createPodcastNoteFileIfNotExists(this.api.podcast));
+		const content = await this.app.vault.read(file);
+		const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+
+		await this.app.vault.modify(file, `${content}${separator}${textToAppend}`);
+		return true;
+	}
+
+	private async captureTimestampFromMediaSession(): Promise<boolean> {
+		if (this.captureTimestampInActiveEditor()) {
+			return true;
+		}
+
+		return await this.appendTimestampToEpisodeNote();
+	}
+
+	private registerMediaSessionHandlers(): void {
+		this.registerMediaSessionAction("previoustrack", () => {
+			void this.captureTimestampFromMediaSession();
+		});
+	}
+
+	private registerMediaSessionAction(
+		action: MediaSessionActionName,
+		handler: () => void,
+	): void {
+		const mediaSession = globalThis.navigator?.mediaSession;
+		if (!mediaSession?.setActionHandler) {
+			return;
+		}
+
+		try {
+			mediaSession.setActionHandler(action, handler);
+			this.mediaSessionActions.push(action);
+		} catch (error) {
+			console.warn(
+				`PodNotes: Media Session action "${action}" is not supported`,
+				error,
+			);
+		}
+	}
+
+	private clearMediaSessionHandlers(): void {
+		const mediaSession = globalThis.navigator?.mediaSession;
+		if (!mediaSession?.setActionHandler) {
+			return;
+		}
+
+		for (const action of this.mediaSessionActions) {
+			try {
+				mediaSession.setActionHandler(action, null);
+			} catch {
+				// Ignore unsupported cleanup paths; registration already guarded them.
+			}
+		}
+
+		this.mediaSessionActions = [];
+	}
+
 	override onunload() {
+		this.clearMediaSessionHandlers();
 		this.playedEpisodeController?.off();
 		this.savedFeedsController?.off();
 		this.playlistController?.off();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ import {
 	LOCAL_FILES_SETTINGS,
 	MAX_EPISODE_LIST_LIMIT,
 } from "src/constants";
+import { DEFAULT_PLAYBACK_RATE } from "src/utility/playbackRate";
 import { getEpisodeKey } from "src/utility/episodeKey";
 import {
 	getPlayedEpisode,
@@ -29,6 +30,7 @@ export const requestedPlaybackTime = writable<{
 } | null>(null);
 export const activePlaybackSegment = writable<PlaybackSegment | null>(null);
 export const duration = writable<number>(0);
+export const playbackRate = writable<number>(DEFAULT_PLAYBACK_RATE);
 export const volume = writable<number>(1);
 export const hidePlayedEpisodes = writable<boolean>(false);
 

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -11,6 +11,7 @@
 		playlists,
 		viewState,
 		downloadedEpisodes,
+		playbackRate,
 		requestedPlaybackTime,
 		activePlaybackSegment,
 	} from "src/store";
@@ -31,22 +32,13 @@
 	import { createMediaUrlObjectFromFilePath } from "src/utility/createMediaUrlObjectFromFilePath";
 	import Image from "../common/Image.svelte";
 	import { episodeMatchesKey, getEpisodeKey } from "src/utility/episodeKey";
+	import {
+		normalizePlaybackRate,
+		PLAYBACK_RATE_MAX,
+		PLAYBACK_RATE_MIN,
+		PLAYBACK_RATE_STEP,
+	} from "src/utility/playbackRate";
 
-	// #region Circumventing the forced two-way binding of the playback rate.
-	class CircumentForcedTwoWayBinding {
-		public playbackRate: number = $plugin.settings.defaultPlaybackRate || 1;
-
-		public get _playbackRate() {
-			return this.playbackRate;
-		}
-
-		public set _playbackRate(_: number) {
-			// No-op: prevent two-way binding from overwriting our value
-		}
-	}
-
-	const offBinding = new CircumentForcedTwoWayBinding();
-	//#endregion
 	const clampVolume = (value: number): number => Math.min(1, Math.max(0, value));
 
 	// Hide the player's Queue list only when queue automation is off AND the queue
@@ -61,6 +53,7 @@
 	let isHoveringArtwork: boolean = false;
 	let isLoading: boolean = true;
 	let playerVolume: number = 1;
+	let audioElement: HTMLAudioElement | null = null;
 	// The currentEpisode subscription fires synchronously on subscribe with the
 	// already-loaded episode; that first fire must not wipe a restored position
 	// (or flash 0) on the initial mount. Only genuine in-player switches reset.
@@ -123,7 +116,7 @@
 	}
 
 	function onPlaybackRateChange(event: CustomEvent<{ value: number }>) {
-		offBinding.playbackRate = event.detail.value;
+		playbackRate.set(normalizePlaybackRate(event.detail.value));
 	}
 
 	function onVolumeChange(event: CustomEvent<{ value: number }>) {
@@ -400,6 +393,10 @@
 		
 		return episode.streamUrl;
 	}
+
+	$: if (audioElement && audioElement.playbackRate !== $playbackRate) {
+		audioElement.playbackRate = $playbackRate;
+	}
 </script>
 
 	<div class="episode-player">
@@ -444,11 +441,11 @@
 
 	{#await srcPromise then src}
 		<audio
+			bind:this={audioElement}
 			src={src}
 			bind:duration={$duration}
 			bind:currentTime={$currentTime}
 			bind:paused={$isPaused}
-			bind:playbackRate={offBinding._playbackRate}
 			bind:volume={playerVolume}
 			on:ended={onEpisodeEnded}
 			on:loadedmetadata={onMetadataLoaded}
@@ -495,11 +492,11 @@
 		</div>
 
 		<div class="playbackrate-container">
-			<span>{offBinding.playbackRate}x</span>
+			<span>{$playbackRate}x</span>
 			<Slider
 				on:change={onPlaybackRateChange}
-				value={offBinding.playbackRate}
-				limits={[0.5, 3.5, 0.1]}
+				value={$playbackRate}
+				limits={[PLAYBACK_RATE_MIN, PLAYBACK_RATE_MAX, PLAYBACK_RATE_STEP]}
 			/>
 		</div>
 	</div>

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -8,6 +8,7 @@ import {
 	duration,
 	isPaused,
 	activePlaybackSegment,
+	playbackRate,
 	playedEpisodes,
 	plugin,
 	requestedPlaybackTime,
@@ -31,6 +32,7 @@ beforeEach(() => {
 	duration.set(3600);
 	isPaused.set(true);
 	activePlaybackSegment.set(null);
+	playbackRate.set(1);
 	playedEpisodes.set({});
 	requestedPlaybackTime.set(null);
 	HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
@@ -208,6 +210,37 @@ describe("EpisodePlayer", () => {
 		expect(get(currentTime)).toBe(1800);
 		expect(get(isPaused)).toBe(false);
 		expect(get(requestedPlaybackTime)).toBeNull();
+	});
+
+	test("keeps the audio element and slider label in sync with playbackRate store", async () => {
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+
+		playbackRate.set(1.7);
+
+		await waitFor(() => {
+			expect(audio.playbackRate).toBe(1.7);
+		});
+		expect(container.querySelector(".playbackrate-container span")?.textContent).toBe(
+			"1.7x",
+		);
+	});
+
+	test("updates playbackRate store from the playback-rate slider", async () => {
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+
+		const sliders = Array.from(container.querySelectorAll("input[type='range']"));
+		const rateSlider = sliders[sliders.length - 1] as HTMLInputElement;
+		rateSlider.value = "2.2";
+		await fireEvent.input(rateSlider);
+
+		expect(get(playbackRate)).toBe(2.2);
 	});
 });
 

--- a/src/ui/settings/PodNotesSettingsTab.import.test.ts
+++ b/src/ui/settings/PodNotesSettingsTab.import.test.ts
@@ -1,0 +1,32 @@
+import { get } from "svelte/store";
+import { describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+
+import { DEFAULT_SETTINGS } from "src/constants";
+import type PodNotes from "src/main";
+import { playbackRate } from "src/store";
+import { PodNotesSettingsTab } from "./PodNotesSettingsTab";
+
+describe("PodNotesSettingsTab settings import", () => {
+	it("rehydrates the live playback-rate store when importing a new default", async () => {
+		playbackRate.set(1);
+		const plugin = {
+			settings: structuredClone(DEFAULT_SETTINGS),
+			saveSettings: vi.fn().mockResolvedValue(undefined),
+		} as unknown as PodNotes;
+		const tab = new PodNotesSettingsTab({} as App, plugin);
+		vi.spyOn(tab, "display").mockImplementation(() => {});
+
+		await (
+			tab as unknown as {
+				applyImportedSettings: (
+					imported: Partial<typeof DEFAULT_SETTINGS>,
+				) => Promise<void>;
+			}
+		).applyImportedSettings({ defaultPlaybackRate: 2.3 });
+
+		expect(plugin.settings.defaultPlaybackRate).toBe(2.3);
+		expect(get(playbackRate)).toBe(2.3);
+		expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ui/settings/PodNotesSettingsTab.ts
+++ b/src/ui/settings/PodNotesSettingsTab.ts
@@ -23,6 +23,7 @@ import {
 	favorites,
 	hidePlayedEpisodes,
 	localFiles,
+	playbackRate,
 	playlists,
 	plugin,
 	queue,
@@ -45,6 +46,7 @@ import {
 	parseImport,
 	serializeSettings,
 } from "src/settingsTransfer";
+import { normalizePlaybackRate } from "src/utility/playbackRate";
 
 export class PodNotesSettingsTab extends PluginSettingTab {
 	plugin: PodNotes;
@@ -776,7 +778,7 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 
 		// Re-hydrate the live stores so the running UI and the persistence
 		// controllers reflect the import. Keys without a store (templates, paths,
-		// skip lengths, playback rate, feed cache) are applied via `merged` above.
+		// skip lengths, feed cache) are applied via `merged` above.
 		savedFeeds.set(merged.savedFeeds);
 		playlists.set(merged.playlists);
 		favorites.set(merged.favorites);
@@ -790,6 +792,7 @@ export class PodNotesSettingsTab extends PluginSettingTab {
 			? merged.defaultVolume
 			: 1;
 		volume.set(Math.min(1, Math.max(0, importedVolume)));
+		playbackRate.set(normalizePlaybackRate(merged.defaultPlaybackRate));
 
 		await this.plugin.saveSettings();
 		// Re-emit the plugin store so an open player/grid recomputes Queue tile/list

--- a/src/utility/playbackRate.ts
+++ b/src/utility/playbackRate.ts
@@ -1,0 +1,38 @@
+export const PLAYBACK_RATE_MIN = 0.5;
+export const PLAYBACK_RATE_MAX = 4;
+export const PLAYBACK_RATE_STEP = 0.1;
+export const DEFAULT_PLAYBACK_RATE = 1;
+
+export function normalizePlaybackRate(
+	value: unknown,
+	fallback = DEFAULT_PLAYBACK_RATE,
+): number {
+	const numeric = typeof value === "number" ? value : Number(value);
+	const fallbackRate = Number.isFinite(fallback)
+		? fallback
+		: DEFAULT_PLAYBACK_RATE;
+
+	if (!Number.isFinite(numeric)) {
+		return clampPlaybackRate(fallbackRate);
+	}
+
+	return clampPlaybackRate(numeric);
+}
+
+export function adjustPlaybackRate(
+	currentRate: number,
+	delta: number,
+): number {
+	return normalizePlaybackRate(roundToTenths(currentRate + delta));
+}
+
+function clampPlaybackRate(value: number): number {
+	return Math.min(
+		PLAYBACK_RATE_MAX,
+		Math.max(PLAYBACK_RATE_MIN, roundToTenths(value)),
+	);
+}
+
+function roundToTenths(value: number): number {
+	return Math.round(value * 10) / 10;
+}

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -154,10 +154,50 @@ export async function restorePodNotesData(
 	plugin: PluginHandle,
 	obsidian: ObsidianClient,
 ): Promise<void> {
+	await detachPodNotesViews(obsidian);
+	await flushPodNotesSaves(obsidian);
 	await plugin.disable();
 	await plugin.restoreData();
 	await plugin.enable();
 	await waitForPodNotesReady(obsidian);
+}
+
+async function detachPodNotesViews(obsidian: ObsidianClient): Promise<void> {
+	await evalJsonAsync<boolean>(
+		obsidian,
+		`
+		(async () => {
+			await app.workspace.detachLeavesOfType(${JSON.stringify(VIEW_TYPE)});
+			return true;
+		})()
+	`,
+	);
+}
+
+async function flushPodNotesSaves(obsidian: ObsidianClient): Promise<void> {
+	await evalJsonAsync<boolean>(
+		obsidian,
+		`
+		(async () => {
+			const podnotes = app.plugins.plugins.${PLUGIN_ID};
+			if (!podnotes) return true;
+
+			if (podnotes.saveChain) {
+				await podnotes.saveChain;
+			}
+
+			if (podnotes.pendingSave) {
+				await podnotes.saveSettings();
+			}
+
+			if (podnotes.saveChain) {
+				await podnotes.saveChain;
+			}
+
+			return true;
+		})()
+	`,
+	);
 }
 
 export async function waitForPodNotesReady(

--- a/tests/e2e/podnotes-runtime.test.ts
+++ b/tests/e2e/podnotes-runtime.test.ts
@@ -34,24 +34,39 @@ describe("PodNotes runtime", () => {
 		await openPodNotesView(obsidian);
 
 		const state = await obsidian.dev.evalJson<{
+			captureUsesEditorCallback: boolean;
+			captureUsesEditorCheckCallback: boolean;
 			hasCaptureSegment10Command: boolean;
 			hasCaptureSegment20Command: boolean;
 			hasProtocolHandler: boolean;
+			hasRateCommands: boolean;
 			hasShowCommand: boolean;
 			viewCount: number;
 		}>(`
-				(() => ({
-					hasCaptureSegment10Command: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-segment-10s`)}]),
-					hasCaptureSegment20Command: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-segment-20s`)}]),
-					hasProtocolHandler: app.workspace.protocolHandlers?.has(${JSON.stringify(PLUGIN_ID)}) ?? false,
-					hasShowCommand: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:podnotes-show-leaf`)}]),
-					viewCount: app.workspace.getLeavesOfType(${JSON.stringify(VIEW_TYPE)}).length,
+			(() => ({
+				captureUsesEditorCallback:
+					typeof app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-timestamp`)}]?.editorCallback === "function",
+				captureUsesEditorCheckCallback:
+					typeof app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-timestamp`)}]?.editorCheckCallback === "function",
+				hasCaptureSegment10Command: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-segment-10s`)}]),
+				hasCaptureSegment20Command: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:capture-segment-20s`)}]),
+				hasProtocolHandler: app.workspace.protocolHandlers?.has(${JSON.stringify(PLUGIN_ID)}) ?? false,
+				hasRateCommands: [
+					${JSON.stringify(`${PLUGIN_ID}:increase-playback-rate`)},
+					${JSON.stringify(`${PLUGIN_ID}:decrease-playback-rate`)},
+					${JSON.stringify(`${PLUGIN_ID}:reset-playback-rate`)},
+				].every((id) => Boolean(app.commands?.commands?.[id])),
+				hasShowCommand: Boolean(app.commands?.commands?.[${JSON.stringify(`${PLUGIN_ID}:podnotes-show-leaf`)}]),
+				viewCount: app.workspace.getLeavesOfType(${JSON.stringify(VIEW_TYPE)}).length,
 			}))()
 		`);
 
 		expect(state).toMatchObject({
+			captureUsesEditorCallback: true,
+			captureUsesEditorCheckCallback: false,
 			hasCaptureSegment10Command: true,
 			hasCaptureSegment20Command: true,
+			hasRateCommands: true,
 			hasProtocolHandler: true,
 			hasShowCommand: true,
 		});
@@ -258,6 +273,7 @@ describe("PodNotes runtime", () => {
 		await openPodNotesView(obsidian);
 
 		await invokePodNotesUri(obsidian, episode, 115, 125);
+		await openPodNotesView(obsidian);
 		await dispatchLoadedMetadata(obsidian);
 
 		await waitForPlaybackState(
@@ -284,6 +300,132 @@ describe("PodNotes runtime", () => {
 			isPlaying: false,
 			title: episode.title,
 		});
+	});
+
+	test("playback-rate commands update the live player rate and reset to the configured default", async () => {
+		const { obsidian, plugin, sandbox } = getContext();
+		const audioPath = await seedAudio(sandbox, "rate-command-episode.mp3");
+		const episode = createLocalEpisode("E2E Rate Command Episode", audioPath);
+
+		await seedRuntimeData(plugin, sandbox, episode, {
+			currentEpisode: episode,
+			defaultPlaybackRate: 1.5,
+		});
+		await waitForPodNotesReady(obsidian);
+		await openPodNotesView(obsidian);
+		await invokePodNotesUri(obsidian, episode, 0);
+		await dispatchLoadedMetadata(obsidian);
+		await waitForPlaybackRate(obsidian, 1.5);
+
+		await obsidian.command(`${PLUGIN_ID}:increase-playback-rate`).run();
+		await waitForPlaybackRate(obsidian, 1.6);
+
+		await obsidian.command(`${PLUGIN_ID}:decrease-playback-rate`).run();
+		await obsidian.command(`${PLUGIN_ID}:decrease-playback-rate`).run();
+		await waitForPlaybackRate(obsidian, 1.4);
+
+		await obsidian.command(`${PLUGIN_ID}:reset-playback-rate`).run();
+		const rate = await waitForPlaybackRate(obsidian, 1.5);
+
+		expect(rate).toMatchObject({
+			api: 1.5,
+			audio: 1.5,
+		});
+	});
+
+	test("previous-track Media Session action captures a timestamp into the active editor", async () => {
+		const { obsidian, plugin, sandbox } = getContext();
+		const audioPath = await seedAudio(sandbox, "headphone-capture-episode.mp3");
+		const episode = createLocalEpisode(
+			"E2E Headphone Capture Episode",
+			audioPath,
+		);
+		const notePath = sandbox.path("headphone-capture-target.md");
+
+		await seedRuntimeData(plugin, sandbox, episode, {
+			currentEpisode: episode,
+			timestampTemplate: "- {{linktime}}",
+		});
+		await installMediaSessionRecorder(obsidian);
+		try {
+			await waitForPodNotesReady(obsidian);
+			await openMarkdownFile(obsidian, notePath);
+			await setPlayback(obsidian, { currentTime: 95, paused: false });
+
+			const action = await invokeRecordedMediaSessionAction(
+				obsidian,
+				"previoustrack",
+			);
+			expect(action).toMatchObject({
+				action: "previoustrack",
+				ok: true,
+			});
+
+			const expectedLink = `- ${expectedTimestampLink("00:01:35", episode, 95)}`;
+			const content = await sandbox.waitForContent(
+				"headphone-capture-target.md",
+				(value) => value.includes(expectedLink),
+				WAIT_OPTS,
+			);
+
+			expect(content).toContain(expectedLink);
+		} finally {
+			await restoreMediaSessionRecorder(obsidian);
+		}
+	});
+
+	test("previous-track Media Session action appends to the episode note without an active editor", async () => {
+		const { obsidian, plugin, sandbox } = getContext();
+		const audioPath = await seedAudio(
+			sandbox,
+			"headphone-background-episode.mp3",
+		);
+		const episode = createLocalEpisode(
+			"E2E Background Capture Episode",
+			audioPath,
+		);
+		const noteRelativePath = `${episode.title}.md`;
+
+		await seedRuntimeData(plugin, sandbox, episode, {
+			currentEpisode: episode,
+			note: {
+				path: sandbox.path("{{title}}.md"),
+				template: "# {{title}}\n",
+			},
+			timestampTemplate: "- {{linktime}}",
+		});
+		await installMediaSessionRecorder(obsidian);
+		try {
+			await waitForPodNotesReady(obsidian);
+			await openPodNotesView(obsidian);
+			await setPlayback(obsidian, { currentTime: 185, paused: false });
+
+			const noEditor = await obsidian.dev.evalJson<boolean>(`
+				!app.workspace.activeEditor?.editor
+			`);
+			expect(noEditor).toBe(true);
+
+			const action = await invokeRecordedMediaSessionAction(
+				obsidian,
+				"previoustrack",
+			);
+			expect(action).toMatchObject({
+				action: "previoustrack",
+				ok: true,
+			});
+
+			const expectedLink = `- ${expectedTimestampLink("00:03:05", episode, 185)}`;
+			const content = await sandbox.waitForContent(
+				noteRelativePath,
+				(value) => value.includes(expectedLink),
+				WAIT_OPTS,
+			);
+
+			expect(content).toContain("# E2E Background Capture Episode");
+			expect(content).toContain(expectedLink);
+		} finally {
+			await restoreMediaSessionRecorder(obsidian);
+		}
 	});
 
 	test("persists API volume changes and clamps out-of-range values", async () => {
@@ -397,6 +539,8 @@ async function seedRuntimeData(
 	episode: LocalEpisode,
 	options: {
 		currentEpisode?: Episode;
+		defaultPlaybackRate?: number;
+		note?: { path: string; template: string };
 		played?: { duration: number; time: number };
 		timestampTemplate?: string;
 	} = {},
@@ -413,6 +557,7 @@ async function seedRuntimeData(
 
 	await plugin.updateDataAndReload<PodNotesData>((data) => {
 		data.currentEpisode = options.currentEpisode ?? placeholderEpisode;
+		data.defaultPlaybackRate = options.defaultPlaybackRate ?? 1;
 		data.defaultVolume = 1;
 		data.downloadedEpisodes = {
 			[episode.podcastName]: [toDownloadedEpisode(episode)],
@@ -436,6 +581,9 @@ async function seedRuntimeData(
 			template: options.timestampTemplate ?? "- {{time}}",
 			offset: 0,
 		};
+		if (options.note) {
+			data.note = options.note;
+		}
 	}, RELOAD_OPTIONS);
 }
 
@@ -500,32 +648,44 @@ async function invokePodNotesUri(
 
 async function dispatchLoadedMetadata(obsidian: {
 	dev: { evalJson: <T>(code: string) => Promise<T> };
+	sleep: (ms: number) => Promise<void>;
 }): Promise<void> {
-	const result = await obsidian.dev.evalJson<{ error?: string; ok: boolean }>(`
-		(() => {
-			const audio = document.querySelector(".podcast-view audio");
-			if (!audio) {
-				return { ok: false, error: "No PodNotes audio element found." };
-			}
+	const startedAt = Date.now();
+	let lastError = "No PodNotes audio element found.";
 
-			Object.defineProperty(audio, "duration", {
-				configurable: true,
-				value: 3600,
-			});
-			audio.dispatchEvent(new Event("loadedmetadata"));
-			Object.defineProperty(audio, "paused", {
-				configurable: true,
-				value: false,
-			});
-			audio.dispatchEvent(new Event("play"));
+	while (Date.now() - startedAt < WAIT_OPTS.timeoutMs) {
+		const result = await obsidian.dev.evalJson<{
+			error?: string;
+			ok: boolean;
+		}>(`
+			(() => {
+				const audio = document.querySelector(".podcast-view audio");
+				if (!audio) {
+					return { ok: false, error: "No PodNotes audio element found." };
+				}
 
-			return { ok: true };
-		})()
-	`);
+				Object.defineProperty(audio, "duration", {
+					configurable: true,
+					value: 3600,
+				});
+				audio.dispatchEvent(new Event("loadedmetadata"));
+				Object.defineProperty(audio, "paused", {
+					configurable: true,
+					value: false,
+				});
+				audio.dispatchEvent(new Event("play"));
 
-	if (!result.ok) {
-		throw new Error(result.error ?? "Failed to dispatch loadedmetadata.");
+				return { ok: true };
+			})()
+		`);
+
+		if (result.ok) return;
+
+		lastError = result.error ?? "Failed to dispatch loadedmetadata.";
+		await obsidian.sleep(WAIT_OPTS.intervalMs);
 	}
+
+	throw new Error(lastError);
 }
 
 async function dispatchAudioPlay(obsidian: {
@@ -654,6 +814,141 @@ async function setVolume(
 			return true;
 		})()
 	`);
+}
+
+async function waitForPlaybackRate(
+	obsidian: {
+		dev: { evalJson: <T>(code: string) => Promise<T> };
+		sleep: (ms: number) => Promise<void>;
+	},
+	expected: number,
+): Promise<{ api: number | null; audio: number | null; label: string | null }> {
+	const startedAt = Date.now();
+	let lastRate: {
+		api: number | null;
+		audio: number | null;
+		label: string | null;
+	} = {
+		api: null,
+		audio: null,
+		label: null,
+	};
+
+	while (Date.now() - startedAt < WAIT_OPTS.timeoutMs) {
+		lastRate = await obsidian.dev.evalJson<{
+			api: number | null;
+			audio: number | null;
+			label: string | null;
+		}>(`
+			(() => {
+				const audio = document.querySelector(".podcast-view audio");
+				const label = document.querySelector(".playbackrate-container span");
+				return {
+					api: app.plugins.plugins.${PLUGIN_ID}?.api?.playbackRate ?? null,
+					audio: audio?.playbackRate ?? null,
+					label: label?.textContent ?? null,
+				};
+			})()
+		`);
+
+		if (
+			lastRate.api === expected &&
+			lastRate.audio === expected &&
+			lastRate.label === `${expected}x`
+		) {
+			return lastRate;
+		}
+
+		await obsidian.sleep(WAIT_OPTS.intervalMs);
+	}
+
+	throw new Error(
+		`Timed out waiting for playback rate ${expected}. Last rate: ${JSON.stringify(lastRate)}`,
+	);
+}
+
+async function installMediaSessionRecorder(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+): Promise<void> {
+	const result = await evalJsonAsync<{ error?: string; ok: boolean }>(
+		obsidian,
+		`
+		(async () => {
+			const mediaSession = navigator.mediaSession;
+			if (!mediaSession?.setActionHandler) {
+				return { ok: false, error: "Media Session API is unavailable." };
+			}
+
+			const original = mediaSession.setActionHandler.bind(mediaSession);
+			const handlers = {};
+
+			globalThis.__podnotesMediaSessionHandlers = handlers;
+			globalThis.__podnotesOriginalSetActionHandler = original;
+
+			mediaSession.setActionHandler = (action, handler) => {
+				const result = original(action, handler);
+				handlers[action] = handler;
+				return result;
+			};
+
+			await app.plugins.disablePlugin(${JSON.stringify(PLUGIN_ID)});
+			await app.plugins.enablePlugin(${JSON.stringify(PLUGIN_ID)});
+
+			return { ok: true };
+		})()
+	`,
+	);
+
+	if (!result.ok) {
+		throw new Error(
+			result.error ?? "Failed to install Media Session recorder.",
+		);
+	}
+}
+
+async function restoreMediaSessionRecorder(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+): Promise<void> {
+	await evalJsonAsync<boolean>(
+		obsidian,
+		`
+		(() => {
+			const original = globalThis.__podnotesOriginalSetActionHandler;
+			if (navigator.mediaSession?.setActionHandler && original) {
+				navigator.mediaSession.setActionHandler = original;
+			}
+			delete globalThis.__podnotesMediaSessionHandlers;
+			delete globalThis.__podnotesOriginalSetActionHandler;
+			return true;
+		})()
+	`,
+	);
+}
+
+async function invokeRecordedMediaSessionAction(
+	obsidian: Parameters<typeof evalJsonAsync>[0],
+	action: string,
+): Promise<{ action: string; error?: string; ok: boolean }> {
+	return await evalJsonAsync(
+		obsidian,
+		`
+		(() => {
+			const handlers = globalThis.__podnotesMediaSessionHandlers ?? {};
+			const handler = handlers[${JSON.stringify(action)}];
+
+			if (typeof handler !== "function") {
+				return {
+					action: ${JSON.stringify(action)},
+					ok: false,
+					error: "Media Session action handler was not registered.",
+				};
+			}
+
+			handler({ action: ${JSON.stringify(action)} });
+			return { action: ${JSON.stringify(action)}, ok: true };
+		})()
+	`,
+	);
 }
 
 async function getVolume(obsidian: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
 		],
 		globals: true,
 		environment: "jsdom",
+		environmentOptions: {
+			jsdom: {
+				url: "https://podnotes.test/",
+			},
+		},
 		setupFiles: ["./vitest.setup.ts"],
 	},
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,52 @@
 import "@testing-library/jest-dom";
 
+function createMemoryStorage(): Storage {
+	const items = new Map<string, string>();
+
+	return {
+		get length() {
+			return items.size;
+		},
+		clear: () => {
+			items.clear();
+		},
+		getItem: (key: string) => items.get(key) ?? null,
+		key: (index: number) => Array.from(items.keys())[index] ?? null,
+		removeItem: (key: string) => {
+			items.delete(key);
+		},
+		setItem: (key: string, value: string) => {
+			items.set(key, value);
+		},
+	};
+}
+
+function ensureLocalStorage(): void {
+	let storage: Storage;
+
+	try {
+		storage = window.localStorage;
+	} catch {
+		storage = createMemoryStorage();
+	}
+
+	if (!storage) {
+		storage = createMemoryStorage();
+	}
+
+	Object.defineProperty(globalThis, "localStorage", {
+		configurable: true,
+		value: storage,
+	});
+
+	Object.defineProperty(window, "localStorage", {
+		configurable: true,
+		value: storage,
+	});
+}
+
+ensureLocalStorage();
+
 const months = [
 	"January",
 	"February",


### PR DESCRIPTION
Adds command/API support for playback-rate control and makes timestamp capture available through both the mobile editor toolbar and Media Session controls.

This covers the command surface requested across the assigned issues:
- playback-rate store/API methods plus Increase, Decrease, and Reset playback rate commands wired to the actual audio element
- Capture Timestamp now registers with `editorCallback`, making it eligible for Obsidian's mobile editor toolbar
- Media Session `previoustrack` handling captures the current timestamp from headset/media controls, inserting into the active editor when present and appending to the current episode note otherwise

I intentionally did not map ordinary play/pause headset events to timestamp capture. Those events fire for normal listening controls and would create timestamps on routine pauses; `previoustrack` gives a deliberate capture action while preserving playback controls.

Validation run after rebasing onto `origin/master` (`d97e59e`):
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run test` (includes `npm run check:a11y`, 0 Svelte warnings)
- `PATH="/tmp/podnotes-docs-venv/bin:$PATH" npm run docs:build`
- isolated real Obsidian vault runtime: `npx vitest run --config vitest.e2e.config.ts tests/e2e/podnotes-runtime.test.ts -t 'captures a linked segment|stops playback when a segment URI|playback-rate commands|previous-track Media Session action'`
- isolated mobile-emulation probe confirmed `podnotes:capture-timestamp` has `editorCallback`, no `editorCheckCallback`, and no runtime errors were captured

Runtime note: the Media Session behavior was validated in the real isolated Obsidian app by invoking the registered action handler. Physical iOS/Android headset button mapping was not validated on device in this worktree environment.

Adversarial review covered correctness/runtime behavior, API/settings persistence, mobile/MediaSession behavior, maintainability, and docs. Findings were fixed before the final validation pass.

Fixes #92
Fixes #95
Fixes #89