### PR TITLE
feat(api): expose generated episode transcripts

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -2,6 +2,7 @@
 ```js
 export interface IAPI {
 	readonly podcast: Episode;
+	readonly transcript: Promise<string | null>;
 	readonly isPlaying: boolean;
 	readonly length: number;
 	currentTime: number;
@@ -19,6 +20,7 @@ export interface IAPI {
 		endTime: number,
 		linkify?: boolean,
 	): string;
+	getTranscript(episode?: Episode): Promise<string | null>;
 	start(): void;
 	stop(): void;
 	togglePlayback(): void;
@@ -47,6 +49,57 @@ export interface Episode {
 	artworkUrl?: string;
 	episodeDate?: Date;
 }
+```
+
+## `transcript`
+This is a convenience getter for `getTranscript()`:
+
+```js
+const transcript = await app.plugins.plugins.podnotes.api.transcript;
+```
+
+It returns the generated transcript note for the current episode, or `null` if no
+episode is loaded or no transcript file exists yet. It does not call OpenAI or
+create a new transcript. Generate the transcript first with PodNotes' **Transcribe
+current episode** command.
+
+If your transcript template includes metadata such as the title and date, that
+metadata is included in the returned text. Set the transcript template to
+`{{transcript}}` if your macro should receive only the transcript body.
+
+## `getTranscript(episode?: Episode)`
+This reads the generated transcript note for the provided episode. If no episode
+is provided, it reads the current episode's transcript.
+
+```js
+const api = app.plugins.plugins.podnotes.api;
+const transcript = await api.getTranscript();
+```
+
+### QuickAdd AI prompt example
+PodNotes exposes the transcript text; the AI summarization is done by your
+QuickAdd macro or whichever AI service/plugin your macro calls.
+
+```js
+module.exports = async (params) => {
+	const podnotes = params.app.plugins.plugins.podnotes?.api;
+	if (!podnotes) throw new Error("PodNotes is not enabled.");
+
+	const transcript = await podnotes.transcript;
+	if (!transcript) {
+		throw new Error(
+			"Generate a transcript for the current PodNotes episode first.",
+		);
+	}
+
+	const prompt = `Summarize this podcast transcript in five bullet points.
+
+Transcript:
+${transcript}`;
+
+	// Send `prompt` to the AI action/provider used by your QuickAdd macro.
+	return prompt;
+};
 ```
 
 ## `getPodcastTimeFormatted(format: string, linkify?: boolean)`

--- a/docs/docs/transcripts.md
+++ b/docs/docs/transcripts.md
@@ -21,9 +21,13 @@ To create a transcript:
 3. PodNotes will fetch the audio for the episode you are playing (reusing an already-downloaded copy when one exists), split it into chunks, and send these chunks to OpenAI for transcription. The transcription always uses the currently playing episode's own audio, regardless of your download path settings.
 4. Once the transcription is complete, a new file will be created at the specified location with the transcribed content.
 
