### PR TITLE
feat(player): support video episode playback

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -13,7 +13,7 @@ Here are the features that will help you do that 👇.
 - Create podcast notes from templates with metadata about episodes
 - Capture timestamps & link directly to the time in the episode
 - Download episodes for offline playback
-- Support for non-podcast local audio files
+- Support for non-podcast local audio and video files
 - API that can be used by plugins like [QuickAdd](https://github.com/chhoumann/QuickAdd) or [Templater](https://github.com/silentvoid13/Templater) for custom workflows
 
 ## Installation

--- a/docs/docs/local_files.md
+++ b/docs/docs/local_files.md
@@ -1,6 +1,6 @@
-PodNotes supports local files. You can right-click any audio file and click `Play with PodNotes`.
+PodNotes supports local media files. You can right-click any audio or video file and click `Play with PodNotes`.
 
-In the podcast grid, you will see a playlist with a folder icon. This is a playlist of every episode you have available offline: both local audio files you have played with `Play with PodNotes` and episodes you have downloaded. Removing a downloaded file also removes it from this playlist.
+In the podcast grid, you will see a playlist with a folder icon. This is a playlist of every episode you have available offline: both local media files you have played with `Play with PodNotes` and episodes you have downloaded. Removing a downloaded file also removes it from this playlist.
 
 PodNotes will attempt to treat all local files as podcast episodes. This means all standard features are available, such as timestamps, note creation, and persisting playback time. Any exceptions will be added here.
 

--- a/docs/docs/templates.md
+++ b/docs/docs/templates.md
@@ -31,7 +31,7 @@ This template will be used to create the note text. You can use the following sy
 
 - `{{podcast}}`: The name of the podcast.
 - `{{url}}`: The URL of the podcast episode. For a local-file episode this is a link to the file rather than a web URL. Tag values are inserted verbatim, so when you place one in a quoted YAML property (e.g. `url: "{{url}}"`) it stays valid for well-formed feed URLs and ordinary file names (a URL or file name containing a literal `"` would need escaping).
-- `{{stream}}`: The direct URL of the episode's audio file — the RSS `<enclosure>` URL for podcast feeds, or the underlying audio source for Pocket Casts and local-file episodes. Handy for embedding the raw audio or linking to the source. An empty string is used in the rare case no audio URL is available. Available in episode note templates only.
+- `{{stream}}`: The direct URL of the episode's media file — the RSS `<enclosure>` URL for podcast feeds, or the underlying media source for Pocket Casts and local-file episodes. Handy for embedding the raw audio/video or linking to the source. An empty string is used in the rare case no media URL is available. Available in episode note templates only.
 - `{{date}}`: The publish date of the podcast episode.
 	- You can use `{{date:format}}` to specify a custom [Moment.js](https://momentjs.com) format. E.g. `{{date:YYYY-MM-DD}}`.
 - `{{currentDate}}`: The current date — i.e. when the note is created — as opposed to `{{date}}`, which is the episode's publish date. Useful for a "captured on" metadata field.

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -161,6 +161,42 @@ describe("downloadEpisodeWithNotice (download command path)", () => {
 			size: buffer.byteLength,
 		});
 	});
+
+	it("preserves audio/webm downloads as audio WebM files", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x00, 0x00, 0x00, 0x18);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "audio/webm" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Audio WebM Title",
+			streamUrl: "https://example.com/episode.webm",
+			mediaType: "audio",
+		});
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+		try {
+			await downloadEpisodeWithNotice(episode, "Podcasts/{{title}}");
+		} finally {
+			setTimeoutSpy.mockRestore();
+		}
+
+		expect(createBinary).toHaveBeenCalledWith(
+			"Podcasts/Audio WebM Title.webm",
+			buffer,
+		);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded).toMatchObject({
+			title: "Audio WebM Title",
+			filePath: "Podcasts/Audio WebM Title.webm",
+			mediaType: "audio",
+			size: buffer.byteLength,
+		});
+	});
 });
 
 describe("downloadEpisode (API path)", () => {
@@ -501,24 +537,45 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
-	it("does not transcribe a downloaded video file with stale audio metadata", async () => {
+	it("does not transcribe a downloaded video file without media metadata", async () => {
 		const downloaded = episode({
-			title: "Stale Metadata Video",
+			title: "Unmarked Video",
 			streamUrl: "https://cdn.example.com/watch?id=old",
-			mediaType: "audio",
 		});
-		seedFile("Podcasts/stale-video.webm", "VIDEO-BYTES");
-		downloadedEpisodes.addEpisode(downloaded, "Podcasts/stale-video.webm", 20);
+		seedFile("Podcasts/unmarked-video.webm", "VIDEO-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/unmarked-video.webm", 20);
 
 		const current = episode({
-			title: "Stale Metadata Video",
+			title: "Unmarked Video",
 			streamUrl: "https://cdn.example.com/watch?id=old",
-			mediaType: "audio",
 		});
 
 		await expect(getEpisodeAudioBuffer(current)).rejects.toThrow(
 			/audio episodes only/i,
 		);
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
+	it("reuses an audio/webm download whose file path is webm", async () => {
+		const downloaded = episode({
+			title: "Audio WebM Download",
+			streamUrl: "https://cdn.example.com/episode.webm",
+			mediaType: "audio",
+		});
+		seedFile("Podcasts/audio-webm.webm", "AUDIO-WEBM-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/audio-webm.webm", 20);
+
+		const current = episode({
+			title: "Audio WebM Download",
+			streamUrl: "https://cdn.example.com/episode.webm",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(current);
+
+		expect(decode(result.buffer)).toBe("AUDIO-WEBM-BYTES");
+		expect(result.extension).toBe("webm");
+		expect(result.basename).toBe("audio-webm");
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
@@ -545,7 +602,7 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
-	it("does not transcribe a local video file with stale audio metadata", async () => {
+	it("does not transcribe a local video file", async () => {
 		const local = episode({
 			title: "Local Video",
 			podcastName: "local file",
@@ -554,7 +611,7 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 			streamUrl: "",
 			url: "Local/video.webm",
 			filePath: "Local/video.webm",
-			mediaType: "audio",
+			mediaType: "video",
 		} as Partial<LocalEpisode>) as LocalEpisode;
 		seedFile("Local/video.webm", "VIDEO-BYTES");
 

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -148,6 +148,28 @@ describe("downloadEpisodeWithNotice (download command path)", () => {
 		expect(get(downloadedEpisodes)["Pod"]).toBeUndefined();
 	});
 
+	it("rejects blank-type extensionless video downloads instead of saving them as mp3", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x00, 0x01, 0x02, 0x03);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: {},
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Blank Type Video",
+			streamUrl: "https://example.com/watch?id=42",
+			mediaType: "video",
+		});
+
+		await expect(
+			downloadEpisodeWithNotice(episode, "Podcasts/{{title}}"),
+		).rejects.toThrow("Not a playable media file");
+
+		expect(createBinary).not.toHaveBeenCalled();
+		expect(get(downloadedEpisodes)["Pod"]).toBeUndefined();
+	});
+
 	it("saves video/ogg downloads with a video extension even when bytes have an Ogg signature", async () => {
 		const { createBinary } = setupVault();
 		const buffer = bytes(0x4f, 0x67, 0x67, 0x53);

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -126,6 +126,74 @@ describe("downloadEpisodeWithNotice (download command path)", () => {
 		});
 	});
 
+	it("saves video/ogg downloads with a video extension even when bytes have an Ogg signature", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x4f, 0x67, 0x67, 0x53);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "video/ogg" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Ogg Video Title",
+			streamUrl: "https://example.com/video.ogv",
+			mediaType: "video",
+		});
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+		try {
+			await downloadEpisodeWithNotice(episode, "Podcasts/{{title}}");
+		} finally {
+			setTimeoutSpy.mockRestore();
+		}
+
+		expect(createBinary).toHaveBeenCalledWith(
+			"Podcasts/Ogg Video Title.ogv",
+			buffer,
+		);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded).toMatchObject({
+			title: "Ogg Video Title",
+			filePath: "Podcasts/Ogg Video Title.ogv",
+			mediaType: "video",
+			size: buffer.byteLength,
+		});
+	});
+
+	it("uses an unambiguous video URL extension before the Ogg audio signature", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x4f, 0x67, 0x67, 0x53);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "application/octet-stream" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Generic Ogg Video",
+			streamUrl: "https://example.com/video.ogv",
+			mediaType: "video",
+		});
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+		try {
+			await downloadEpisodeWithNotice(episode, "Podcasts/{{title}}");
+		} finally {
+			setTimeoutSpy.mockRestore();
+		}
+
+		expect(createBinary).toHaveBeenCalledWith(
+			"Podcasts/Generic Ogg Video.ogv",
+			buffer,
+		);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded?.filePath).toBe("Podcasts/Generic Ogg Video.ogv");
+		expect(recorded?.mediaType).toBe("video");
+	});
+
 	it("saves audio/mp4 downloads with an audio extension even when the URL ends in mp4", async () => {
 		const { createBinary } = setupVault();
 		const buffer = bytes(0x00, 0x00, 0x00, 0x18);
@@ -254,6 +322,32 @@ describe("downloadEpisode (API path)", () => {
 		expect(createBinary).toHaveBeenCalledWith("My Title.mp3", buffer);
 		const [writtenPath] = createBinary.mock.calls[0];
 		expect(writtenPath).not.toBe(".mp3");
+	});
+
+	it("uses GET response metadata for the final extension on new writes", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x4f, 0x67, 0x67, 0x53);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "video/ogg" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+
+		const episode = makeEpisode({
+			title: "API Ogg Video",
+			streamUrl: "https://example.com/video.ogg",
+			mediaType: "video",
+		});
+		const path = await downloadEpisode(episode, "Podcasts/{{title}}");
+
+		expect(path).toBe("Podcasts/API Ogg Video.ogv");
+		expect(createBinary).toHaveBeenCalledWith(
+			"Podcasts/API Ogg Video.ogv",
+			buffer,
+		);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded?.filePath).toBe("Podcasts/API Ogg Video.ogv");
+		expect(recorded?.mediaType).toBe("video");
 	});
 });
 
@@ -628,8 +722,8 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 			title: "Unmarked Video",
 			streamUrl: "https://cdn.example.com/watch?id=old",
 		});