+Generated transcript notes are also available to workflow plugins through the
+[PodNotes API](./api.md#transcript), so tools such as QuickAdd or Templater can
+read the text and send it to the AI provider configured in your own macro.
+
 ## Transcript Template
 
-The transcript template works similarly to the [note template](./templates.md#note-template), but with the added `{{template}}` placeholder.
+The transcript template works similarly to the [note template](./templates.md#note-template), but with the added `{{transcript}}` placeholder.
 
 ## Speaker Diarization
 

--- a/src/API/API.test.ts
+++ b/src/API/API.test.ts
@@ -1,5 +1,6 @@
+import { TFile } from "obsidian";
 import { get } from "svelte/store";
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { API } from "./API";
 import {
@@ -155,5 +156,88 @@ describe("API playback rate controls", () => {
 		api.resetPlaybackRate();
 
 		expect(api.playbackRate).toBe(1.8);
+	});
+});
+
+describe("API transcript access", () => {
+	function setTranscriptVault(files: Record<string, string>) {
+		const createTFile = (path: string): TFile =>
+			Object.assign(new TFile(), { path });
+		const getAbstractFileByPath = vi.fn((path: string) =>
+			Object.prototype.hasOwnProperty.call(files, path)
+				? createTFile(path)
+				: null,
+		);
+		const read = vi.fn(async (file: TFile) => files[file.path] ?? "");
+
+		plugin.set({
+			settings: {
+				defaultPlaybackRate: 1.8,
+				transcript: {
+					path: "Transcripts/{{podcast}}/{{title}}.md",
+				},
+			},
+			app: {
+				vault: {
+					getAbstractFileByPath,
+					read,
+				},
+			},
+		} as never);
+
+		return { getAbstractFileByPath, read };
+	}
+
+	test("returns null when no episode is loaded", async () => {
+		setTranscriptVault({});
+		const api = new API();
+
+		await expect(api.getTranscript()).resolves.toBeNull();
+	});
+
+	test("returns null when the current episode has no generated transcript file", async () => {
+		currentEpisode.set(feedEpisode);
+		const { getAbstractFileByPath, read } = setTranscriptVault({});
+		const api = new API();
+
+		await expect(api.getTranscript()).resolves.toBeNull();
+
+		expect(getAbstractFileByPath).toHaveBeenCalledWith(
+			"Transcripts/Feed Podcast/Feed Episode.md",
+		);
+		expect(read).not.toHaveBeenCalled();
+	});
+
+	test("reads the generated transcript note for the current episode", async () => {
+		currentEpisode.set(feedEpisode);
+		const transcript = "# Feed Episode\n\nTranscript body for AI macros.";
+		const { read } = setTranscriptVault({
+			"Transcripts/Feed Podcast/Feed Episode.md": transcript,
+		});
+		const api = new API();
+
+		await expect(api.getTranscript()).resolves.toBe(transcript);
+		await expect(api.transcript).resolves.toBe(transcript);
+
+		expect(read).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: "Transcripts/Feed Podcast/Feed Episode.md",
+			}),
+		);
+	});
+
+	test("reads the generated transcript note for an explicit episode", async () => {
+		currentEpisode.set(feedEpisode);
+		const transcript = "Local episode transcript";
+		const { getAbstractFileByPath } = setTranscriptVault({
+			"Transcripts/local file/Local Episode.md": transcript,
+		});
+		const api = new API();
+
+		await expect(api.getTranscript(localEpisode)).resolves.toBe(transcript);
+
+		expect(getAbstractFileByPath).toHaveBeenCalledWith(
+			"Transcripts/local file/Local Episode.md",
+		);
 	});
 });

--- a/src/API/API.ts
+++ b/src/API/API.ts
@@ -1,6 +1,7 @@
 import type { Episode } from "src/types/Episode";
 import { formatSeconds } from "src/utility/formatSeconds";
 import type { IAPI } from "./IAPI";
+import { TFile } from "obsidian";
 import {
 	currentEpisode,
 	currentTime,
@@ -24,6 +25,7 @@ import {
 	normalizePlaybackRate,
 	PLAYBACK_RATE_STEP,
 } from "src/utility/playbackRate";
+import { getEpisodeTranscriptPath } from "src/utility/getEpisodeTranscriptPath";
 
 const clampVolume = (value: number): number =>
 	Math.min(1, Math.max(0, value));
@@ -31,6 +33,10 @@ const clampVolume = (value: number): number =>
 export class API implements IAPI {
 	public get podcast(): Episode {
 		return get(currentEpisode);
+	}
+
+	public get transcript(): Promise<string | null> {
+		return this.getTranscript();
 	}
 
 	public get length(): number {
@@ -139,6 +145,26 @@ export class API implements IAPI {
 		);
 
 		return `[${segment}](${url.href})`;
+	}
+
+	async getTranscript(episode = this.podcast): Promise<string | null> {
+		if (!episode) {
+			return null;
+		}
+
+		const pluginInstance = get(plugin);
+		const transcriptPath = getEpisodeTranscriptPath(
+			episode,
+			pluginInstance.settings.transcript.path,
+		);
+		const transcriptFile =
+			pluginInstance.app.vault.getAbstractFileByPath(transcriptPath);
+
+		if (!(transcriptFile instanceof TFile)) {
+			return null;
+		}
+
+		return await pluginInstance.app.vault.read(transcriptFile);
 	}
 
 	private getEpisodeLinkTarget(): string | undefined {

--- a/src/API/IAPI.ts
+++ b/src/API/IAPI.ts
@@ -2,6 +2,7 @@ import type { Episode } from 'src/types/Episode';
 
 export interface IAPI {
 	readonly podcast: Episode;
+	readonly transcript: Promise<string | null>;
 	readonly isPlaying: boolean;
 	readonly length: number;
 	currentTime: number;
@@ -20,6 +21,8 @@ export interface IAPI {
 		endTime: number,
 		linkify?: boolean,
 	): string;
+
+	getTranscript(episode?: Episode): Promise<string | null>;
 	
 	start(): void;
 	stop(): void;

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -2,16 +2,10 @@ import { Notice, TFile } from "obsidian";
 import type { OpenAI } from "openai";
 import type PodNotes from "../main";
 import { getEpisodeAudioBuffer } from "../downloadEpisode";
-import {
-	FilePathTemplateEngine,
-	TranscriptTemplateEngine,
-} from "../TemplateEngine";
-import {
-	enforceMaxPathLength,
-	lastSegmentExtension,
-} from "../utility/enforceMaxPathLength";
+import { TranscriptTemplateEngine } from "../TemplateEngine";
 import { ensureFolderExists } from "../utility/ensureFolderExists";
 import type { Episode } from "src/types/Episode";
+import { getEpisodeTranscriptPath } from "src/utility/getEpisodeTranscriptPath";
 import {
 	type DiarizationAudio,
 	type DiarizationProviderId,
@@ -570,11 +564,10 @@ export class TranscriptionService {
 	 * the user's chosen suffix.
 	 */
 	private getTranscriptPath(episode: Episode): string {
-		const rendered = FilePathTemplateEngine(
-			this.plugin.settings.transcript.path,
+		return getEpisodeTranscriptPath(
 			episode,
+			this.plugin.settings.transcript.path,
 		);
-		return enforceMaxPathLength(rendered, lastSegmentExtension(rendered));
 	}
 
 	private async saveTranscription(

--- a/src/utility/getEpisodeTranscriptPath.ts
+++ b/src/utility/getEpisodeTranscriptPath.ts
@@ -1,0 +1,14 @@
+import { FilePathTemplateEngine } from "src/TemplateEngine";
+import type { Episode } from "src/types/Episode";
+import {
+	enforceMaxPathLength,
+	lastSegmentExtension,
+} from "src/utility/enforceMaxPathLength";
+
+export function getEpisodeTranscriptPath(
+	episode: Episode,
+	transcriptPathTemplate: string,
+): string {
+	const rendered = FilePathTemplateEngine(transcriptPathTemplate, episode);
+	return enforceMaxPathLength(rendered, lastSegmentExtension(rendered));
+}


### PR DESCRIPTION
Expose generated PodNotes transcript notes through the public plugin API so QuickAdd, Templater, and other workflow plugins can read transcript text from `app.plugins.plugins.podnotes.api`.

This adds `api.transcript` as a convenience async getter and `api.getTranscript(episode?)` for current or explicit episode lookup. Both read the already-generated transcript note using the same configured transcript path logic as the transcription writer; they do not trigger transcription, call OpenAI, or create new transcript files.

Docs now include a concrete QuickAdd-style macro example that builds an AI prompt from the PodNotes transcript. The transcript docs also clarify that the transcript template placeholder is `{{transcript}}`.

Validation performed:
- Real Obsidian isolated worktree vault: reproduced missing transcript API on current master-equivalent bundle; after implementation reloaded PodNotes and verified `api.transcript`, `api.getTranscript()`, and `api.getTranscript(explicitEpisode)` return the generated transcript note, with missing transcript returning `null` and `dev:errors` clean.
- `fnm exec --using 22 npm run lint`
- `fnm exec --using 22 npm run format:check`
- `fnm exec --using 22 npm run typecheck`
- `fnm exec --using 22 npm run build`
- `fnm exec --using 22 npm run test`
- `PATH=/tmp/podnotes-codex-105-mkdocs/bin:$PATH fnm exec --using 22 npm run docs:build`

Adversarial review covered correctness/runtime behavior, public API ergonomics, security/privacy/cost, and maintainability/test quality. Follow-up fixes added explicit-episode API test coverage and corrected the transcript placeholder docs.

Closes #105