-		seedFile("Podcasts/unmarked-video.webm", "VIDEO-BYTES");
-		downloadedEpisodes.addEpisode(downloaded, "Podcasts/unmarked-video.webm", 20);
+		seedFile("Podcasts/unmarked-video.ogv", "VIDEO-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/unmarked-video.ogv", 20);
 
 		const current = episode({
 			title: "Unmarked Video",

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -566,6 +566,28 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
+	it("does not reuse a media-path download when the stable query id changed", async () => {
+		const downloaded = episode({
+			title: "Fixed Path Episode",
+			streamUrl: "https://cdn.example.com/episode.mp3?id=1&token=OLD",
+		});
+		seedFile("Podcasts/fixed-path.mp3", "WRONG-CACHED-AUDIO");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/fixed-path.mp3", 20);
+
+		const current = episode({
+			title: "Fixed Path Episode",
+			streamUrl: "https://cdn.example.com/episode.mp3?id=2&token=NEW",
+		});
+		const result = await getEpisodeAudioBuffer(current);
+
+		expect(decode(result.buffer)).toBe("ENGLISH-AUDIO");
+		expect(requestUrlMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "https://cdn.example.com/episode.mp3?id=2&token=NEW",
+			}),
+		);
+	});
+
 	it("reuses an extensionless cached file when only signed token params changed", async () => {
 		const downloaded = episode({
 			title: "Extensionless Token Episode",

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -700,6 +700,42 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		await expect(getEpisodeAudioBuffer(ep)).rejects.toThrow(/not audio/i);
 	});
 
+	it.each([
+		{
+			contentType: "video/mp4",
+			expectedExtension: "m4a",
+			streamUrl: "https://cdn.example.com/legacy-audio.mp4",
+			text: "LEGACY-VIDEO-TYPED-AUDIO-MP4",
+		},
+		{
+			contentType: "application/octet-stream",
+			expectedExtension: "webm",
+			streamUrl: "https://cdn.example.com/legacy-audio.webm",
+			text: "LEGACY-GENERIC-AUDIO-WEBM",
+		},
+	])(
+		"uses an inferred audio hint for legacy container streams served as $contentType",
+		async ({ contentType, expectedExtension, streamUrl, text }) => {
+			requestUrlMock.mockImplementation(
+				() =>
+					Promise.resolve({
+						status: 200,
+						headers: { "content-type": contentType },
+						arrayBuffer: new TextEncoder().encode(text).buffer,
+					}) as unknown as ReturnType<typeof requestUrl>,
+			);
+			const ep = episode({
+				title: "Legacy Container Audio",
+				streamUrl,
+			});
+
+			const result = await getEpisodeAudioBuffer(ep);
+
+			expect(decode(result.buffer)).toBe(text);
+			expect(result.extension).toBe(expectedExtension);
+		},
+	);
+
 	it("uses explicit audio metadata for mp4 streams served with a video content type", async () => {
 		requestUrlMock.mockImplementation(
 			() =>

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -518,6 +518,50 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		await expect(getEpisodeAudioBuffer(ep)).rejects.toThrow(/not audio/i);
 	});
 
+	it("uses explicit audio metadata for mp4 streams served with a video content type", async () => {
+		requestUrlMock.mockImplementation(
+			() =>
+				Promise.resolve({
+					status: 200,
+					headers: { "content-type": "video/mp4" },
+					arrayBuffer: new TextEncoder().encode("VIDEO-TYPED-AUDIO-MP4")
+						.buffer,
+				}) as unknown as ReturnType<typeof requestUrl>,
+		);
+		const ep = episode({
+			title: "Video Typed Audio MP4",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(ep);
+
+		expect(decode(result.buffer)).toBe("VIDEO-TYPED-AUDIO-MP4");
+		expect(result.extension).toBe("m4a");
+	});
+
+	it("uses explicit audio metadata for webm streams served with a video content type", async () => {
+		requestUrlMock.mockImplementation(
+			() =>
+				Promise.resolve({
+					status: 200,
+					headers: { "content-type": "video/webm" },
+					arrayBuffer: new TextEncoder().encode("VIDEO-TYPED-AUDIO-WEBM")
+						.buffer,
+				}) as unknown as ReturnType<typeof requestUrl>,
+		);
+		const ep = episode({
+			title: "Video Typed Audio WebM",
+			streamUrl: "https://cdn.example.com/episode.webm",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(ep);
+
+		expect(decode(result.buffer)).toBe("VIDEO-TYPED-AUDIO-WEBM");
+		expect(result.extension).toBe("webm");
+	});
+
 	it("uses explicit audio metadata for mp4 streams served as octet-stream", async () => {
 		requestUrlMock.mockImplementation(
 			() =>

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -644,6 +644,32 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
+	it("reuses a legacy audio/mp4 download whose registry entry lacks media metadata", async () => {
+		const downloaded = episode({
+			title: "Legacy Audio MP4 Download",
+			streamUrl: "https://cdn.example.com/legacy-episode.mp4",
+		});
+		seedFile("Podcasts/legacy-audio-mp4.mp4", "LEGACY-AUDIO-MP4-BYTES");
+		downloadedEpisodes.addEpisode(
+			downloaded,
+			"Podcasts/legacy-audio-mp4.mp4",
+			20,
+		);
+
+		const current = episode({
+			title: "Legacy Audio MP4 Download",
+			streamUrl: "https://cdn.example.com/legacy-episode.mp4",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(current);
+
+		expect(decode(result.buffer)).toBe("LEGACY-AUDIO-MP4-BYTES");
+		expect(result.extension).toBe("m4a");
+		expect(result.basename).toBe("legacy-audio-mp4");
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
 	it("does not transcribe a local video file", async () => {
 		const local = episode({
 			title: "Local Video",

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -518,6 +518,48 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		await expect(getEpisodeAudioBuffer(ep)).rejects.toThrow(/not audio/i);
 	});
 
+	it("uses explicit audio metadata for mp4 streams served as octet-stream", async () => {
+		requestUrlMock.mockImplementation(
+			() =>
+				Promise.resolve({
+					status: 200,
+					headers: { "content-type": "application/octet-stream" },
+					arrayBuffer: new TextEncoder().encode("AUDIO-MP4-BYTES").buffer,
+				}) as unknown as ReturnType<typeof requestUrl>,
+		);
+		const ep = episode({
+			title: "Generic Audio MP4",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(ep);
+
+		expect(decode(result.buffer)).toBe("AUDIO-MP4-BYTES");
+		expect(result.extension).toBe("m4a");
+	});
+
+	it("uses explicit audio metadata for webm streams served as octet-stream", async () => {
+		requestUrlMock.mockImplementation(
+			() =>
+				Promise.resolve({
+					status: 200,
+					headers: { "content-type": "application/octet-stream" },
+					arrayBuffer: new TextEncoder().encode("AUDIO-WEBM-BYTES").buffer,
+				}) as unknown as ReturnType<typeof requestUrl>,
+		);
+		const ep = episode({
+			title: "Generic Audio WebM",
+			streamUrl: "https://cdn.example.com/episode.webm",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(ep);
+
+		expect(decode(result.buffer)).toBe("AUDIO-WEBM-BYTES");
+		expect(result.extension).toBe("webm");
+	});
+
 	it("does not reuse a known video download for transcription", async () => {
 		const downloaded = episode({
 			title: "Known Video",

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -566,6 +566,28 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
+	it("reuses an extensionless cached file when only signed token params changed", async () => {
+		const downloaded = episode({
+			title: "Extensionless Token Episode",
+			streamUrl: "https://cdn.example.com/download?id=123&token=OLD&exp=1",
+		});
+		seedFile("Podcasts/extensionless-token.m4a", "CACHED-EXTENSIONLESS-AUDIO");
+		downloadedEpisodes.addEpisode(
+			downloaded,
+			"Podcasts/extensionless-token.m4a",
+			20,
+		);
+
+		const current = episode({
+			title: "Extensionless Token Episode",
+			streamUrl: "https://cdn.example.com/download?id=123&token=NEW&exp=2",
+		});
+		const result = await getEpisodeAudioBuffer(current);
+
+		expect(decode(result.buffer)).toBe("CACHED-EXTENSIONLESS-AUDIO");
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
 	it("does not reuse a same-title sibling's download; fetches this episode's own audio", async () => {
 		// Same podcast + same title, different episode (different stream URL). The
 		// registry is keyed by podcastName+title, so getEpisode() returns the

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -126,6 +126,28 @@ describe("downloadEpisodeWithNotice (download command path)", () => {
 		});
 	});
 
+	it("rejects unsupported extensionless video downloads instead of saving them as mp3", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x00, 0x01, 0x02, 0x03);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "video/x-msvideo" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Unsupported Video",
+			streamUrl: "https://example.com/watch?id=42",
+			mediaType: "video",
+		});
+
+		await expect(
+			downloadEpisodeWithNotice(episode, "Podcasts/{{title}}"),
+		).rejects.toThrow("Not a playable media file");
+
+		expect(createBinary).not.toHaveBeenCalled();
+		expect(get(downloadedEpisodes)["Pod"]).toBeUndefined();
+	});
+
 	it("saves video/ogg downloads with a video extension even when bytes have an Ogg signature", async () => {
 		const { createBinary } = setupVault();
 		const buffer = bytes(0x4f, 0x67, 0x67, 0x53);

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -125,6 +125,42 @@ describe("downloadEpisodeWithNotice (download command path)", () => {
 			size: buffer.byteLength,
 		});
 	});
+
+	it("saves audio/mp4 downloads with an audio extension even when the URL ends in mp4", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x00, 0x00, 0x00, 0x18);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "audio/mp4" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Audio MP4 Title",
+			streamUrl: "https://example.com/episode.mp4",
+			mediaType: "audio",
+		});
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+		try {
+			await downloadEpisodeWithNotice(episode, "Podcasts/{{title}}");
+		} finally {
+			setTimeoutSpy.mockRestore();
+		}
+
+		expect(createBinary).toHaveBeenCalledWith(
+			"Podcasts/Audio MP4 Title.m4a",
+			buffer,
+		);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded).toMatchObject({
+			title: "Audio MP4 Title",
+			filePath: "Podcasts/Audio MP4 Title.m4a",
+			mediaType: "audio",
+			size: buffer.byteLength,
+		});
+	});
 });
 
 describe("downloadEpisode (API path)", () => {
@@ -471,8 +507,8 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 			streamUrl: "https://cdn.example.com/watch?id=old",
 			mediaType: "audio",
 		});
-		seedFile("Podcasts/stale-video.mp4", "VIDEO-BYTES");
-		downloadedEpisodes.addEpisode(downloaded, "Podcasts/stale-video.mp4", 20);
+		seedFile("Podcasts/stale-video.webm", "VIDEO-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/stale-video.webm", 20);
 
 		const current = episode({
 			title: "Stale Metadata Video",
@@ -486,6 +522,29 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
+	it("reuses an audio/mp4 download whose legacy file path is mp4", async () => {
+		const downloaded = episode({
+			title: "Audio MP4 Download",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "audio",
+		});
+		seedFile("Podcasts/audio-mp4.mp4", "AUDIO-MP4-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/audio-mp4.mp4", 20);
+
+		const current = episode({
+			title: "Audio MP4 Download",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "audio",
+		});
+
+		const result = await getEpisodeAudioBuffer(current);
+
+		expect(decode(result.buffer)).toBe("AUDIO-MP4-BYTES");
+		expect(result.extension).toBe("m4a");
+		expect(result.basename).toBe("audio-mp4");
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
 	it("does not transcribe a local video file with stale audio metadata", async () => {
 		const local = episode({
 			title: "Local Video",
@@ -493,11 +552,11 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 			description: "",
 			content: "",
 			streamUrl: "",
-			url: "Local/video.mp4",
-			filePath: "Local/video.mp4",
+			url: "Local/video.webm",
+			filePath: "Local/video.webm",
 			mediaType: "audio",
 		} as Partial<LocalEpisode>) as LocalEpisode;
-		seedFile("Local/video.mp4", "VIDEO-BYTES");
+		seedFile("Local/video.webm", "VIDEO-BYTES");
 
 		await expect(getEpisodeAudioBuffer(local)).rejects.toThrow(
 			/audio episodes only/i,

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { get } from "svelte/store";
 import { requestUrl, TFile } from "obsidian";
-import {
+import downloadEpisodeWithNotice, {
 	detectAudioFileExtension,
 	downloadEpisode,
 	getEpisodeAudioBuffer,
@@ -89,6 +89,41 @@ describe("detectAudioFileExtension", () => {
 	it("does not crash on a buffer shorter than the longest signature", () => {
 		expect(detectAudioFileExtension(bytes(0xff))).toBeNull();
 		expect(detectAudioFileExtension(new ArrayBuffer(0))).toBeNull();
+	});
+});
+
+describe("downloadEpisodeWithNotice (download command path)", () => {
+	it("saves extensionless video downloads using the response content type", async () => {
+		const { createBinary } = setupVault();
+		const buffer = bytes(0x00, 0x00, 0x00, 0x18);
+		requestUrlMock.mockResolvedValue({
+			status: 200,
+			headers: { "content-type": "video/mp4" },
+			arrayBuffer: buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>);
+		const episode = makeEpisode({
+			title: "Video Title",
+			streamUrl: "https://example.com/watch?id=42",
+			mediaType: "video",
+		});
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+		try {
+			await downloadEpisodeWithNotice(episode, "Podcasts/{{title}}");
+		} finally {
+			setTimeoutSpy.mockRestore();
+		}
+
+		expect(createBinary).toHaveBeenCalledWith("Podcasts/Video Title.mp4", buffer);
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded).toMatchObject({
+			title: "Video Title",
+			filePath: "Podcasts/Video Title.mp4",
+			mediaType: "video",
+			size: buffer.byteLength,
+		});
 	});
 });
 
@@ -392,6 +427,82 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		});
 
 		await expect(getEpisodeAudioBuffer(ep)).rejects.toThrow(/not audio/i);
+	});
+
+	it("rejects extensionless video streams instead of treating their mp4 content type as audio", async () => {
+		requestUrlMock.mockImplementation(
+			() =>
+				Promise.resolve({
+					status: 200,
+					headers: { "content-type": "video/mp4" },
+					arrayBuffer: bytes(0x00, 0x00, 0x00, 0x18),
+				}) as unknown as ReturnType<typeof requestUrl>,
+		);
+		const ep = episode({
+			title: "Video Episode",
+			streamUrl: "https://example.com/watch?id=42",
+		});
+
+		await expect(getEpisodeAudioBuffer(ep)).rejects.toThrow(/not audio/i);
+	});
+
+	it("does not reuse a known video download for transcription", async () => {
+		const downloaded = episode({
+			title: "Known Video",
+			streamUrl: "https://cdn.example.com/watch?id=old",
+			mediaType: "video",
+		});
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/video.mp4", 20);
+
+		const current = episode({
+			title: "Known Video",
+			streamUrl: "https://cdn.example.com/watch?id=old",
+		});
+
+		await expect(getEpisodeAudioBuffer(current)).rejects.toThrow(
+			/audio episodes only/i,
+		);
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
+	it("does not transcribe a downloaded video file with stale audio metadata", async () => {
+		const downloaded = episode({
+			title: "Stale Metadata Video",
+			streamUrl: "https://cdn.example.com/watch?id=old",
+			mediaType: "audio",
+		});
+		seedFile("Podcasts/stale-video.mp4", "VIDEO-BYTES");
+		downloadedEpisodes.addEpisode(downloaded, "Podcasts/stale-video.mp4", 20);
+
+		const current = episode({
+			title: "Stale Metadata Video",
+			streamUrl: "https://cdn.example.com/watch?id=old",
+			mediaType: "audio",
+		});
+
+		await expect(getEpisodeAudioBuffer(current)).rejects.toThrow(
+			/audio episodes only/i,
+		);
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
+	it("does not transcribe a local video file with stale audio metadata", async () => {
+		const local = episode({
+			title: "Local Video",
+			podcastName: "local file",
+			description: "",
+			content: "",
+			streamUrl: "",
+			url: "Local/video.mp4",
+			filePath: "Local/video.mp4",
+			mediaType: "audio",
+		} as Partial<LocalEpisode>) as LocalEpisode;
+		seedFile("Local/video.mp4", "VIDEO-BYTES");
+
+		await expect(getEpisodeAudioBuffer(local)).rejects.toThrow(
+			/audio episodes only/i,
+		);
+		expect(requestUrlMock).not.toHaveBeenCalled();
 	});
 
 	it("reads local-file episodes from disk by their resolved path", async () => {

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -4,7 +4,7 @@ import {
 	DownloadPathTemplateEngine,
 	replaceIllegalFileNameCharactersInString,
 } from "./TemplateEngine";
-import type { Episode } from "./types/Episode";
+import type { Episode, EpisodeMediaType } from "./types/Episode";
 import type { LocalEpisode } from "./types/LocalEpisode";
 import { encodeUrlForRequest } from "./utility/encodeUrlForRequest";
 import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
@@ -310,12 +310,17 @@ function inferFileExtensionFromDownload(
 		return signatureExtension;
 	}
 
+	const contentTypeExtension = getExtensionFromContentType(contentType);
+	if (contentTypeExtension) {
+		return contentTypeExtension;
+	}
+
 	const urlExtension = getUrlExtension(episode.streamUrl);
 	if (urlExtension) {
 		return urlExtension;
 	}
 
-	return getExtensionFromContentType(contentType);
+	return null;
 }
 
 function downloadAppearsPlayable(
@@ -457,7 +462,7 @@ export async function getEpisodeAudioBuffer(
 			);
 		}
 
-		return readVaultAudio(localFilePath);
+		return readVaultAudio(localFilePath, getEpisodeMediaType(episode));
 	}
 
 	// Reuse a previously downloaded file only when the registry entry is the SAME
@@ -478,7 +483,10 @@ export async function getEpisodeAudioBuffer(
 
 		const existingFile = app.vault.getAbstractFileByPath(registered.filePath);
 		if (existingFile instanceof TFile) {
-			return readVaultAudio(registered.filePath);
+			return readVaultAudio(
+				registered.filePath,
+				getEpisodeMediaType(registered),
+			);
 		}
 	}
 
@@ -510,21 +518,37 @@ export async function getEpisodeAudioBuffer(
 
 async function readVaultAudio(
 	filePath: string,
+	mediaTypeHint?: EpisodeMediaType,
 ): Promise<{ buffer: ArrayBuffer; extension: string; basename: string }> {
 	const file = app.vault.getAbstractFileByPath(filePath);
 	if (!(file instanceof TFile)) {
 		throw new Error(`Unable to read the audio file at "${filePath}".`);
 	}
 
-	const mediaType =
-		getMediaTypeFromExtension(file.extension) ??
-		getMediaTypeFromPath(file.path);
+	const fileExtension =
+		file.extension || getUrlExtension(file.path || filePath) || "";
+	const explicitAudioMp4 =
+		mediaTypeHint === "audio" && fileExtension.toLowerCase() === "mp4";
+	const mediaType = explicitAudioMp4
+		? "audio"
+		: getMediaTypeFromExtension(fileExtension) ??
+			getMediaTypeFromPath(file.path || filePath);
 	if (mediaType !== "audio") {
 		throw new Error(`Unable to read the non-audio file at "${filePath}".`);
 	}
 
 	const buffer = await app.vault.readBinary(file);
-	return { buffer, extension: file.extension, basename: file.basename };
+	return {
+		buffer,
+		extension: explicitAudioMp4 ? "m4a" : fileExtension,
+		basename: file.basename || getFileBasename(file.path || filePath),
+	};
+}
+
+function getFileBasename(filePath: string): string {
+	const fileName = filePath.split("/").pop() ?? filePath;
+	const dot = fileName.lastIndexOf(".");
+	return dot > 0 ? fileName.slice(0, dot) : fileName;
 }
 
 interface AudioSignature {

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -12,6 +12,14 @@ import { ensureFolderExists } from "./utility/ensureFolderExists";
 import { isLocalFile } from "./utility/isLocalFile";
 import getUrlExtension from "./utility/getUrlExtension";
 import getExtensionFromContentType from "./utility/getExtensionFromContentType";
+import {
+	getEpisodeMediaType,
+	getMediaTypeFromContentType,
+	getMediaTypeFromExtension,
+	getMediaTypeFromPath,
+	isPlayableMediaExtension,
+	isSameMediaSource,
+} from "./utility/mediaType";
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -98,17 +106,15 @@ export default async function downloadEpisodeWithNotice(
 		data,
 		contentType,
 	);
-	const normalizedType = contentType.toLowerCase();
-	const typeAppearsAudio = normalizedType === "" || normalizedType.includes("audio");
 
-	if (!typeAppearsAudio && !inferredExtension) {
+	if (!downloadAppearsPlayable(contentType, inferredExtension)) {
 		update((bodyEl) => {
 			bodyEl.createEl("p", {
-				text: `Downloaded file is not an audio file. It is of type "${contentType}". File: ${data.byteLength} bytes.`,
+				text: `Downloaded file is not an audio or video file. It is of type "${contentType}". File: ${data.byteLength} bytes.`,
 			});
 		});
 
-		throw new Error("Not an audio file");
+		throw new Error("Not a playable media file");
 	}
 
 	const fileExtension = inferredExtension ?? "mp3";
@@ -312,6 +318,31 @@ function inferFileExtensionFromDownload(
 	return getExtensionFromContentType(contentType);
 }
 
+function downloadAppearsPlayable(
+	contentType: string,
+	extension: string | null,
+): boolean {
+	const normalizedType = contentType.toLowerCase();
+	return (
+		normalizedType === "" ||
+		getMediaTypeFromContentType(normalizedType) !== null ||
+		isPlayableMediaExtension(extension)
+	);
+}
+
+function downloadAppearsAudio(
+	contentType: string,
+	extension: string | null,
+): boolean {
+	const contentMediaType = getMediaTypeFromContentType(contentType);
+	if (contentMediaType) {
+		return contentMediaType === "audio";
+	}
+
+	const normalizedType = contentType.toLowerCase();
+	return normalizedType === "" || getMediaTypeFromExtension(extension) === "audio";
+}
+
 /**
  * UNUSED IN PRODUCTION — kept only for the #178 tests. Do NOT use this for
  * transcription: it derives the on-disk path from the download-path template and
@@ -351,8 +382,8 @@ export async function downloadEpisode(
 	try {
 		const { data, contentType } = await downloadFile(episode.streamUrl);
 
-		if (!contentType.includes("audio") && !fileExtension) {
-			throw new Error("Not an audio file.");
+		if (!downloadAppearsPlayable(contentType, fileExtension)) {
+			throw new Error("Not a playable media file.");
 		}
 
 		await createEpisodeFile({
@@ -414,6 +445,10 @@ async function getFileExtension(url: string): Promise<string> {
 export async function getEpisodeAudioBuffer(
 	episode: Episode,
 ): Promise<{ buffer: ArrayBuffer; extension: string; basename: string }> {
+	if (getEpisodeMediaType(episode) !== "audio") {
+		throw new Error("Transcription supports audio episodes only.");
+	}
+
 	if (isLocalFile(episode)) {
 		const localFilePath = resolveLocalEpisodeFilePath(episode);
 		if (!localFilePath) {
@@ -435,8 +470,12 @@ export async function getEpisodeAudioBuffer(
 	const registered = downloadedEpisodes.getEpisode(episode);
 	if (
 		registered?.filePath &&
-		isSameAudioSource(registered.streamUrl, episode.streamUrl)
+		isSameMediaSource(registered.streamUrl, episode.streamUrl)
 	) {
+		if (getEpisodeMediaType(registered) !== "audio") {
+			throw new Error("Transcription supports audio episodes only.");
+		}
+
 		const existingFile = app.vault.getAbstractFileByPath(registered.filePath);
 		if (existingFile instanceof TFile) {
 			return readVaultAudio(registered.filePath);
@@ -450,10 +489,7 @@ export async function getEpisodeAudioBuffer(
 			data,
 			contentType,
 		);
-		const normalizedType = contentType.toLowerCase();
-		const typeAppearsAudio =
-			normalizedType === "" || normalizedType.includes("audio");
-		if (!typeAppearsAudio && !inferredExtension) {
+		if (!downloadAppearsAudio(contentType, inferredExtension)) {
 			throw new Error(
 				`The downloaded file is not audio (received "${contentType}"). The episode may be unavailable or require re-authentication.`,
 			);
@@ -472,29 +508,19 @@ export async function getEpisodeAudioBuffer(
 	}
 }
 
-/**
- * Whether two stream URLs point at the same audio file. Compares origin+path so
- * rotating query strings (signed-CDN tokens, cache-busters) don't count as a
- * different source. Falls back to exact equality for non-absolute/odd URLs.
- */
-function isSameAudioSource(a: string, b: string): boolean {
-	if (a === b) return true;
-	if (!a || !b) return false;
-	try {
-		const ua = new URL(a);
-		const ub = new URL(b);
-		return ua.origin === ub.origin && ua.pathname === ub.pathname;
-	} catch {
-		return false;
-	}
-}
-
 async function readVaultAudio(
 	filePath: string,
 ): Promise<{ buffer: ArrayBuffer; extension: string; basename: string }> {
 	const file = app.vault.getAbstractFileByPath(filePath);
 	if (!(file instanceof TFile)) {
 		throw new Error(`Unable to read the audio file at "${filePath}".`);
+	}
+
+	const mediaType =
+		getMediaTypeFromExtension(file.extension) ??
+		getMediaTypeFromPath(file.path);
+	if (mediaType !== "audio") {
+		throw new Error(`Unable to read the non-audio file at "${filePath}".`);
 	}
 
 	const buffer = await app.vault.readBinary(file);

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -527,9 +527,11 @@ async function readVaultAudio(
 
 	const fileExtension =
 		file.extension || getUrlExtension(file.path || filePath) || "";
-	const explicitAudioMp4 =
-		mediaTypeHint === "audio" && fileExtension.toLowerCase() === "mp4";
-	const mediaType = explicitAudioMp4
+	const explicitAudioContainer =
+		mediaTypeHint === "audio" &&
+		(fileExtension.toLowerCase() === "mp4" ||
+			fileExtension.toLowerCase() === "webm");
+	const mediaType = explicitAudioContainer
 		? "audio"
 		: getMediaTypeFromExtension(fileExtension) ??
 			getMediaTypeFromPath(file.path || filePath);
@@ -540,7 +542,10 @@ async function readVaultAudio(
 	const buffer = await app.vault.readBinary(file);
 	return {
 		buffer,
-		extension: explicitAudioMp4 ? "m4a" : fileExtension,
+		extension:
+			mediaTypeHint === "audio" && fileExtension.toLowerCase() === "mp4"
+				? "m4a"
+				: fileExtension,
 		basename: file.basename || getFileBasename(file.path || filePath),
 	};
 }

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -338,6 +338,7 @@ function downloadAppearsPlayable(
 function downloadAppearsAudio(
 	contentType: string,
 	extension: string | null,
+	mediaTypeHint?: EpisodeMediaType,
 ): boolean {
 	const contentMediaType = getMediaTypeFromContentType(contentType);
 	if (contentMediaType) {
@@ -345,7 +346,35 @@ function downloadAppearsAudio(
 	}
 
 	const normalizedType = contentType.toLowerCase();
-	return normalizedType === "" || getMediaTypeFromExtension(extension) === "audio";
+	return (
+		normalizedType === "" ||
+		getMediaTypeFromExtension(extension) === "audio" ||
+		isExplicitAudioContainer(extension, mediaTypeHint)
+	);
+}
+
+function isExplicitAudioContainer(
+	extension: string | null | undefined,
+	mediaTypeHint?: EpisodeMediaType,
+): boolean {
+	if (mediaTypeHint !== "audio" || !extension) return false;
+
+	const normalizedExtension = extension.toLowerCase();
+	return normalizedExtension === "mp4" || normalizedExtension === "webm";
+}
+
+function normalizeAudioExtension(
+	extension: string | null,
+	mediaTypeHint?: EpisodeMediaType,
+): string | null {
+	if (
+		mediaTypeHint === "audio" &&
+		extension?.toLowerCase() === "mp4"
+	) {
+		return "m4a";
+	}
+
+	return extension;
 }
 
 /**
@@ -450,7 +479,8 @@ async function getFileExtension(url: string): Promise<string> {
 export async function getEpisodeAudioBuffer(
 	episode: Episode,
 ): Promise<{ buffer: ArrayBuffer; extension: string; basename: string }> {
-	if (getEpisodeMediaType(episode) !== "audio") {
+	const episodeMediaType = getEpisodeMediaType(episode);
+	if (episodeMediaType !== "audio") {
 		throw new Error("Transcription supports audio episodes only.");
 	}
 
@@ -462,7 +492,7 @@ export async function getEpisodeAudioBuffer(
 			);
 		}
 
-		return readVaultAudio(localFilePath, getEpisodeMediaType(episode));
+		return readVaultAudio(localFilePath, episodeMediaType);
 	}
 
 	// Reuse a previously downloaded file only when the registry entry is the SAME
@@ -497,7 +527,13 @@ export async function getEpisodeAudioBuffer(
 			data,
 			contentType,
 		);
-		if (!downloadAppearsAudio(contentType, inferredExtension)) {
+		if (
+			!downloadAppearsAudio(
+				contentType,
+				inferredExtension,
+				episodeMediaType,
+			)
+		) {
 			throw new Error(
 				`The downloaded file is not audio (received "${contentType}"). The episode may be unavailable or require re-authentication.`,
 			);
@@ -505,7 +541,8 @@ export async function getEpisodeAudioBuffer(
 
 		return {
 			buffer: data,
-			extension: inferredExtension ?? "mp3",
+			extension:
+				normalizeAudioExtension(inferredExtension, episodeMediaType) ?? "mp3",
 			basename:
 				replaceIllegalFileNameCharactersInString(episode.title) || "episode",
 		};

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -109,7 +109,9 @@ export default async function downloadEpisodeWithNotice(
 		contentType,
 	);
 
-	if (!downloadAppearsPlayable(contentType, inferredExtension)) {
+	if (
+		!downloadAppearsPlayable(contentType, inferredExtension, episode.mediaType)
+	) {
 		update((bodyEl) => {
 			bodyEl.createEl("p", {
 				text: `Downloaded file is not an audio or video file. It is of type "${contentType}". File: ${data.byteLength} bytes.`,
@@ -342,11 +344,16 @@ function inferFileExtensionFromDownload(
 function downloadAppearsPlayable(
 	contentType: string,
 	extension: string | null,
+	mediaTypeHint?: EpisodeMediaType,
 ): boolean {
 	const normalizedType = contentType.toLowerCase();
 	const contentMediaType = getMediaTypeFromContentType(normalizedType);
 
 	if (contentMediaType === "video") {
+		return getMediaTypeFromExtension(extension) === "video";
+	}
+
+	if (normalizedType === "" && mediaTypeHint === "video") {
 		return getMediaTypeFromExtension(extension) === "video";
 	}
 
@@ -441,7 +448,13 @@ export async function downloadEpisode(
 			inferFileExtensionFromDownload(episode, data, contentType) ??
 			provisionalExtension;
 
-		if (!downloadAppearsPlayable(contentType, inferredExtension)) {
+		if (
+			!downloadAppearsPlayable(
+				contentType,
+				inferredExtension,
+				episode.mediaType,
+			)
+		) {
 			throw new Error("Not a playable media file.");
 		}
 

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -14,9 +14,11 @@ import getUrlExtension from "./utility/getUrlExtension";
 import getExtensionFromContentType from "./utility/getExtensionFromContentType";
 import {
 	getEpisodeMediaType,
+	getEpisodeMediaTypeWithAudioContainerHint,
 	getMediaTypeFromContentType,
 	getMediaTypeFromExtension,
 	getMediaTypeFromPath,
+	isAudioContainerExtension,
 	isPlayableMediaExtension,
 	isSameMediaSource,
 } from "./utility/mediaType";
@@ -357,10 +359,7 @@ function isExplicitAudioContainer(
 	extension: string | null | undefined,
 	mediaTypeHint?: EpisodeMediaType,
 ): boolean {
-	if (mediaTypeHint !== "audio" || !extension) return false;
-
-	const normalizedExtension = extension.toLowerCase();
-	return normalizedExtension === "mp4" || normalizedExtension === "webm";
+	return mediaTypeHint === "audio" && isAudioContainerExtension(extension);
 }
 
 function normalizeAudioExtension(
@@ -375,26 +374,6 @@ function normalizeAudioExtension(
 	}
 
 	return extension;
-}
-
-function getRegisteredEpisodeMediaType(
-	episode: Episode & { filePath?: string },
-	currentEpisodeMediaTypeHint?: EpisodeMediaType,
-): EpisodeMediaType {
-	if (episode.mediaType) return episode.mediaType;
-	const fileExtension = episode.filePath
-		? getUrlExtension(episode.filePath)
-		: null;
-	if (
-		isExplicitAudioContainer(
-			fileExtension,
-			currentEpisodeMediaTypeHint,
-		)
-	) {
-		return "audio";
-	}
-
-	return getEpisodeMediaType(episode);
 }
 
 /**
@@ -527,7 +506,7 @@ export async function getEpisodeAudioBuffer(
 		registered?.filePath &&
 		isSameMediaSource(registered.streamUrl, episode.streamUrl)
 	) {
-		const registeredMediaType = getRegisteredEpisodeMediaType(
+		const registeredMediaType = getEpisodeMediaTypeWithAudioContainerHint(
 			registered,
 			episode.mediaType === "audio" ? episodeMediaType : undefined,
 		);

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -14,7 +14,7 @@ import getUrlExtension from "./utility/getUrlExtension";
 import getExtensionFromContentType from "./utility/getExtensionFromContentType";
 import {
 	getEpisodeMediaType,
-	getEpisodeMediaTypeWithAudioContainerHint,
+	getEpisodeMediaTypeWithContainerHint,
 	getMediaTypeFromContentType,
 	getMediaTypeFromExtension,
 	getMediaTypeFromPath,
@@ -307,17 +307,31 @@ function inferFileExtensionFromDownload(
 	data: ArrayBuffer,
 	contentType: string,
 ): string | null {
+	const contentTypeExtension = getExtensionFromContentType(contentType);
+	if (
+		getMediaTypeFromContentType(contentType) === "video" &&
+		contentTypeExtension
+	) {
+		return contentTypeExtension;
+	}
+
+	const urlExtension = getUrlExtension(episode.streamUrl);
+	if (
+		getMediaTypeFromExtension(urlExtension) === "video" &&
+		!isAudioContainerExtension(urlExtension)
+	) {
+		return urlExtension;
+	}
+
 	const signatureExtension = detectAudioFileExtension(data);
 	if (signatureExtension) {
 		return signatureExtension;
 	}
 
-	const contentTypeExtension = getExtensionFromContentType(contentType);
 	if (contentTypeExtension) {
 		return contentTypeExtension;
 	}
 
-	const urlExtension = getUrlExtension(episode.streamUrl);
 	if (urlExtension) {
 		return urlExtension;
 	}
@@ -402,31 +416,44 @@ export async function downloadEpisode(
 		return localFilePath;
 	}
 
-	const fileExtension = await getFileExtension(episode.streamUrl);
-	const filePath = safeDownloadFilePath(
+	const provisionalExtension = await getFileExtension(episode.streamUrl);
+	const provisionalFilePath = safeDownloadFilePath(
 		downloadPathTemplate,
 		episode,
-		fileExtension,
+		provisionalExtension,
 	);
 
 	// Check if the file already exists
-	const existingFile = app.vault.getAbstractFileByPath(filePath);
+	const existingFile = app.vault.getAbstractFileByPath(provisionalFilePath);
 	if (existingFile instanceof TFile) {
-		return filePath; // Return the existing file path
+		return provisionalFilePath; // Return the existing file path
 	}
 
 	try {
 		const { data, contentType } = await downloadFile(episode.streamUrl);
+		const inferredExtension =
+			inferFileExtensionFromDownload(episode, data, contentType) ??
+			provisionalExtension;
 
-		if (!downloadAppearsPlayable(contentType, fileExtension)) {
+		if (!downloadAppearsPlayable(contentType, inferredExtension)) {
 			throw new Error("Not a playable media file.");
+		}
+
+		const filePath = safeDownloadFilePath(
+			downloadPathTemplate,
+			episode,
+			inferredExtension,
+		);
+		const finalExistingFile = app.vault.getAbstractFileByPath(filePath);
+		if (finalExistingFile instanceof TFile) {
+			return filePath;
 		}
 
 		await createEpisodeFile({
 			episode,
 			downloadPathTemplate,
 			data,
-			extension: fileExtension,
+			extension: inferredExtension,
 		});
 
 		return filePath;
@@ -509,7 +536,7 @@ export async function getEpisodeAudioBuffer(
 		registered?.filePath &&
 		isSameMediaSource(registered.streamUrl, episode.streamUrl)
 	) {
-		const registeredMediaType = getEpisodeMediaTypeWithAudioContainerHint(
+		const registeredMediaType = getEpisodeMediaTypeWithContainerHint(
 			registered,
 			episode.mediaType === "audio" ? episodeMediaType : undefined,
 		);

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -344,9 +344,15 @@ function downloadAppearsPlayable(
 	extension: string | null,
 ): boolean {
 	const normalizedType = contentType.toLowerCase();
+	const contentMediaType = getMediaTypeFromContentType(normalizedType);
+
+	if (contentMediaType === "video") {
+		return getMediaTypeFromExtension(extension) === "video";
+	}
+
 	return (
 		normalizedType === "" ||
-		getMediaTypeFromContentType(normalizedType) !== null ||
+		contentMediaType === "audio" ||
 		isPlayableMediaExtension(extension)
 	);
 }

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -377,6 +377,26 @@ function normalizeAudioExtension(
 	return extension;
 }
 
+function getRegisteredEpisodeMediaType(
+	episode: Episode & { filePath?: string },
+	currentEpisodeMediaTypeHint?: EpisodeMediaType,
+): EpisodeMediaType {
+	if (episode.mediaType) return episode.mediaType;
+	const fileExtension = episode.filePath
+		? getUrlExtension(episode.filePath)
+		: null;
+	if (
+		isExplicitAudioContainer(
+			fileExtension,
+			currentEpisodeMediaTypeHint,
+		)
+	) {
+		return "audio";
+	}
+
+	return getEpisodeMediaType(episode);
+}
+
 /**
  * UNUSED IN PRODUCTION — kept only for the #178 tests. Do NOT use this for
  * transcription: it derives the on-disk path from the download-path template and
@@ -507,16 +527,17 @@ export async function getEpisodeAudioBuffer(
 		registered?.filePath &&
 		isSameMediaSource(registered.streamUrl, episode.streamUrl)
 	) {
-		if (getEpisodeMediaType(registered) !== "audio") {
+		const registeredMediaType = getRegisteredEpisodeMediaType(
+			registered,
+			episode.mediaType === "audio" ? episodeMediaType : undefined,
+		);
+		if (registeredMediaType !== "audio") {
 			throw new Error("Transcription supports audio episodes only.");
 		}
 
 		const existingFile = app.vault.getAbstractFileByPath(registered.filePath);
 		if (existingFile instanceof TFile) {
-			return readVaultAudio(
-				registered.filePath,
-				getEpisodeMediaType(registered),
-			);
+			return readVaultAudio(registered.filePath, registeredMediaType);
 		}
 	}
 

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -531,6 +531,7 @@ export async function getEpisodeAudioBuffer(
 	if (episodeMediaType !== "audio") {
 		throw new Error("Transcription supports audio episodes only.");
 	}
+	const audioContainerHint = getAudioContainerHint(episode, episodeMediaType);
 
 	if (isLocalFile(episode)) {
 		const localFilePath = resolveLocalEpisodeFilePath(episode);
@@ -557,7 +558,7 @@ export async function getEpisodeAudioBuffer(
 	) {
 		const registeredMediaType = getEpisodeMediaTypeWithContainerHint(
 			registered,
-			episode.mediaType === "audio" ? episodeMediaType : undefined,
+			audioContainerHint,
 		);
 		if (registeredMediaType !== "audio") {
 			throw new Error("Transcription supports audio episodes only.");
@@ -580,7 +581,7 @@ export async function getEpisodeAudioBuffer(
 			!downloadAppearsAudio(
 				contentType,
 				inferredExtension,
-				episode.mediaType === "audio" ? episodeMediaType : undefined,
+				audioContainerHint,
 			)
 		) {
 			throw new Error(
@@ -591,10 +592,7 @@ export async function getEpisodeAudioBuffer(
 		return {
 			buffer: data,
 			extension:
-				normalizeAudioExtension(
-					inferredExtension,
-					episode.mediaType === "audio" ? episodeMediaType : undefined,
-				) ?? "mp3",
+				normalizeAudioExtension(inferredExtension, audioContainerHint) ?? "mp3",
 			basename:
 				replaceIllegalFileNameCharactersInString(episode.title) || "episode",
 		};
@@ -603,6 +601,18 @@ export async function getEpisodeAudioBuffer(
 			`Failed to fetch ${episode.title}: ${getErrorMessage(error)}`,
 		);
 	}
+}
+
+function getAudioContainerHint(
+	episode: Episode,
+	episodeMediaType: EpisodeMediaType,
+): EpisodeMediaType | undefined {
+	if (episodeMediaType !== "audio") return undefined;
+	if (episode.mediaType === "audio") return "audio";
+
+	return isAudioContainerExtension(getUrlExtension(episode.streamUrl))
+		? "audio"
+		: undefined;
 }
 
 async function readVaultAudio(

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -344,7 +344,10 @@ function downloadAppearsAudio(
 ): boolean {
 	const contentMediaType = getMediaTypeFromContentType(contentType);
 	if (contentMediaType) {
-		return contentMediaType === "audio";
+		return (
+			contentMediaType === "audio" ||
+			isExplicitAudioContainer(extension, mediaTypeHint)
+		);
 	}
 
 	const normalizedType = contentType.toLowerCase();
@@ -531,7 +534,7 @@ export async function getEpisodeAudioBuffer(
 			!downloadAppearsAudio(
 				contentType,
 				inferredExtension,
-				episodeMediaType,
+				episode.mediaType === "audio" ? episodeMediaType : undefined,
 			)
 		) {
 			throw new Error(
@@ -542,7 +545,10 @@ export async function getEpisodeAudioBuffer(
 		return {
 			buffer: data,
 			extension:
-				normalizeAudioExtension(inferredExtension, episodeMediaType) ?? "mp3",
+				normalizeAudioExtension(
+					inferredExtension,
+					episode.mediaType === "audio" ? episodeMediaType : undefined,
+				) ?? "mp3",
 			basename:
 				replaceIllegalFileNameCharactersInString(episode.title) || "episode",
 		};

--- a/src/getContextMenuHandler.test.ts
+++ b/src/getContextMenuHandler.test.ts
@@ -94,7 +94,12 @@ function makeApp(workspace: unknown, file: TFile) {
 	};
 }
 
-async function playFile(app: unknown, workspace: { _fileMenuHandler: unknown }, file: TFile) {
+async function playFile(
+	app: unknown,
+	workspace: { _fileMenuHandler: unknown },
+	file: TFile,
+	title = "Play with PodNotes",
+) {
 	getContextMenuHandler(app as never);
 	const menu = fakeMenu();
 	(
@@ -104,7 +109,7 @@ async function playFile(app: unknown, workspace: { _fileMenuHandler: unknown }, 
 			source: string,
 		) => void
 	)(menu, file, "file-explorer-context-menu");
-	const play = menu.items.find((i) => i.title === "Play with PodNotes");
+	const play = menu.items.find((i) => i.title === title);
 	expect(play).toBeTruthy();
 	await play?.onClick?.();
 	return menu;
@@ -145,14 +150,45 @@ describe("getContextMenuHandler — Play with PodNotes", () => {
 		const { workspace } = setupWorkspace([{}]);
 		const app = makeApp(workspace, file);
 
-		await playFile(app, workspace, file);
+		const menu = await playFile(
+			app,
+			workspace,
+			file,
+			"Play as video with PodNotes",
+		);
 
+		expect(menu.items.map((item) => item.title)).toEqual([
+			"Play as audio with PodNotes",
+			"Play as video with PodNotes",
+		]);
 		expect(get(currentEpisode)).toMatchObject({
 			title: "lecture",
 			podcastName: "local file",
 			filePath: "Videos/lecture.mp4",
 			mediaType: "video",
 			streamUrl: "app://resource/Videos/lecture.mp4?1",
+		});
+		expect(get(viewState)).toBe(ViewState.Player);
+	});
+
+	it("can preserve local audio-only ambiguous container files as audio", async () => {
+		const file = audioFile("Audio/lecture.mp4");
+		const { workspace } = setupWorkspace([{}]);
+		const app = makeApp(workspace, file);
+
+		await playFile(app, workspace, file, "Play as audio with PodNotes");
+
+		const stored = get(downloadedEpisodes)["local file"]?.[0];
+		expect(stored).toMatchObject({
+			title: "lecture",
+			filePath: "Audio/lecture.mp4",
+			mediaType: "audio",
+			streamUrl: "app://resource/Audio/lecture.mp4?1",
+		});
+		expect(get(currentEpisode)).toMatchObject({
+			title: "lecture",
+			filePath: "Audio/lecture.mp4",
+			mediaType: "audio",
 		});
 		expect(get(viewState)).toBe(ViewState.Player);
 	});
@@ -164,7 +200,7 @@ describe("getContextMenuHandler — Play with PodNotes", () => {
 		const app = makeApp(workspace, audio);
 
 		await playFile(app, workspace, audio);
-		await playFile(app, workspace, video);
+		await playFile(app, workspace, video, "Play as video with PodNotes");
 
 		const stored = get(downloadedEpisodes)["local file"]?.[0];
 		expect(stored).toMatchObject({

--- a/src/getContextMenuHandler.test.ts
+++ b/src/getContextMenuHandler.test.ts
@@ -3,7 +3,7 @@ import { TFile } from "obsidian";
 import { get } from "svelte/store";
 import getContextMenuHandler from "./getContextMenuHandler";
 import { VIEW_TYPE } from "./constants";
-import { currentEpisode, viewState } from "./store";
+import { currentEpisode, downloadedEpisodes, viewState } from "./store";
 import { ViewState } from "./types/ViewState";
 
 // `tsc` resolves `obsidian` to the real typings while Vitest aliases it to
@@ -78,7 +78,9 @@ function setupWorkspace(openLeaves: unknown[]) {
 
 function makeApp(workspace: unknown, file: TFile) {
 	const vault = {
-		getAbstractFileByPath: vi.fn(() => file),
+		getAbstractFileByPath: vi.fn((path: string) =>
+			path ? audioFile(path) : file,
+		),
 		getResourcePath: vi.fn((f: TFile) => `app://resource/${f.path}?1`),
 	};
 	// createMediaUrlObjectFromFilePath reads the global `app`.
@@ -86,7 +88,9 @@ function makeApp(workspace: unknown, file: TFile) {
 	return {
 		workspace,
 		vault,
-		fileManager: { generateMarkdownLink: vi.fn(() => `[[${file.path}]]`) },
+		fileManager: {
+			generateMarkdownLink: vi.fn((target: TFile) => `[[${target.path}]]`),
+		},
 	};
 }
 
@@ -113,6 +117,7 @@ afterEach(() => {
 
 beforeEach(() => {
 	currentEpisode.set(undefined as never);
+	downloadedEpisodes.set({});
 	viewState.set(ViewState.PodcastGrid);
 });
 
@@ -135,7 +140,47 @@ describe("getContextMenuHandler — Play with PodNotes", () => {
 		expect(get(viewState)).toBe(ViewState.Player);
 	});
 
-	it("does not offer the item for non-audio files", () => {
+	it("offers the item for local video files and preserves their media type", async () => {
+		const file = audioFile("Videos/lecture.mp4");
+		const { workspace } = setupWorkspace([{}]);
+		const app = makeApp(workspace, file);
+
+		await playFile(app, workspace, file);
+
+		expect(get(currentEpisode)).toMatchObject({
+			title: "lecture",
+			podcastName: "local file",
+			filePath: "Videos/lecture.mp4",
+			mediaType: "video",
+			streamUrl: "app://resource/Videos/lecture.mp4?1",
+		});
+		expect(get(viewState)).toBe(ViewState.Player);
+	});
+
+	it("refreshes the stored local file when a same-basename video replaces audio", async () => {
+		const audio = audioFile("Audio/lecture.mp3");
+		const video = audioFile("Videos/lecture.mp4");
+		const { workspace } = setupWorkspace([{}]);
+		const app = makeApp(workspace, audio);
+
+		await playFile(app, workspace, audio);
+		await playFile(app, workspace, video);
+
+		const stored = get(downloadedEpisodes)["local file"]?.[0];
+		expect(stored).toMatchObject({
+			title: "lecture",
+			filePath: "Videos/lecture.mp4",
+			mediaType: "video",
+			streamUrl: "app://resource/Videos/lecture.mp4?1",
+		});
+		expect(get(currentEpisode)).toMatchObject({
+			title: "lecture",
+			filePath: "Videos/lecture.mp4",
+			mediaType: "video",
+		});
+	});
+
+	it("does not offer the item for non-media files", () => {
 		const { workspace } = setupWorkspace([{}]);
 		const file = audioFile("Notes/page.md");
 		const app = makeApp(workspace, file);

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -12,31 +12,15 @@ import {
 import type { LocalEpisode } from "./types/LocalEpisode";
 import { ViewState } from "./types/ViewState";
 import { createMediaUrlObjectFromFilePath } from "./utility/createMediaUrlObjectFromFilePath";
-
-// Extensions for which "Play with PodNotes" is offered. Kept in sync with the
-// formats PodNotes already recognizes as audio elsewhere (detectAudioFileExtension
-// in downloadEpisode.ts and getExtensionFromContentType), plus the mp4/webm
-// containers, so right-clicking any such file offers playback. The previous inline
-// regex had a trailing empty alternative that matched every file regardless of type.
-const PLAYABLE_EXTENSIONS = new Set([
-	"mp3",
-	"mp4",
-	"m4a",
-	"aac",
-	"ogg",
-	"wav",
-	"webm",
-	"flac",
-	"wma",
-	"amr",
-]);
+import { getMediaTypeFromPath } from "./utility/mediaType";
 
 export default function getContextMenuHandler(app: App): EventRef {
 	return app.workspace.on(
 		"file-menu",
 		(menu: Menu, file: TAbstractFile) => {
 			if (!(file instanceof TFile)) return;
-			if (!PLAYABLE_EXTENSIONS.has(file.extension.toLowerCase())) return;
+			const mediaType = getMediaTypeFromPath(file.path);
+			if (!mediaType) return;
 
 			menu.addItem((item) =>
 				item
@@ -52,22 +36,18 @@ export default function getContextMenuHandler(app: App): EventRef {
 							streamUrl: createMediaUrlObjectFromFilePath(file.path),
 							filePath: file.path,
 							episodeDate: new Date(file.stat.ctime),
+							mediaType,
 						};
 
-						if (
-							!downloadedEpisodes.isEpisodeDownloaded(
-								localEpisode
-							)
-						) {
-							// The Local Files playlist is mirrored from downloadedEpisodes
-							// (see localFiles.syncWithDownloaded), so this single write
-							// surfaces the file there too.
-							downloadedEpisodes.addEpisode(
-								localEpisode,
-								file.path,
-								file.stat.size
-							);
-						}
+						// The Local Files playlist is mirrored from downloadedEpisodes
+						// (see localFiles.syncWithDownloaded), so this single write
+						// surfaces the file there too. Always refresh the entry: two
+						// same-basename local files can differ by folder or media type.
+						downloadedEpisodes.addEpisode(
+							localEpisode,
+							file.path,
+							file.stat.size
+						);
 
 						// Fixes where the episode won't play if it has been played.
 						if (get(playedEpisodes)[file.basename]?.finished) {

--- a/src/getContextMenuHandler.ts
+++ b/src/getContextMenuHandler.ts
@@ -9,10 +9,14 @@ import {
 	viewState,
 	plugin,
 } from "./store";
+import type { EpisodeMediaType } from "./types/Episode";
 import type { LocalEpisode } from "./types/LocalEpisode";
 import { ViewState } from "./types/ViewState";
 import { createMediaUrlObjectFromFilePath } from "./utility/createMediaUrlObjectFromFilePath";
-import { getMediaTypeFromPath } from "./utility/mediaType";
+import {
+	getMediaTypeFromPath,
+	isAudioContainerExtension,
+} from "./utility/mediaType";
 
 export default function getContextMenuHandler(app: App): EventRef {
 	return app.workspace.on(
@@ -20,54 +24,72 @@ export default function getContextMenuHandler(app: App): EventRef {
 		(menu: Menu, file: TAbstractFile) => {
 			if (!(file instanceof TFile)) return;
 			const mediaType = getMediaTypeFromPath(file.path);
+			const isAmbiguousContainer = isAudioContainerExtension(file.extension);
+			if (!mediaType && !isAmbiguousContainer) return;
+
+			if (isAmbiguousContainer) {
+				addPlayLocalFileItem(menu, app, file, "audio");
+				addPlayLocalFileItem(menu, app, file, "video");
+				return;
+			}
+
 			if (!mediaType) return;
-
-			menu.addItem((item) =>
-				item
-					.setIcon("play")
-					.setTitle("Play with PodNotes")
-					.onClick(async () => {
-						const localEpisode: LocalEpisode = {
-							title: file.basename,
-							description: "",
-							content: "",
-							podcastName: "local file",
-							url: app.fileManager.generateMarkdownLink(file, ""),
-							streamUrl: createMediaUrlObjectFromFilePath(file.path),
-							filePath: file.path,
-							episodeDate: new Date(file.stat.ctime),
-							mediaType,
-						};
-
-						// The Local Files playlist is mirrored from downloadedEpisodes
-						// (see localFiles.syncWithDownloaded), so this single write
-						// surfaces the file there too. Always refresh the entry: two
-						// same-basename local files can differ by folder or media type.
-						downloadedEpisodes.addEpisode(
-							localEpisode,
-							file.path,
-							file.stat.size
-						);
-
-						// Fixes where the episode won't play if it has been played.
-						if (get(playedEpisodes)[file.basename]?.finished) {
-							playedEpisodes.markAsUnplayed(localEpisode);
-						}
-
-						currentEpisode.set(localEpisode);
-						viewState.set(ViewState.Player);
-						get(plugin)?.enablePodcastViewMount();
-
-						// Setting the stores above only updates an already-mounted
-						// PodNotes view. When the view is closed (or hidden in a
-						// collapsed sidebar) nothing reacts, so "Play with PodNotes"
-						// silently did nothing — the file played to no visible player
-						// (issue #84). Open the view if needed and reveal it so the
-						// player surfaces with the just-selected episode.
-						await revealPodcastView(app);
-					})
-			);
+			addPlayLocalFileItem(menu, app, file, mediaType);
 		}
+	);
+}
+
+function addPlayLocalFileItem(
+	menu: Menu,
+	app: App,
+	file: TFile,
+	mediaType: EpisodeMediaType,
+): void {
+	const isAmbiguousContainer = isAudioContainerExtension(file.extension);
+	const title = isAmbiguousContainer
+		? `Play as ${mediaType} with PodNotes`
+		: "Play with PodNotes";
+
+	menu.addItem((item) =>
+		item
+			.setIcon("play")
+			.setTitle(title)
+			.onClick(async () => {
+				const localEpisode: LocalEpisode = {
+					title: file.basename,
+					description: "",
+					content: "",
+					podcastName: "local file",
+					url: app.fileManager.generateMarkdownLink(file, ""),
+					streamUrl: createMediaUrlObjectFromFilePath(file.path),
+					filePath: file.path,
+					episodeDate: new Date(file.stat.ctime),
+					mediaType,
+				};
+
+				// The Local Files playlist is mirrored from downloadedEpisodes
+				// (see localFiles.syncWithDownloaded), so this single write
+				// surfaces the file there too. Always refresh the entry: two
+				// same-basename local files can differ by folder or media type.
+				downloadedEpisodes.addEpisode(localEpisode, file.path, file.stat.size);
+
+				// Fixes where the episode won't play if it has been played.
+				if (get(playedEpisodes)[file.basename]?.finished) {
+					playedEpisodes.markAsUnplayed(localEpisode);
+				}
+
+				currentEpisode.set(localEpisode);
+				viewState.set(ViewState.Player);
+				get(plugin)?.enablePodcastViewMount();
+
+				// Setting the stores above only updates an already-mounted
+				// PodNotes view. When the view is closed (or hidden in a
+				// collapsed sidebar) nothing reacts, so "Play with PodNotes"
+				// silently did nothing — the file played to no visible player
+				// (issue #84). Open the view if needed and reveal it so the
+				// player surfaces with the just-selected episode.
+				await revealPodcastView(app);
+			}),
 	);
 }
 

--- a/src/main.activateView.test.ts
+++ b/src/main.activateView.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PodNotes from "./main";
 import { VIEW_TYPE } from "./constants";
 import { Platform } from "obsidian";
+import type { Episode } from "./types/Episode";
 
 // Regression coverage for #55: "Show PodNotes" / the ribbon icon must reliably
 // surface the view. The bug was that the command was gated on the leaf NOT
@@ -214,7 +215,7 @@ describe("PodNotes onload wiring (#55)", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function loadPlugin() {
+	async function loadPlugin(loadedData: Record<string, unknown> = {}) {
 		const activateSpy = vi
 			.spyOn(PodNotes.prototype, "activateView")
 			.mockResolvedValue(undefined);
@@ -228,7 +229,7 @@ describe("PodNotes onload wiring (#55)", () => {
 
 		const plugin = Object.create(PodNotes.prototype) as PodNotes;
 		Object.assign(plugin, {
-			loadData: vi.fn().mockResolvedValue({}),
+			loadData: vi.fn().mockResolvedValue(loadedData),
 			saveData: vi.fn().mockResolvedValue(undefined),
 			addCommand: vi.fn((cmd: Record<string, unknown>) => {
 				commands.push(cmd);
@@ -391,5 +392,27 @@ describe("PodNotes onload wiring (#55)", () => {
 		expect(ribbon?.icon).toBe("podcast");
 		ribbon?.handler(new MouseEvent("click"));
 		expect(activateSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not offer transcription for known video episodes", async () => {
+		const videoEpisode: Episode = {
+			title: "Video Episode",
+			streamUrl: "https://example.com/video.mp4",
+			url: "https://example.com/video",
+			description: "",
+			content: "",
+			podcastName: "Pod",
+			mediaType: "video",
+		};
+		const { commands } = await loadPlugin({
+			openAIApiKey: "sk-test",
+			currentEpisode: videoEpisode,
+		});
+
+		const transcribeCmd = commands.find((c) => c.id === "podnotes-transcribe");
+		expect(transcribeCmd).toBeDefined();
+		expect(
+			(transcribeCmd?.checkCallback as (checking: boolean) => boolean)(true),
+		).toBe(false);
 	});
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,7 @@ import type { IconType } from "./types/IconType";
 import { TranscriptionService } from "./services/TranscriptionService";
 import { get, type Unsubscriber } from "svelte/store";
 import { normalizePlaybackRate } from "./utility/playbackRate";
+import { getEpisodeMediaType } from "./utility/mediaType";
 
 type MediaSessionActionName =
 	| "previoustrack"
@@ -496,7 +497,8 @@ export default class PodNotes extends Plugin implements IPodNotes {
 			checkCallback: (checking) => {
 				const canTranscribe =
 					!!this.api.podcast &&
-					requiredTranscriptionKeyPresent(this.settings);
+					requiredTranscriptionKeyPresent(this.settings) &&
+					getEpisodeMediaType(this.api.podcast) === "audio";
 
 				if (checking) {
 					return canTranscribe;

--- a/src/parser/feedParser.test.ts
+++ b/src/parser/feedParser.test.ts
@@ -414,6 +414,45 @@ describe("FeedParser", () => {
 			expect(episodes[1].chaptersUrl).toBeUndefined();
 		});
 
+		test("marks video enclosures so the player can render video", async () => {
+			const videoFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Video Podcast</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Lecture Video</title>
+      <enclosure url="https://example.com/lecture.mp4" type="video/mp4"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+			mockRequestWithTimeout
+				.mockResolvedValueOnce({
+					text: videoFeed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				})
+				.mockResolvedValueOnce({
+					text: videoFeed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				});
+
+			const parser = new FeedParser();
+			const episodes = await parser.getEpisodes("https://example.com/feed.xml");
+
+			expect(episodes[0]).toMatchObject({
+				title: "Lecture Video",
+				streamUrl: "https://example.com/lecture.mp4",
+				mediaType: "video",
+			});
+		});
+
 		test("filters out invalid episodes missing required fields", async () => {
 			mockRequestWithTimeout
 				.mockResolvedValueOnce({

--- a/src/parser/feedParser.test.ts
+++ b/src/parser/feedParser.test.ts
@@ -453,6 +453,45 @@ describe("FeedParser", () => {
 			});
 		});
 
+		test("trusts audio enclosure type when URL uses an mp4 extension", async () => {
+			const audioMp4Feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Audio Podcast</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Audio MP4 Episode</title>
+      <enclosure url="https://example.com/episode.mp4" type="audio/mp4"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+			mockRequestWithTimeout
+				.mockResolvedValueOnce({
+					text: audioMp4Feed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				})
+				.mockResolvedValueOnce({
+					text: audioMp4Feed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				});
+
+			const parser = new FeedParser();
+			const episodes = await parser.getEpisodes("https://example.com/feed.xml");
+
+			expect(episodes[0]).toMatchObject({
+				title: "Audio MP4 Episode",
+				streamUrl: "https://example.com/episode.mp4",
+				mediaType: "audio",
+			});
+		});
+
 		test("filters out invalid episodes missing required fields", async () => {
 			mockRequestWithTimeout
 				.mockResolvedValueOnce({

--- a/src/parser/feedParser.test.ts
+++ b/src/parser/feedParser.test.ts
@@ -492,6 +492,55 @@ describe("FeedParser", () => {
 			});
 		});
 
+		test("keeps untyped ambiguous container enclosures as audio", async () => {
+			const untypedAmbiguousFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Audio Podcast</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Untyped MP4 Episode</title>
+      <enclosure url="https://example.com/episode.mp4"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Opaque WebM Episode</title>
+      <enclosure url="https://example.com/episode.webm" type="application/octet-stream"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Untyped MOV Episode</title>
+      <enclosure url="https://example.com/lecture.mov"/>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+			mockRequestWithTimeout
+				.mockResolvedValueOnce({
+					text: untypedAmbiguousFeed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				})
+				.mockResolvedValueOnce({
+					text: untypedAmbiguousFeed,
+					status: 200,
+					headers: {},
+					arrayBuffer: new ArrayBuffer(0),
+					json: {},
+				});
+
+			const parser = new FeedParser();
+			const episodes = await parser.getEpisodes("https://example.com/feed.xml");
+
+			expect(episodes.map((episode) => episode.mediaType)).toEqual([
+				"audio",
+				"audio",
+				"video",
+			]);
+		});
+
 		test("filters out invalid episodes missing required fields", async () => {
 			mockRequestWithTimeout
 				.mockResolvedValueOnce({

--- a/src/parser/feedParser.ts
+++ b/src/parser/feedParser.ts
@@ -5,7 +5,7 @@ import { parseEpisodeNumber } from "src/utility/parseEpisodeNumber";
 import { parseDurationToSeconds } from "src/utility/parseDuration";
 import {
 	getMediaTypeFromContentType,
-	getMediaTypeFromPath,
+	getUnambiguousMediaTypeFromPath,
 } from "src/utility/mediaType";
 
 export default class FeedParser {
@@ -198,7 +198,7 @@ export default class FeedParser {
 			chaptersUrl,
 			mediaType:
 				getMediaTypeFromContentType(enclosureType) ??
-				getMediaTypeFromPath(streamUrl) ??
+				getUnambiguousMediaTypeFromPath(streamUrl) ??
 				"audio",
 		};
 	}

--- a/src/parser/feedParser.ts
+++ b/src/parser/feedParser.ts
@@ -3,6 +3,10 @@ import type { Episode } from "src/types/Episode";
 import { requestWithTimeout } from "src/utility/networkRequest";
 import { parseEpisodeNumber } from "src/utility/parseEpisodeNumber";
 import { parseDurationToSeconds } from "src/utility/parseDuration";
+import {
+	getMediaTypeFromContentType,
+	getMediaTypeFromPath,
+} from "src/utility/mediaType";
 
 export default class FeedParser {
 	private feed: PodcastFeed | undefined;
@@ -163,6 +167,7 @@ export default class FeedParser {
 
 		const title = titleEl.textContent || "";
 		const streamUrl = streamUrlEl.getAttribute("url") || "";
+		const enclosureType = streamUrlEl.getAttribute("type");
 		const url = linkEl?.textContent || "";
 		const description = descriptionEl?.textContent || "";
 		const content = contentEl?.textContent || "";
@@ -191,6 +196,10 @@ export default class FeedParser {
 			episodeNumber,
 			duration,
 			chaptersUrl,
+			mediaType:
+				getMediaTypeFromContentType(enclosureType) ??
+				getMediaTypeFromPath(streamUrl) ??
+				"audio",
 		};
 	}
 

--- a/src/services/FeedCacheService.test.ts
+++ b/src/services/FeedCacheService.test.ts
@@ -99,11 +99,12 @@ describe("FeedCacheService", () => {
 		expect(getCachedEpisodes(testFeed)).toEqual(episodes);
 	});
 
-	test("round-trips episodeNumber and duration (#34, #88)", () => {
+	test("round-trips episodeNumber, duration, and mediaType (#34, #88, #78)", () => {
 		const episode: Episode = {
 			...createEpisode(1),
 			episodeNumber: 42,
 			duration: 3723,
+			mediaType: "video",
 		};
 
 		setCachedEpisodes(testFeed, [episode]);
@@ -111,6 +112,7 @@ describe("FeedCacheService", () => {
 		const cached = getCachedEpisodes(testFeed);
 		expect(cached?.[0]?.episodeNumber).toBe(42);
 		expect(cached?.[0]?.duration).toBe(3723);
+		expect(cached?.[0]?.mediaType).toBe("video");
 	});
 
 	test("removes the superseded v1 cache key on first load", async () => {
@@ -144,11 +146,28 @@ describe("FeedCacheService", () => {
 		expect(localStorage.getItem("podnotes:feed-cache:v2")).toBeNull();
 	});
 
+	test("removes the superseded v3 cache key on first load (#78 media type change)", async () => {
+		// v3 entries can contain extensionless video enclosures parsed before
+		// Episode.mediaType existed, so they must be dropped on upgrade.
+		localStorage.setItem(
+			"podnotes:feed-cache:v3",
+			JSON.stringify({ stale: { episodes: [], updatedAt: 0 } }),
+		);
+
+		vi.resetModules();
+		const fresh = await import("./FeedCacheService");
+		fresh.getCachedEpisodes(testFeed);
+
+		expect(localStorage.getItem("podnotes:feed-cache:v3")).toBeNull();
+	});
+
 	test("clearFeedCache also removes superseded legacy keys", () => {
 		// Covers a clear issued before any cache load, where loadCache's memo would
 		// otherwise short-circuit and leave the v1 blob behind.
 		localStorage.setItem("podnotes:feed-cache:v1", "{}");
+		localStorage.setItem("podnotes:feed-cache:v3", "{}");
 		clearFeedCache();
 		expect(localStorage.getItem("podnotes:feed-cache:v1")).toBeNull();
+		expect(localStorage.getItem("podnotes:feed-cache:v3")).toBeNull();
 	});
 });

--- a/src/services/FeedCacheService.ts
+++ b/src/services/FeedCacheService.ts
@@ -20,12 +20,16 @@ type FeedCache = Record<string, CachedFeedData>;
 // expired. Bumping the key forces a fresh parse so the new retention applies
 // immediately. Superseded keys are actively deleted on load (see
 // LEGACY_STORAGE_KEYS) so a stale blob can't linger and eat the localStorage quota.
-const STORAGE_KEY = "podnotes:feed-cache:v3";
+// v4: Episode gained mediaType (#78), sourced from enclosure MIME/path parsing.
+// Dropping v3 prevents cached extensionless video enclosures from continuing to
+// render as audio until the TTL expires.
+const STORAGE_KEY = "podnotes:feed-cache:v4";
 // Storage keys from earlier cache schemas, removed on first load so they don't
-// orphan ~MBs of data (which could push v3 writes over the localStorage quota).
+// orphan ~MBs of data (which could push current writes over the localStorage quota).
 const LEGACY_STORAGE_KEYS = [
 	"podnotes:feed-cache:v1",
 	"podnotes:feed-cache:v2",
+	"podnotes:feed-cache:v3",
 ];
 const DEFAULT_TTL_MS = 1000 * 60 * 60 * 6; // 6 hours.
 // Keep this >= MAX_EPISODE_LIST_LIMIT (src/constants.ts): the Latest Episodes

--- a/src/services/TranscriptionService.test.ts
+++ b/src/services/TranscriptionService.test.ts
@@ -97,6 +97,8 @@ describe("TranscriptionService", () => {
 						return "audio/wav";
 					case "flac":
 						return "audio/flac";
+					case "webm":
+						return "audio/webm";
 					default:
 						return "audio/mpeg";
 				}
@@ -108,6 +110,7 @@ describe("TranscriptionService", () => {
 			expect(getMimeType("ogg")).toBe("audio/ogg");
 			expect(getMimeType("wav")).toBe("audio/wav");
 			expect(getMimeType("flac")).toBe("audio/flac");
+			expect(getMimeType("webm")).toBe("audio/webm");
 			expect(getMimeType("unknown")).toBe("audio/mpeg");
 		});
 	});

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -489,6 +489,8 @@ export class TranscriptionService {
 				return "audio/wav";
 			case "flac":
 				return "audio/flac";
+			case "webm":
+				return "audio/webm";
 			default:
 				return "audio/mpeg";
 		}

--- a/src/store/index.test.ts
+++ b/src/store/index.test.ts
@@ -234,6 +234,32 @@ describe("localFiles store — syncWithDownloaded (issue #176)", () => {
 		unsubscribe();
 	});
 
+	test("updates metadata when a same-key local media entry changes", () => {
+		localFiles.syncWithDownloaded({
+			"local file": [
+				downloadedEpisode("local file", "Lecture", {
+					filePath: "Audio/Lecture.mp3",
+					mediaType: "audio",
+				}),
+			],
+		});
+
+		localFiles.syncWithDownloaded({
+			"local file": [
+				downloadedEpisode("local file", "Lecture", {
+					streamUrl: "app://resource/Videos/Lecture.mp4?1",
+					filePath: "Videos/Lecture.mp4",
+					mediaType: "video",
+				}),
+			],
+		});
+
+		const [ep] = get(localFiles).episodes;
+		expect((ep as DownloadedEpisode).filePath).toBe("Videos/Lecture.mp4");
+		expect(ep.mediaType).toBe("video");
+		expect(ep.streamUrl).toBe("app://resource/Videos/Lecture.mp4?1");
+	});
+
 	test("getLocalEpisode prefers a manual local file over a same-titled download", () => {
 		localFiles.syncWithDownloaded({
 			"Real Podcast": [downloadedEpisode("Real Podcast", "Collision")],

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -648,12 +648,25 @@ export const favorites = writable<Playlist>({
 	shouldRepeat: false,
 });
 
-function sameEpisodeKeySet(a: Episode[], b: Episode[]): boolean {
+function getEpisodeFilePath(episode: Episode): string | undefined {
+	return (episode as Partial<DownloadedEpisode>).filePath;
+}
+
+function sameEpisodeProjection(a: Episode[], b: Episode[]): boolean {
 	if (a.length !== b.length) return false;
 
-	const keysInA = new Set(a.map(getEpisodeKey));
+	const episodesInA = new Map(
+		a.map((episode) => [getEpisodeKey(episode), episode]),
+	);
 	for (const episode of b) {
-		if (!keysInA.has(getEpisodeKey(episode))) return false;
+		const key = getEpisodeKey(episode);
+		const existing = key ? episodesInA.get(key) : undefined;
+		if (!existing) return false;
+		if (existing.streamUrl !== episode.streamUrl) return false;
+		if (existing.mediaType !== episode.mediaType) return false;
+		if (getEpisodeFilePath(existing) !== getEpisodeFilePath(episode)) {
+			return false;
+		}
 	}
 
 	return true;
@@ -708,7 +721,7 @@ export const localFiles = (() => {
 			// every object value as changed), re-running LocalFilesController.onChange and
 			// saveSettings on every unrelated downloadedEpisodes mutation and the
 			// load-time immediate-fire. Comparing before touching the store avoids that.
-			if (sameEpisodeKeySet(get(store).episodes, episodes)) {
+			if (sameEpisodeProjection(get(store).episodes, episodes)) {
 				return;
 			}
 

--- a/src/types/Episode.ts
+++ b/src/types/Episode.ts
@@ -1,3 +1,5 @@
+export type EpisodeMediaType = "audio" | "video";
+
 export interface Episode {
     title: string,
 	streamUrl: string
@@ -18,4 +20,6 @@ export interface Episode {
 	duration?: number;
 	/** URL to the podcast:chapters JSON file */
 	chaptersUrl?: string;
+	/** Media element type used to play the enclosure/local file. */
+	mediaType?: EpisodeMediaType;
 }

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -40,6 +40,7 @@
 	} from "src/utility/playbackRate";
 	import {
 		getEpisodeMediaType,
+		getEpisodeMediaTypeWithAudioContainerHint,
 		isSameMediaSource,
 	} from "src/utility/mediaType";
 	import type DownloadedEpisode from "src/types/DownloadedEpisode";
@@ -392,7 +393,7 @@
 		if (shouldUseDownloadedEpisode(episode, downloadedEpisode)) {
 			return {
 				src: createMediaUrlObjectFromFilePath(downloadedEpisode.filePath),
-				mediaType: getEpisodeMediaType(downloadedEpisode),
+				mediaType: getDownloadedEpisodeMediaType(episode, downloadedEpisode),
 			};
 		}
 
@@ -417,7 +418,10 @@
 	): downloadedEpisode is DownloadedEpisode {
 		if (!downloadedEpisode?.filePath) return false;
 
-		const downloadedMediaType = getEpisodeMediaType(downloadedEpisode);
+		const downloadedMediaType = getDownloadedEpisodeMediaType(
+			episode,
+			downloadedEpisode,
+		);
 		if (episode.mediaType && downloadedMediaType !== episode.mediaType) {
 			return false;
 		}
@@ -428,6 +432,16 @@
 		}
 
 		return isSameMediaSource(downloadedEpisode.streamUrl, episode.streamUrl);
+	}
+
+	function getDownloadedEpisodeMediaType(
+		episode: Episode,
+		downloadedEpisode: DownloadedEpisode,
+	): EpisodeMediaType {
+		return getEpisodeMediaTypeWithAudioContainerHint(
+			downloadedEpisode,
+			episode.mediaType === "audio" ? "audio" : undefined,
+		);
 	}
 
 	$: if (mediaElement && mediaElement.playbackRate !== $playbackRate) {

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -40,7 +40,7 @@
 	} from "src/utility/playbackRate";
 	import {
 		getEpisodeMediaType,
-		getEpisodeMediaTypeWithAudioContainerHint,
+		getEpisodeMediaTypeWithContainerHint,
 		isSameMediaSource,
 	} from "src/utility/mediaType";
 	import type DownloadedEpisode from "src/types/DownloadedEpisode";
@@ -438,9 +438,9 @@
 		episode: Episode,
 		downloadedEpisode: DownloadedEpisode,
 	): EpisodeMediaType {
-		return getEpisodeMediaTypeWithAudioContainerHint(
+		return getEpisodeMediaTypeWithContainerHint(
 			downloadedEpisode,
-			episode.mediaType === "audio" ? "audio" : undefined,
+			episode.mediaType,
 		);
 	}
 

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -26,7 +26,7 @@
 	import ChapterList from "./ChapterList.svelte";
 	import Progressbar from "../common/Progressbar.svelte";
 	import spawnEpisodeContextMenu from "./spawnEpisodeContextMenu";
-	import type { Episode } from "src/types/Episode";
+	import type { Episode, EpisodeMediaType } from "src/types/Episode";
 	import type { Chapter } from "src/types/Chapter";
 	import { ViewState } from "src/types/ViewState";
 	import { createMediaUrlObjectFromFilePath } from "src/utility/createMediaUrlObjectFromFilePath";
@@ -38,6 +38,11 @@
 		PLAYBACK_RATE_MIN,
 		PLAYBACK_RATE_STEP,
 	} from "src/utility/playbackRate";
+	import {
+		getEpisodeMediaType,
+		isSameMediaSource,
+	} from "src/utility/mediaType";
+	import type DownloadedEpisode from "src/types/DownloadedEpisode";
 
 	const clampVolume = (value: number): number => Math.min(1, Math.max(0, value));
 
@@ -49,11 +54,16 @@
 
 	// Title length feeds the CSS length-based downscaling on .podcast-title (issue #81).
 	$: titleCharCount = $currentEpisode?.title?.length ?? 0;
+	type MediaSource = { mediaType: EpisodeMediaType; src: string };
+	let mediaSource: MediaSource = getMediaSource($currentEpisode);
+	$: mediaSource = getMediaSource($currentEpisode, $downloadedEpisodes);
+	$: playerMediaType = mediaSource.mediaType;
+	$: isVideoEpisode = playerMediaType === "video";
 
 	let isHoveringArtwork: boolean = false;
 	let isLoading: boolean = true;
 	let playerVolume: number = 1;
-	let audioElement: HTMLAudioElement | null = null;
+	let mediaElement: HTMLMediaElement | null = null;
 	// The currentEpisode subscription fires synchronously on subscribe with the
 	// already-loaded episode; that first fire must not wipe a restored position
 	// (or flash 0) on the initial mount. Only genuine in-player switches reset.
@@ -264,9 +274,9 @@
 
 		if ($currentTime < activeSegment.endTime) return false;
 
-		const audio = event.currentTarget as HTMLAudioElement | null;
-		if (audio) {
-			audio.currentTime = activeSegment.endTime;
+		const media = event.currentTarget as HTMLMediaElement | null;
+		if (media) {
+			media.currentTime = activeSegment.endTime;
 		}
 		currentTime.set(activeSegment.endTime);
 		segmentStopTimeWithoutProgressSave = activeSegment.endTime;
@@ -282,15 +292,7 @@
 		persistPlaybackPosition();
 	}
 
-	let srcPromise: Promise<string> = getSrc($currentEpisode);
-
 	onMount(() => {
-		// This only happens when the player is open and the user downloads the episode via the context menu.
-		// So we want to update the source of the audio element to local file / online stream.
-		const unsubDownloadedSource = downloadedEpisodes.subscribe(_ => {
-			srcPromise = getSrc($currentEpisode);
-		});
-
 		const unsubCurrentEpisode = currentEpisode.subscribe((episode) => {
 			// Re-arm the load guard and throttle for the incoming episode. isLoading
 			// is cleared once on the first loadedmetadata and this component instance
@@ -304,7 +306,7 @@
 
 			// Clear the outgoing episode's progress the instant the episode changes
 			// so the player never renders its full/last position against the
-			// incoming episode while the new audio's metadata loads (issue #94).
+			// incoming episode while the new media's metadata loads (issue #94).
 			// Finishing an episode auto-advances by calling currentEpisode.set (see
 			// queue.playNext), which swaps the title/artwork immediately — but
 			// $currentTime/$duration keep the finished episode's end values until
@@ -318,8 +320,6 @@
 				duration.set(0);
 			}
 			hasSeenFirstEpisodeFire = true;
-
-			srcPromise = getSrc($currentEpisode);
 
 			// Fetch chapters when episode changes
 			const chaptersUrl = episode?.chaptersUrl;
@@ -351,7 +351,6 @@
 		document.addEventListener("visibilitychange", onVisibilityChange);
 
 		return () => {
-			unsubDownloadedSource();
 			unsubCurrentEpisode();
 			unsubVolume();
 			document.removeEventListener("visibilitychange", onVisibilityChange);
@@ -383,23 +382,99 @@
 		viewState.set(ViewState.Player);
 	}
 
-	async function getSrc(episode: Episode): Promise<string> {
-		if (downloadedEpisodes.isEpisodeDownloaded(episode)) {
-			const downloadedEpisode = downloadedEpisodes.getEpisode(episode);
-			if (!downloadedEpisode) return '';
+	function getMediaSource(
+		episode: Episode | undefined,
+		downloaded: typeof $downloadedEpisodes = {},
+	): MediaSource {
+		if (!episode) return { src: "", mediaType: "audio" };
 
-			return createMediaUrlObjectFromFilePath(downloadedEpisode.filePath);
+		const downloadedEpisode = findDownloadedEpisode(episode, downloaded);
+		if (shouldUseDownloadedEpisode(episode, downloadedEpisode)) {
+			return {
+				src: createMediaUrlObjectFromFilePath(downloadedEpisode.filePath),
+				mediaType: getEpisodeMediaType(downloadedEpisode),
+			};
 		}
-		
-		return episode.streamUrl;
+
+		return {
+			src: episode.streamUrl,
+			mediaType: getEpisodeMediaType(episode),
+		};
 	}
 
-	$: if (audioElement && audioElement.playbackRate !== $playbackRate) {
-		audioElement.playbackRate = $playbackRate;
+	function findDownloadedEpisode(
+		episode: Episode,
+		downloaded: typeof $downloadedEpisodes,
+	): DownloadedEpisode | undefined {
+		return downloaded[episode.podcastName]?.find(
+			(downloadedEpisode) => downloadedEpisode.title === episode.title,
+		);
+	}
+
+	function shouldUseDownloadedEpisode(
+		episode: Episode,
+		downloadedEpisode: DownloadedEpisode | undefined,
+	): downloadedEpisode is DownloadedEpisode {
+		if (!downloadedEpisode?.filePath) return false;
+
+		const downloadedMediaType = getEpisodeMediaType(downloadedEpisode);
+		if (episode.mediaType && downloadedMediaType !== episode.mediaType) {
+			return false;
+		}
+
+		if (episode.podcastName === "local file") {
+			const filePath = (episode as Partial<DownloadedEpisode>).filePath;
+			return !filePath || downloadedEpisode.filePath === filePath;
+		}
+
+		return isSameMediaSource(downloadedEpisode.streamUrl, episode.streamUrl);
+	}
+
+	$: if (mediaElement && mediaElement.playbackRate !== $playbackRate) {
+		mediaElement.playbackRate = $playbackRate;
 	}
 </script>
 
-	<div class="episode-player">
+<div class="episode-player">
+	{#if isVideoEpisode}
+		<div class="episode-video-container">
+			<!-- svelte-ignore a11y_media_has_caption -->
+			<video
+				class="podcast-video"
+				bind:this={mediaElement}
+				src={mediaSource.src}
+				bind:duration={$duration}
+				bind:currentTime={$currentTime}
+				bind:paused={$isPaused}
+				bind:volume={playerVolume}
+				on:ended={onEpisodeEnded}
+				on:loadedmetadata={onMetadataLoaded}
+				on:timeupdate={onTimeUpdate}
+				on:pause={onPause}
+				on:play|preventDefault
+				aria-label={$currentEpisode.title}
+				playsinline
+				autoplay={true}
+			></video>
+
+			{#if isLoading}
+				<div class="podcast-artwork-isloading-overlay">
+					<Loading />
+				</div>
+			{:else}
+				<button
+					type="button"
+					class="podcast-video-overlay"
+					class:visible={$isPaused}
+					on:click={togglePlayback}
+					on:contextmenu={handleContextMenuEpisodeImage}
+					aria-label="Toggle playback"
+				>
+					<Icon icon={$isPaused ? "play" : "pause"} clickable={false} />
+				</button>
+			{/if}
+		</div>
+	{:else}
 		<div class="episode-image-container">
 			<button
 				type="button"
@@ -410,39 +485,41 @@
 				on:mouseleave={() => (isHoveringArtwork = false)}
 				aria-label="Toggle playback"
 			>
-		 <Image 
-			class={"podcast-artwork"}
-			src={$currentEpisode.artworkUrl ?? ""}
-			alt={$currentEpisode.title}
-			opacity={(isHoveringArtwork || $isPaused) ? 0.5 : 1}
-		 >
-			<svelte:fragment slot="fallback">
-				<div class={"podcast-artwork-placeholder" + (isHoveringArtwork || $isPaused ? " opacity-50" : "")}>
-					<Icon icon="image" size={150} clickable={false} />
-				</div>
-			</svelte:fragment>
-		 </Image>
-			{#if isLoading}
-				<div class="podcast-artwork-isloading-overlay">
-					<Loading />
-				</div>
-			{:else}
-				<div
-					class="podcast-artwork-overlay"
-					class:visible={isHoveringArtwork || $isPaused}
+				<Image
+					class="podcast-artwork"
+					src={$currentEpisode.artworkUrl ?? ""}
+					alt={$currentEpisode.title}
+					opacity={isHoveringArtwork || $isPaused ? 0.5 : 1}
 				>
-					<Icon icon={$isPaused ? "play" : "pause"} clickable={false} />
-				</div>
-			{/if}
-		</button>
-	</div>
+					<svelte:fragment slot="fallback">
+						<div class={"podcast-artwork-placeholder" + (isHoveringArtwork || $isPaused ? " opacity-50" : "")}>
+							<Icon icon="image" size={150} clickable={false} />
+						</div>
+					</svelte:fragment>
+				</Image>
+
+				{#if isLoading}
+					<div class="podcast-artwork-isloading-overlay">
+						<Loading />
+					</div>
+				{:else}
+					<div
+						class="podcast-artwork-overlay"
+						class:visible={isHoveringArtwork || $isPaused}
+					>
+						<Icon icon={$isPaused ? "play" : "pause"} clickable={false} />
+					</div>
+				{/if}
+			</button>
+		</div>
+	{/if}
 
 	<h2 class="podcast-title" style="--title-char-count: {titleCharCount}">{$currentEpisode.title}</h2>
 
-	{#await srcPromise then src}
+	{#if !isVideoEpisode}
 		<audio
-			bind:this={audioElement}
-			src={src}
+			bind:this={mediaElement}
+			src={mediaSource.src}
 			bind:duration={$duration}
 			bind:currentTime={$currentTime}
 			bind:paused={$isPaused}
@@ -454,7 +531,7 @@
 			on:play|preventDefault
 			autoplay={true}
 		></audio>
-	{/await}
+	{/if}
 
 	<div class="status-container">
 		<span>{formatSeconds($currentTime, "HH:mm:ss")}</span>
@@ -542,6 +619,26 @@
 		padding: 1rem 0 0.5rem;
 	}
 
+	.episode-video-container {
+		width: 100%;
+		max-width: 32rem;
+		aspect-ratio: 16 / 9;
+		position: relative;
+		margin: 0 auto 0.5rem;
+		background: #000;
+		border-radius: 0.75rem;
+		overflow: hidden;
+		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+	}
+
+	.podcast-video {
+		width: 100%;
+		height: 100%;
+		display: block;
+		object-fit: contain;
+		background: #000;
+	}
+
 	.hover-container {
 		width: 100%;
 		height: 0;
@@ -599,8 +696,30 @@
 		transition: opacity 200ms ease;
 	}
 
-	.podcast-artwork-overlay.visible {
+	.podcast-video-overlay {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		border: none;
+		background: rgba(0, 0, 0, 0.1);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		transition: opacity 200ms ease;
+	}
+
+	.episode-video-container:hover .podcast-video-overlay,
+	.podcast-video-overlay:focus-visible,
+	.podcast-artwork-overlay.visible,
+	.podcast-video-overlay.visible {
 		opacity: 1;
+	}
+
+	.podcast-video-overlay:focus-visible {
+		outline: 2px solid var(--background-modifier-border-focus);
+		outline-offset: -4px;
 	}
 
 	.podcast-artwork-isloading-overlay {

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -369,7 +369,40 @@ describe("EpisodePlayer", () => {
 		);
 	});
 
-	test("uses a matching downloaded video file to classify old extensionless records", async () => {
+	test("uses a legacy downloaded video mp4 file for an explicitly video feed episode", async () => {
+		mockVaultFile("Downloads/legacy-video.mp4");
+		const videoEpisode: Episode = {
+			...testEpisode,
+			title: "Legacy Video MP4",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "video",
+		};
+		downloadedEpisodes.set({
+			[testEpisode.podcastName]: [
+				{
+					...testEpisode,
+					title: "Legacy Video MP4",
+					streamUrl: "https://cdn.example.com/episode.mp4",
+					filePath: "Downloads/legacy-video.mp4",
+					size: 10,
+				},
+			],
+		});
+		currentEpisode.set(videoEpisode);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("video")).not.toBeNull();
+		});
+		const video = container.querySelector("video") as HTMLVideoElement;
+
+		expect(container.querySelector("audio")).toBeNull();
+		expect(video.getAttribute("src")).toBe(
+			"app://resource/Downloads/legacy-video.mp4?token",
+		);
+	});
+
+	test("uses matching downloaded video metadata to classify extensionless records", async () => {
 		mockVaultFile("Downloads/video.mp4");
 		const extensionlessEpisode: Episode = {
 			...testEpisode,
@@ -381,6 +414,7 @@ describe("EpisodePlayer", () => {
 				{
 					...extensionlessEpisode,
 					filePath: "Downloads/video.mp4",
+					mediaType: "video",
 					size: 10,
 				},
 			],

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -1,10 +1,12 @@
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { TFile } from "obsidian";
 import { get } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
 	currentEpisode,
 	currentTime,
+	downloadedEpisodes,
 	duration,
 	isPaused,
 	activePlaybackSegment,
@@ -35,6 +37,7 @@ beforeEach(() => {
 	playbackRate.set(1);
 	playedEpisodes.set({});
 	requestedPlaybackTime.set(null);
+	downloadedEpisodes.set({});
 	HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
 	HTMLMediaElement.prototype.pause = vi.fn();
 	plugin.set({
@@ -47,6 +50,34 @@ beforeEach(() => {
 		},
 	} as never);
 });
+
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+});
+
+function makeTFile(path: string): TFile {
+	const file = new TFile();
+	const dot = path.lastIndexOf(".");
+	const slash = path.lastIndexOf("/");
+	Object.assign(file as unknown as Record<string, unknown>, {
+		path,
+		extension: dot > slash ? path.slice(dot + 1) : "",
+		basename: path.slice(slash + 1, dot > slash ? dot : undefined),
+	});
+	return file;
+}
+
+function mockVaultFile(path: string): void {
+	const file = makeTFile(path);
+	(globalThis as { app?: unknown }).app = {
+		vault: {
+			getAbstractFileByPath: vi.fn((candidate: string) =>
+				candidate === path ? file : null,
+			),
+			getResourcePath: vi.fn(() => `app://resource/${path}?token`),
+		},
+	};
+}
 
 describe("EpisodePlayer", () => {
 	test("uses requested timestamp before restored played progress", async () => {
@@ -241,6 +272,96 @@ describe("EpisodePlayer", () => {
 		await fireEvent.input(rateSlider);
 
 		expect(get(playbackRate)).toBe(2.2);
+	});
+
+	test("renders video episodes with a video media element and shared playback bindings", async () => {
+		const videoEpisode: Episode = {
+			...testEpisode,
+			title: "Video Episode",
+			streamUrl: "https://pod.example.com/video.mp4",
+			mediaType: "video",
+		};
+		const episodeKey = `${videoEpisode.podcastName}::${videoEpisode.title}`;
+		currentEpisode.set(videoEpisode);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("video")).not.toBeNull();
+		});
+		const video = container.querySelector("video") as HTMLVideoElement;
+
+		expect(container.querySelector("audio")).toBeNull();
+		expect(video.getAttribute("src")).toBe(videoEpisode.streamUrl);
+
+		await fireEvent.loadedMetadata(video);
+		expect(get(isPaused)).toBe(false);
+
+		playbackRate.set(1.5);
+		await waitFor(() => {
+			expect(video.playbackRate).toBe(1.5);
+		});
+
+		currentTime.set(42);
+		await fireEvent.timeUpdate(video);
+		expect(get(playedEpisodes)[episodeKey]?.time).toBe(42);
+	});
+
+	test("does not reuse a same-title downloaded audio file for a video episode", async () => {
+		downloadedEpisodes.set({
+			[testEpisode.podcastName]: [
+				{
+					...testEpisode,
+					title: "Video Episode",
+					streamUrl: "https://pod.example.com/audio.mp3",
+					filePath: "Downloads/audio.mp3",
+					size: 10,
+				},
+			],
+		});
+		const videoEpisode: Episode = {
+			...testEpisode,
+			title: "Video Episode",
+			streamUrl: "https://pod.example.com/video.mp4",
+			mediaType: "video",
+		};
+		currentEpisode.set(videoEpisode);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("video")).not.toBeNull();
+		});
+		const video = container.querySelector("video") as HTMLVideoElement;
+
+		expect(container.querySelector("audio")).toBeNull();
+		expect(video.getAttribute("src")).toBe(videoEpisode.streamUrl);
+	});
+
+	test("uses a matching downloaded video file to classify old extensionless records", async () => {
+		mockVaultFile("Downloads/video.mp4");
+		const extensionlessEpisode: Episode = {
+			...testEpisode,
+			title: "Extensionless Video",
+			streamUrl: "https://cdn.example.com/watch?id=42",
+		};
+		downloadedEpisodes.set({
+			[testEpisode.podcastName]: [
+				{
+					...extensionlessEpisode,
+					filePath: "Downloads/video.mp4",
+					size: 10,
+				},
+			],
+		});
+		currentEpisode.set(extensionlessEpisode);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("video")).not.toBeNull();
+		});
+		const video = container.querySelector("video") as HTMLVideoElement;
+
+		expect(container.querySelector("audio")).toBeNull();
+		expect(video.getAttribute("src")).toBe("app://resource/Downloads/video.mp4?token");
 	});
 });
 

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -336,6 +336,39 @@ describe("EpisodePlayer", () => {
 		expect(video.getAttribute("src")).toBe(videoEpisode.streamUrl);
 	});
 
+	test("uses a legacy downloaded audio mp4 file for an explicitly audio feed episode", async () => {
+		mockVaultFile("Downloads/legacy-audio.mp4");
+		const audioEpisode: Episode = {
+			...testEpisode,
+			title: "Legacy Audio MP4",
+			streamUrl: "https://cdn.example.com/episode.mp4",
+			mediaType: "audio",
+		};
+		downloadedEpisodes.set({
+			[testEpisode.podcastName]: [
+				{
+					...testEpisode,
+					title: "Legacy Audio MP4",
+					streamUrl: "https://cdn.example.com/episode.mp4",
+					filePath: "Downloads/legacy-audio.mp4",
+					size: 10,
+				},
+			],
+		});
+		currentEpisode.set(audioEpisode);
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+
+		expect(container.querySelector("video")).toBeNull();
+		expect(audio.getAttribute("src")).toBe(
+			"app://resource/Downloads/legacy-audio.mp4?token",
+		);
+	});
+
 	test("uses a matching downloaded video file to classify old extensionless records", async () => {
 		mockVaultFile("Downloads/video.mp4");
 		const extensionlessEpisode: Episode = {

--- a/src/utility/getExtensionFromContentType.test.ts
+++ b/src/utility/getExtensionFromContentType.test.ts
@@ -10,7 +10,12 @@ describe("getExtensionFromContentType", () => {
 		expect(getExtensionFromContentType("Audio/X-M4A")).toBe("m4a");
 	});
 
-	test("returns null when mime type is not audio", () => {
+	test("detects video mime types", () => {
+		expect(getExtensionFromContentType("video/mp4")).toBe("mp4");
+		expect(getExtensionFromContentType("Video/WebM")).toBe("webm");
+	});
+
+	test("returns null when mime type is not playable media", () => {
 		expect(getExtensionFromContentType("text/html")).toBeNull();
 	});
 });

--- a/src/utility/getExtensionFromContentType.test.ts
+++ b/src/utility/getExtensionFromContentType.test.ts
@@ -15,6 +15,10 @@ describe("getExtensionFromContentType", () => {
 		expect(getExtensionFromContentType("Video/WebM")).toBe("webm");
 	});
 
+	test("detects audio webm from mime type", () => {
+		expect(getExtensionFromContentType("audio/webm")).toBe("webm");
+	});
+
 	test("returns null when mime type is not playable media", () => {
 		expect(getExtensionFromContentType("text/html")).toBeNull();
 	});

--- a/src/utility/getExtensionFromContentType.ts
+++ b/src/utility/getExtensionFromContentType.ts
@@ -15,6 +15,7 @@ const CONTENT_TYPE_EXTENSION_MAP: Array<{
 	{ pattern: /audio\/x-ms-wma/i, extension: "wma" },
 	{ pattern: /audio\/wma/i, extension: "wma" },
 	{ pattern: /audio\/amr/i, extension: "amr" },
+	{ pattern: /audio\/webm/i, extension: "webm" },
 	{ pattern: /video\/mp4/i, extension: "mp4" },
 	{ pattern: /video\/x-m4v/i, extension: "m4v" },
 	{ pattern: /video\/quicktime/i, extension: "mov" },

--- a/src/utility/getExtensionFromContentType.ts
+++ b/src/utility/getExtensionFromContentType.ts
@@ -15,6 +15,11 @@ const CONTENT_TYPE_EXTENSION_MAP: Array<{
 	{ pattern: /audio\/x-ms-wma/i, extension: "wma" },
 	{ pattern: /audio\/wma/i, extension: "wma" },
 	{ pattern: /audio\/amr/i, extension: "amr" },
+	{ pattern: /video\/mp4/i, extension: "mp4" },
+	{ pattern: /video\/x-m4v/i, extension: "m4v" },
+	{ pattern: /video\/quicktime/i, extension: "mov" },
+	{ pattern: /video\/webm/i, extension: "webm" },
+	{ pattern: /video\/ogg/i, extension: "ogv" },
 ];
 
 export default function getExtensionFromContentType(

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import type { Episode } from "src/types/Episode";
+import type { LocalEpisode } from "src/types/LocalEpisode";
+import {
+	getEpisodeMediaType,
+	getMediaTypeFromContentType,
+	isSameMediaSource,
+} from "./mediaType";
+
+describe("mediaType", () => {
+	test("detects media type from enclosure content type", () => {
+		expect(getMediaTypeFromContentType("video/mp4")).toBe("video");
+		expect(getMediaTypeFromContentType("Audio/MPEG; charset=utf-8")).toBe(
+			"audio",
+		);
+		expect(getMediaTypeFromContentType("application/rss+xml")).toBeNull();
+	});
+
+	test("falls back to the stream URL extension for older episode records", () => {
+		const episode = {
+			title: "Video",
+			streamUrl: "https://example.com/show/video.MP4?token=abc",
+			url: "https://example.com/show/video",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+		} satisfies Episode;
+
+		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("falls back to a local file path before a resource URL", () => {
+		const episode = {
+			title: "Local Video",
+			streamUrl: "app://resource/no-extension?123",
+			url: "[[Videos/local.mp4]]",
+			description: "",
+			content: "",
+			podcastName: "local file",
+			filePath: "Videos/local.mp4",
+		} satisfies LocalEpisode;
+
+		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("falls back to a downloaded file path for old cached records", () => {
+		const episode = {
+			title: "Downloaded Video",
+			streamUrl: "https://example.com/watch?id=42",
+			url: "https://example.com/watch?id=42",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			filePath: "Podcasts/downloaded-video.webm",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("uses the downloaded file path before stale persisted metadata", () => {
+		const episode = {
+			title: "Downloaded Video",
+			streamUrl: "https://example.com/watch?id=42",
+			url: "https://example.com/watch?id=42",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			mediaType: "audio",
+			filePath: "Podcasts/downloaded-video.mp4",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("keeps a remote episode video when either metadata or URL says video", () => {
+		expect(
+			getEpisodeMediaType({
+				title: "Conflicting URL",
+				streamUrl: "https://example.com/video.mp4",
+				url: "https://example.com/video",
+				description: "",
+				content: "",
+				podcastName: "Feed",
+				mediaType: "audio",
+			} satisfies Episode),
+		).toBe("video");
+		expect(
+			getEpisodeMediaType({
+				title: "Conflicting Metadata",
+				streamUrl: "https://example.com/audio.mp3",
+				url: "https://example.com/audio",
+				description: "",
+				content: "",
+				podcastName: "Feed",
+				mediaType: "video",
+			} satisfies Episode),
+		).toBe("video");
+	});
+
+	test("compares remote sources while ignoring signed query token rotation", () => {
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/video.mp4?token=old",
+				"https://cdn.example.com/video.mp4?token=new",
+			),
+		).toBe(true);
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/video.mp4",
+				"https://cdn.example.com/audio.mp3",
+			),
+		).toBe(false);
+	});
+
+	test("requires exact query strings for extensionless remote sources", () => {
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/watch?id=1",
+				"https://cdn.example.com/watch?id=2",
+			),
+		).toBe(false);
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/watch?id=1",
+				"https://cdn.example.com/watch?id=1",
+			),
+		).toBe(true);
+	});
+});

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -72,10 +72,10 @@ describe("mediaType", () => {
 		expect(getEpisodeMediaType(episode)).toBe("video");
 	});
 
-	test("keeps a remote episode video when either metadata or URL says video", () => {
+	test("trusts remote episode media metadata before URL extension fallback", () => {
 		expect(
 			getEpisodeMediaType({
-				title: "Conflicting URL",
+				title: "Audio MP4",
 				streamUrl: "https://example.com/video.mp4",
 				url: "https://example.com/video",
 				description: "",
@@ -83,10 +83,10 @@ describe("mediaType", () => {
 				podcastName: "Feed",
 				mediaType: "audio",
 			} satisfies Episode),
-		).toBe("video");
+		).toBe("audio");
 		expect(
 			getEpisodeMediaType({
-				title: "Conflicting Metadata",
+				title: "Video Metadata",
 				streamUrl: "https://example.com/audio.mp3",
 				url: "https://example.com/audio",
 				description: "",

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -189,6 +189,18 @@ describe("mediaType", () => {
 		).toBe(true);
 		expect(
 			isSameMediaSource(
+				"https://cdn.example.com/episode.mp4?id=1&token=old",
+				"https://cdn.example.com/episode.mp4?id=1&token=new",
+			),
+		).toBe(true);
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/episode.mp4?id=1",
+				"https://cdn.example.com/episode.mp4?id=2",
+			),
+		).toBe(false);
+		expect(
+			isSameMediaSource(
 				"https://cdn.example.com/video.mp4",
 				"https://cdn.example.com/audio.mp3",
 			),

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -57,22 +57,22 @@ describe("mediaType", () => {
 		expect(getEpisodeMediaType(episode)).toBe("video");
 	});
 
-	test("uses unambiguous downloaded file paths before stale persisted metadata", () => {
+	test("trusts explicit audio metadata before downloaded path fallback", () => {
 		const episode = {
-			title: "Downloaded Video",
-			streamUrl: "https://example.com/watch?id=42",
-			url: "https://example.com/watch?id=42",
+			title: "Downloaded Audio WebM",
+			streamUrl: "https://example.com/episode.webm",
+			url: "https://example.com/episode",
 			description: "",
 			content: "",
 			podcastName: "Feed",
 			mediaType: "audio",
-			filePath: "Podcasts/downloaded-video.webm",
+			filePath: "Podcasts/downloaded-audio.webm",
 		} satisfies Episode & { filePath: string };
 
-		expect(getEpisodeMediaType(episode)).toBe("video");
+		expect(getEpisodeMediaType(episode)).toBe("audio");
 	});
 
-	test("trusts explicit audio metadata for ambiguous mp4 file paths", () => {
+	test("trusts explicit audio metadata for mp4 file paths", () => {
 		const episode = {
 			title: "Downloaded Audio MP4",
 			streamUrl: "https://example.com/episode.mp4",

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -3,6 +3,7 @@ import type { Episode } from "src/types/Episode";
 import type { LocalEpisode } from "src/types/LocalEpisode";
 import {
 	getEpisodeMediaType,
+	getEpisodeMediaTypeWithAudioContainerHint,
 	getMediaTypeFromContentType,
 	isSameMediaSource,
 } from "./mediaType";
@@ -85,6 +86,40 @@ describe("mediaType", () => {
 		} satisfies Episode & { filePath: string };
 
 		expect(getEpisodeMediaType(episode)).toBe("audio");
+	});
+
+	test("uses an audio hint for legacy ambiguous container file paths", () => {
+		const episode = {
+			title: "Legacy Downloaded Audio MP4",
+			streamUrl: "https://example.com/episode.mp4",
+			url: "https://example.com/episode",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			filePath: "Podcasts/downloaded-audio.mp4",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaType(episode)).toBe("video");
+		expect(getEpisodeMediaTypeWithAudioContainerHint(episode, "audio")).toBe(
+			"audio",
+		);
+	});
+
+	test("does not let an audio hint override explicit video metadata", () => {
+		const episode = {
+			title: "Downloaded Video MP4",
+			streamUrl: "https://example.com/episode.mp4",
+			url: "https://example.com/episode",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			mediaType: "video",
+			filePath: "Podcasts/downloaded-video.mp4",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaTypeWithAudioContainerHint(episode, "audio")).toBe(
+			"video",
+		);
 	});
 
 	test("trusts remote episode media metadata before URL extension fallback", () => {

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -3,7 +3,7 @@ import type { Episode } from "src/types/Episode";
 import type { LocalEpisode } from "src/types/LocalEpisode";
 import {
 	getEpisodeMediaType,
-	getEpisodeMediaTypeWithAudioContainerHint,
+	getEpisodeMediaTypeWithContainerHint,
 	getMediaTypeFromContentType,
 	isSameMediaSource,
 } from "./mediaType";
@@ -17,10 +17,10 @@ describe("mediaType", () => {
 		expect(getMediaTypeFromContentType("application/rss+xml")).toBeNull();
 	});
 
-	test("falls back to the stream URL extension for older episode records", () => {
+	test("falls back to unambiguous stream URL extensions for older episode records", () => {
 		const episode = {
 			title: "Video",
-			streamUrl: "https://example.com/show/video.MP4?token=abc",
+			streamUrl: "https://example.com/show/video.MOV?token=abc",
 			url: "https://example.com/show/video",
 			description: "",
 			content: "",
@@ -30,21 +30,21 @@ describe("mediaType", () => {
 		expect(getEpisodeMediaType(episode)).toBe("video");
 	});
 
-	test("falls back to a local file path before a resource URL", () => {
+	test("falls back to unambiguous local file paths before resource URLs", () => {
 		const episode = {
 			title: "Local Video",
 			streamUrl: "app://resource/no-extension?123",
-			url: "[[Videos/local.mp4]]",
+			url: "[[Videos/local.mov]]",
 			description: "",
 			content: "",
 			podcastName: "local file",
-			filePath: "Videos/local.mp4",
+			filePath: "Videos/local.mov",
 		} satisfies LocalEpisode;
 
 		expect(getEpisodeMediaType(episode)).toBe("video");
 	});
 
-	test("falls back to a downloaded file path for old cached records", () => {
+	test("falls back to unambiguous downloaded file paths for old cached records", () => {
 		const episode = {
 			title: "Downloaded Video",
 			streamUrl: "https://example.com/watch?id=42",
@@ -52,10 +52,26 @@ describe("mediaType", () => {
 			description: "",
 			content: "",
 			podcastName: "Feed",
-			filePath: "Podcasts/downloaded-video.webm",
+			filePath: "Podcasts/downloaded-video.ogv",
 		} satisfies Episode & { filePath: string };
 
 		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("preserves legacy ambiguous mp4 and webm records as audio", () => {
+		for (const extension of ["mp4", "webm"]) {
+			const episode = {
+				title: `Legacy Audio ${extension}`,
+				streamUrl: `https://example.com/episode.${extension}`,
+				url: "https://example.com/episode",
+				description: "",
+				content: "",
+				podcastName: "Feed",
+				filePath: `Podcasts/downloaded-audio.${extension}`,
+			} satisfies Episode & { filePath: string };
+
+			expect(getEpisodeMediaType(episode)).toBe("audio");
+		}
 	});
 
 	test("trusts explicit audio metadata before downloaded path fallback", () => {
@@ -88,7 +104,7 @@ describe("mediaType", () => {
 		expect(getEpisodeMediaType(episode)).toBe("audio");
 	});
 
-	test("uses an audio hint for legacy ambiguous container file paths", () => {
+	test("audio hints keep legacy ambiguous container file paths as audio", () => {
 		const episode = {
 			title: "Legacy Downloaded Audio MP4",
 			streamUrl: "https://example.com/episode.mp4",
@@ -99,9 +115,26 @@ describe("mediaType", () => {
 			filePath: "Podcasts/downloaded-audio.mp4",
 		} satisfies Episode & { filePath: string };
 
-		expect(getEpisodeMediaType(episode)).toBe("video");
-		expect(getEpisodeMediaTypeWithAudioContainerHint(episode, "audio")).toBe(
+		expect(getEpisodeMediaType(episode)).toBe("audio");
+		expect(getEpisodeMediaTypeWithContainerHint(episode, "audio")).toBe(
 			"audio",
+		);
+	});
+
+	test("video hints classify legacy ambiguous container file paths as video", () => {
+		const episode = {
+			title: "Legacy Downloaded Video MP4",
+			streamUrl: "https://example.com/episode.mp4",
+			url: "https://example.com/episode",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			filePath: "Podcasts/downloaded-video.mp4",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaType(episode)).toBe("audio");
+		expect(getEpisodeMediaTypeWithContainerHint(episode, "video")).toBe(
+			"video",
 		);
 	});
 
@@ -117,7 +150,7 @@ describe("mediaType", () => {
 			filePath: "Podcasts/downloaded-video.mp4",
 		} satisfies Episode & { filePath: string };
 
-		expect(getEpisodeMediaTypeWithAudioContainerHint(episode, "audio")).toBe(
+		expect(getEpisodeMediaTypeWithContainerHint(episode, "audio")).toBe(
 			"video",
 		);
 	});

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -57,7 +57,7 @@ describe("mediaType", () => {
 		expect(getEpisodeMediaType(episode)).toBe("video");
 	});
 
-	test("uses the downloaded file path before stale persisted metadata", () => {
+	test("uses unambiguous downloaded file paths before stale persisted metadata", () => {
 		const episode = {
 			title: "Downloaded Video",
 			streamUrl: "https://example.com/watch?id=42",
@@ -66,10 +66,25 @@ describe("mediaType", () => {
 			content: "",
 			podcastName: "Feed",
 			mediaType: "audio",
-			filePath: "Podcasts/downloaded-video.mp4",
+			filePath: "Podcasts/downloaded-video.webm",
 		} satisfies Episode & { filePath: string };
 
 		expect(getEpisodeMediaType(episode)).toBe("video");
+	});
+
+	test("trusts explicit audio metadata for ambiguous mp4 file paths", () => {
+		const episode = {
+			title: "Downloaded Audio MP4",
+			streamUrl: "https://example.com/episode.mp4",
+			url: "https://example.com/episode",
+			description: "",
+			content: "",
+			podcastName: "Feed",
+			mediaType: "audio",
+			filePath: "Podcasts/downloaded-audio.mp4",
+		} satisfies Episode & { filePath: string };
+
+		expect(getEpisodeMediaType(episode)).toBe("audio");
 	});
 
 	test("trusts remote episode media metadata before URL extension fallback", () => {

--- a/src/utility/mediaType.test.ts
+++ b/src/utility/mediaType.test.ts
@@ -195,7 +195,13 @@ describe("mediaType", () => {
 		).toBe(false);
 	});
 
-	test("requires exact query strings for extensionless remote sources", () => {
+	test("compares extensionless remote sources by stable query params", () => {
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/download?id=123&token=old&exp=1",
+				"https://cdn.example.com/download?id=123&token=new&exp=2",
+			),
+		).toBe(true);
 		expect(
 			isSameMediaSource(
 				"https://cdn.example.com/watch?id=1",
@@ -208,5 +214,11 @@ describe("mediaType", () => {
 				"https://cdn.example.com/watch?id=1",
 			),
 		).toBe(true);
+		expect(
+			isSameMediaSource(
+				"https://cdn.example.com/download?token=old",
+				"https://cdn.example.com/download?token=new",
+			),
+		).toBe(false);
 	});
 });

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -67,16 +67,9 @@ export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
 	const filePathMediaType = getMediaTypeFromPath(filePath);
 	if (filePathMediaType) return filePathMediaType;
 
-	const streamMediaType = getMediaTypeFromPath(episode.streamUrl);
-	if (episode.mediaType === "video" || streamMediaType === "video") {
-		return "video";
-	}
+	if (episode.mediaType) return episode.mediaType;
 
-	return (
-		episode.mediaType ??
-		streamMediaType ??
-		"audio"
-	);
+	return getMediaTypeFromPath(episode.streamUrl) ?? "audio";
 }
 
 export function isSameMediaSource(a: string, b: string): boolean {

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -62,14 +62,25 @@ export function getMediaTypeFromPath(
 	return getMediaTypeFromExtension(getUrlExtension(pathOrUrl));
 }
 
+export function getUnambiguousMediaTypeFromPath(
+	pathOrUrl?: string | null,
+): EpisodeMediaType | null {
+	if (!pathOrUrl) return null;
+
+	const extension = getUrlExtension(pathOrUrl);
+	if (isAudioContainerExtension(extension)) return null;
+
+	return getMediaTypeFromExtension(extension);
+}
+
 export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
 	if (episode.mediaType) return episode.mediaType;
 
 	const filePath = (episode as Partial<LocalEpisode>).filePath;
-	const filePathMediaType = getLegacyEpisodeMediaTypeFromPath(filePath);
+	const filePathMediaType = getUnambiguousMediaTypeFromPath(filePath);
 	if (filePathMediaType) return filePathMediaType;
 
-	return getLegacyEpisodeMediaTypeFromPath(episode.streamUrl) ?? "audio";
+	return getUnambiguousMediaTypeFromPath(episode.streamUrl) ?? "audio";
 }
 
 export function isAudioContainerExtension(
@@ -79,17 +90,6 @@ export function isAudioContainerExtension(
 
 	const normalizedExtension = extension.toLowerCase();
 	return normalizedExtension === "mp4" || normalizedExtension === "webm";
-}
-
-function getLegacyEpisodeMediaTypeFromPath(
-	pathOrUrl?: string | null,
-): EpisodeMediaType | null {
-	if (!pathOrUrl) return null;
-
-	const extension = getUrlExtension(pathOrUrl);
-	if (isAudioContainerExtension(extension)) return null;
-
-	return getMediaTypeFromExtension(extension);
 }
 
 export function getEpisodeMediaTypeWithContainerHint(

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -1,0 +1,99 @@
+import type { Episode, EpisodeMediaType } from "src/types/Episode";
+import type { LocalEpisode } from "src/types/LocalEpisode";
+import getUrlExtension from "./getUrlExtension";
+
+export const AUDIO_MEDIA_EXTENSIONS = new Set([
+	"mp3",
+	"m4a",
+	"aac",
+	"ogg",
+	"wav",
+	"flac",
+	"wma",
+	"amr",
+]);
+
+export const VIDEO_MEDIA_EXTENSIONS = new Set([
+	"mp4",
+	"m4v",
+	"mov",
+	"webm",
+	"ogv",
+]);
+
+export const PLAYABLE_MEDIA_EXTENSIONS = new Set([
+	...AUDIO_MEDIA_EXTENSIONS,
+	...VIDEO_MEDIA_EXTENSIONS,
+]);
+
+export function getMediaTypeFromExtension(
+	extension?: string | null,
+): EpisodeMediaType | null {
+	if (!extension) return null;
+
+	const normalizedExtension = extension.toLowerCase();
+	if (VIDEO_MEDIA_EXTENSIONS.has(normalizedExtension)) return "video";
+	if (AUDIO_MEDIA_EXTENSIONS.has(normalizedExtension)) return "audio";
+
+	return null;
+}
+
+export function isPlayableMediaExtension(extension?: string | null): boolean {
+	return getMediaTypeFromExtension(extension) !== null;
+}
+
+export function getMediaTypeFromContentType(
+	contentType?: string | null,
+): EpisodeMediaType | null {
+	if (!contentType) return null;
+
+	const normalizedType = contentType.split(";")[0].trim().toLowerCase();
+	if (normalizedType.startsWith("video/")) return "video";
+	if (normalizedType.startsWith("audio/")) return "audio";
+
+	return null;
+}
+
+export function getMediaTypeFromPath(
+	pathOrUrl?: string | null,
+): EpisodeMediaType | null {
+	if (!pathOrUrl) return null;
+
+	return getMediaTypeFromExtension(getUrlExtension(pathOrUrl));
+}
+
+export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
+	const filePath = (episode as Partial<LocalEpisode>).filePath;
+	const filePathMediaType = getMediaTypeFromPath(filePath);
+	if (filePathMediaType) return filePathMediaType;
+
+	const streamMediaType = getMediaTypeFromPath(episode.streamUrl);
+	if (episode.mediaType === "video" || streamMediaType === "video") {
+		return "video";
+	}
+
+	return (
+		episode.mediaType ??
+		streamMediaType ??
+		"audio"
+	);
+}
+
+export function isSameMediaSource(a: string, b: string): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	try {
+		const ua = new URL(a);
+		const ub = new URL(b);
+		if (ua.origin !== ub.origin || ua.pathname !== ub.pathname) {
+			return false;
+		}
+
+		const pathIdentifiesMedia =
+			getMediaTypeFromPath(ua.pathname) !== null ||
+			getMediaTypeFromPath(ub.pathname) !== null;
+		return pathIdentifiesMedia || ua.search === ub.search;
+	} catch {
+		return false;
+	}
+}

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -65,7 +65,16 @@ export function getMediaTypeFromPath(
 export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
 	const filePath = (episode as Partial<LocalEpisode>).filePath;
 	const filePathMediaType = getMediaTypeFromPath(filePath);
-	if (filePathMediaType) return filePathMediaType;
+	if (
+		filePathMediaType &&
+		!(
+			episode.mediaType === "audio" &&
+			filePath &&
+			getUrlExtension(filePath).toLowerCase() === "mp4"
+		)
+	) {
+		return filePathMediaType;
+	}
 
 	if (episode.mediaType) return episode.mediaType;
 

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -66,10 +66,10 @@ export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
 	if (episode.mediaType) return episode.mediaType;
 
 	const filePath = (episode as Partial<LocalEpisode>).filePath;
-	const filePathMediaType = getMediaTypeFromPath(filePath);
+	const filePathMediaType = getLegacyEpisodeMediaTypeFromPath(filePath);
 	if (filePathMediaType) return filePathMediaType;
 
-	return getMediaTypeFromPath(episode.streamUrl) ?? "audio";
+	return getLegacyEpisodeMediaTypeFromPath(episode.streamUrl) ?? "audio";
 }
 
 export function isAudioContainerExtension(
@@ -81,7 +81,18 @@ export function isAudioContainerExtension(
 	return normalizedExtension === "mp4" || normalizedExtension === "webm";
 }
 
-export function getEpisodeMediaTypeWithAudioContainerHint(
+function getLegacyEpisodeMediaTypeFromPath(
+	pathOrUrl?: string | null,
+): EpisodeMediaType | null {
+	if (!pathOrUrl) return null;
+
+	const extension = getUrlExtension(pathOrUrl);
+	if (isAudioContainerExtension(extension)) return null;
+
+	return getMediaTypeFromExtension(extension);
+}
+
+export function getEpisodeMediaTypeWithContainerHint(
 	episode: Episode,
 	mediaTypeHint?: EpisodeMediaType,
 ): EpisodeMediaType {
@@ -89,11 +100,8 @@ export function getEpisodeMediaTypeWithAudioContainerHint(
 
 	const filePath = (episode as Partial<LocalEpisode>).filePath;
 	const fileExtension = filePath ? getUrlExtension(filePath) : null;
-	if (
-		mediaTypeHint === "audio" &&
-		isAudioContainerExtension(fileExtension)
-	) {
-		return "audio";
+	if (mediaTypeHint && isAudioContainerExtension(fileExtension)) {
+		return mediaTypeHint;
 	}
 
 	return getEpisodeMediaType(episode);

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -120,8 +120,46 @@ export function isSameMediaSource(a: string, b: string): boolean {
 		const pathIdentifiesMedia =
 			getMediaTypeFromPath(ua.pathname) !== null ||
 			getMediaTypeFromPath(ub.pathname) !== null;
-		return pathIdentifiesMedia || ua.search === ub.search;
+		return (
+			pathIdentifiesMedia ||
+			ua.search === ub.search ||
+			stableSearchParamsMatch(ua.searchParams, ub.searchParams)
+		);
 	} catch {
 		return false;
 	}
+}
+
+function stableSearchParamsMatch(a: URLSearchParams, b: URLSearchParams): boolean {
+	const stableA = stableSearchParamEntries(a);
+	const stableB = stableSearchParamEntries(b);
+	if (stableA.length === 0 || stableB.length === 0) return false;
+	if (stableA.length !== stableB.length) return false;
+
+	return stableA.every((entry, index) => entry === stableB[index]);
+}
+
+function stableSearchParamEntries(searchParams: URLSearchParams): string[] {
+	return Array.from(searchParams.entries())
+		.filter(([key]) => !isVolatileMediaSearchParam(key))
+		.map(([key, value]) => `${key.toLowerCase()}=${value}`)
+		.sort();
+}
+
+function isVolatileMediaSearchParam(key: string): boolean {
+	const normalizedKey = key.toLowerCase();
+	return (
+		normalizedKey === "token" ||
+		normalizedKey === "access_token" ||
+		normalizedKey === "auth" ||
+		normalizedKey === "authorization" ||
+		normalizedKey === "signature" ||
+		normalizedKey === "sig" ||
+		normalizedKey === "expires" ||
+		normalizedKey === "expiry" ||
+		normalizedKey === "exp" ||
+		normalizedKey === "policy" ||
+		normalizedKey === "key-pair-id" ||
+		normalizedKey.startsWith("x-amz-")
+	);
 }

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -72,6 +72,33 @@ export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
 	return getMediaTypeFromPath(episode.streamUrl) ?? "audio";
 }
 
+export function isAudioContainerExtension(
+	extension?: string | null,
+): boolean {
+	if (!extension) return false;
+
+	const normalizedExtension = extension.toLowerCase();
+	return normalizedExtension === "mp4" || normalizedExtension === "webm";
+}
+
+export function getEpisodeMediaTypeWithAudioContainerHint(
+	episode: Episode,
+	mediaTypeHint?: EpisodeMediaType,
+): EpisodeMediaType {
+	if (episode.mediaType) return episode.mediaType;
+
+	const filePath = (episode as Partial<LocalEpisode>).filePath;
+	const fileExtension = filePath ? getUrlExtension(filePath) : null;
+	if (
+		mediaTypeHint === "audio" &&
+		isAudioContainerExtension(fileExtension)
+	) {
+		return "audio";
+	}
+
+	return getEpisodeMediaType(episode);
+}
+
 export function isSameMediaSource(a: string, b: string): boolean {
 	if (a === b) return true;
 	if (!a || !b) return false;

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -63,20 +63,11 @@ export function getMediaTypeFromPath(
 }
 
 export function getEpisodeMediaType(episode: Episode): EpisodeMediaType {
+	if (episode.mediaType) return episode.mediaType;
+
 	const filePath = (episode as Partial<LocalEpisode>).filePath;
 	const filePathMediaType = getMediaTypeFromPath(filePath);
-	if (
-		filePathMediaType &&
-		!(
-			episode.mediaType === "audio" &&
-			filePath &&
-			getUrlExtension(filePath).toLowerCase() === "mp4"
-		)
-	) {
-		return filePathMediaType;
-	}
-
-	if (episode.mediaType) return episode.mediaType;
+	if (filePathMediaType) return filePathMediaType;
 
 	return getMediaTypeFromPath(episode.streamUrl) ?? "audio";
 }

--- a/src/utility/mediaType.ts
+++ b/src/utility/mediaType.ts
@@ -117,22 +117,25 @@ export function isSameMediaSource(a: string, b: string): boolean {
 			return false;
 		}
 
+		if (ua.search === ub.search) return true;
+
+		const stableA = stableSearchParamEntries(ua.searchParams);
+		const stableB = stableSearchParamEntries(ub.searchParams);
+		if (stableSearchParamEntriesMatch(stableA, stableB)) return true;
+
 		const pathIdentifiesMedia =
 			getMediaTypeFromPath(ua.pathname) !== null ||
 			getMediaTypeFromPath(ub.pathname) !== null;
-		return (
-			pathIdentifiesMedia ||
-			ua.search === ub.search ||
-			stableSearchParamsMatch(ua.searchParams, ub.searchParams)
-		);
+		return pathIdentifiesMedia && stableA.length === 0 && stableB.length === 0;
 	} catch {
 		return false;
 	}
 }
 
-function stableSearchParamsMatch(a: URLSearchParams, b: URLSearchParams): boolean {
-	const stableA = stableSearchParamEntries(a);
-	const stableB = stableSearchParamEntries(b);
+function stableSearchParamEntriesMatch(
+	stableA: string[],
+	stableB: string[],
+): boolean {
 	if (stableA.length === 0 || stableB.length === 0) return false;
 	if (stableA.length !== stableB.length) return false;
 

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -14,6 +14,8 @@ export class TFile {
 
 export class Notice {
 	constructor(public message?: string) {}
+
+	hide(): void {}
 }
 
 export class WorkspaceLeaf {}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -179,6 +179,53 @@ if (!(HTMLElement.prototype as unknown as { setText?: (text: string) => void }).
 		};
 }
 
+type ObsidianDomContainer = HTMLElement | DocumentFragment;
+type CreateElOptions = { text?: string; cls?: string };
+
+function installCreateEl(proto: object): void {
+	const helpers = proto as {
+		createEl?: (
+			tag: keyof HTMLElementTagNameMap,
+			options?: CreateElOptions,
+		) => HTMLElement;
+		createDiv?: (options?: CreateElOptions) => HTMLDivElement;
+	};
+
+	if (!helpers.createEl) {
+		helpers.createEl = function (
+			this: ObsidianDomContainer,
+			tag: keyof HTMLElementTagNameMap,
+			options: CreateElOptions = {},
+		) {
+			const el = document.createElement(tag);
+			if (options.text !== undefined) el.textContent = options.text;
+			if (options.cls) el.className = options.cls;
+			this.appendChild(el);
+			return el;
+		};
+	}
+
+	if (!helpers.createDiv) {
+		helpers.createDiv = function (
+			this: ObsidianDomContainer,
+			options: CreateElOptions = {},
+		) {
+			const createEl = (
+				this as ObsidianDomContainer & {
+					createEl: (
+						tag: keyof HTMLElementTagNameMap,
+						options?: CreateElOptions,
+					) => HTMLElement;
+				}
+			).createEl;
+			return createEl.call(this, "div", options) as HTMLDivElement;
+		};
+	}
+}
+
+installCreateEl(HTMLElement.prototype);
+installCreateEl(DocumentFragment.prototype);
+
 if (!(HTMLElement.prototype as unknown as { empty?: () => void }).empty) {
 	(HTMLElement.prototype as unknown as { empty: () => void }).empty =
 		function (this: HTMLElement) {


### PR DESCRIPTION
## Summary
- Adds video episode playback with a `<video>` media element for direct video enclosures and local vault video files while keeping the existing PodNotes controls, timestamps, playback-rate, volume, queue, and progress persistence behavior.
- Infers audio/video media type from RSS enclosure MIME type, URL/file extensions, downloaded/local file paths, and invalidates the feed cache schema so stale cached feed episodes are reparsed.
- Keeps transcription audio-only, including stale downloaded/local records, and avoids reusing downloaded media for extensionless URLs when query strings identify different content.

Boundary: this supports direct playable media files (`video/*` enclosures and local `.mp4/.m4v/.mov/.webm/.ogv` files). It does not embed third-party video players such as YouTube/iframe pages.

Fixes #78

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run check:a11y`
- `npm run test` (57 files, 621 tests)
- `PATH="/tmp/podnotes-mkdocs-venv/bin:$PATH" npm run docs:build`

## Obsidian runtime validation
Isolated worktree vault only: `podnotes-codex-78-video` via `npm run obsidian:e2e -- ...`.

Runtime: Obsidian 1.12.7 (Electron 39.8.3), macOS/darwin, PodNotes 2.16.0.

Validated in the real rendered Obsidian app:
- Local vault video file through the PodNotes file-menu path rendered `VIDEO`, no `audio`, `mediaType: "video"`, file path `__issue78__/last-local-video.mp4`, and persisted playback time `42`.
- RSS feed with `video/mp4` enclosure from a local test feed rendered `VIDEO`, no `audio`, source `http://127.0.0.1:17878/remote-video.mp4`, `mediaType: "video"`, and persisted playback time `37`.
- `npm run obsidian:e2e -- dev:errors` reported `No errors captured` after validation.

## Review notes
Adversarial review findings were triaged and fixed:
- stale local/downloaded `.mp4` records cannot bypass the audio-only transcription path;
- extensionless source URLs require exact query matches before a downloaded vault resource is reused.
