### PR TITLE
feat: behavioral-audit UI and interaction fixes (front-end, 2/2)

### DIFF
--- a/src/iTunesAPIConsumer.ts
+++ b/src/iTunesAPIConsumer.ts
@@ -1,5 +1,5 @@
 import type { PodcastFeed } from "./types/PodcastFeed";
-import { requestWithTimeout, NetworkError } from "./utility/networkRequest";
+import { requestWithTimeout } from "./utility/networkRequest";
 
 interface iTunesResult {
 	collectionName: string;
@@ -30,9 +30,13 @@ export async function queryiTunesPodcasts(query: string): Promise<PodcastFeed[]>
 			collectionId: d.collectionId,
 		}));
 	} catch (error) {
-		if (error instanceof NetworkError) {
-			console.error(`iTunes search failed: ${error.message}`);
-		}
-		return [];
+		// Log every failure (including a malformed-JSON SyntaxError from
+		// response.json), not just NetworkError, so swallowed errors are
+		// diagnosable, then rethrow so the caller can distinguish a genuine
+		// failure from a legitimate empty result set (SA-01). Returning [] here
+		// collapsed both into the benign "No results." message.
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`iTunes search failed: ${message}`);
+		throw error instanceof Error ? error : new Error(message);
 	}
 }

--- a/src/ui/PodcastView/ChapterList.svelte
+++ b/src/ui/PodcastView/ChapterList.svelte
@@ -11,9 +11,16 @@
 
 	let isExpanded = true;
 
-	function getCurrentChapterIndex(): number {
-		for (let i = chapters.length - 1; i >= 0; i--) {
-			if (currentTime >= chapters[i].startTime) {
+	// Component-unique id so aria-controls on the header points at this
+	// instance's list even if multiple ChapterLists ever render.
+	const listId = "chapter-list-" + Math.random().toString(36).slice(2);
+
+	// Take the list/time as params so Svelte's reactive statement below tracks
+	// both as dependencies and recomputes the highlight as currentTime advances
+	// or the chapters are async-replaced.
+	function getCurrentChapterIndex(list: Chapter[], time: number): number {
+		for (let i = list.length - 1; i >= 0; i--) {
+			if (time >= list[i].startTime) {
 				return i;
 			}
 		}
@@ -24,7 +31,7 @@
 		dispatch("seek", { time: chapter.startTime });
 	}
 
-	$: currentChapterIndex = getCurrentChapterIndex();
+	$: currentChapterIndex = getCurrentChapterIndex(chapters, currentTime);
 </script>
 
 {#if chapters.length > 0}
@@ -34,18 +41,20 @@
 			class="chapter-header"
 			on:click={() => (isExpanded = !isExpanded)}
 			aria-expanded={isExpanded}
+			aria-controls={isExpanded ? listId : undefined}
 		>
 			<Icon icon={isExpanded ? "chevron-down" : "chevron-right"} size={16} />
 			<h3>Chapters ({chapters.length})</h3>
 		</button>
 
 		{#if isExpanded}
-			<ul class="chapters">
+			<ul class="chapters" id={listId}>
 				{#each chapters as chapter, index}
 					<li class:active={index === currentChapterIndex}>
 						<button
 							type="button"
 							class="chapter-item"
+							aria-label={`Jump to ${chapter.title}`}
 							on:click={() => handleChapterClick(chapter)}
 						>
 							<span class="chapter-time">{formatSeconds(chapter.startTime, "H:mm:ss")}</span>

--- a/src/ui/PodcastView/ChapterList.test.ts
+++ b/src/ui/PodcastView/ChapterList.test.ts
@@ -1,0 +1,93 @@
+import { fireEvent, render } from "@testing-library/svelte";
+import { describe, expect, test, vi } from "vitest";
+
+import type { Chapter } from "src/types/Chapter";
+import ChapterList from "./ChapterList.svelte";
+
+const chapters: Chapter[] = [
+	{ title: "Intro", startTime: 0 },
+	{ title: "Main topic", startTime: 60 },
+	{ title: "Wrap up", startTime: 120 },
+];
+
+function activeIndex(container: HTMLElement): number {
+	const items = Array.from(container.querySelectorAll(".chapters li"));
+	return items.findIndex((li) => li.classList.contains("active"));
+}
+
+describe("ChapterList", () => {
+	test("highlights the chapter containing the initial currentTime", () => {
+		const { container } = render(ChapterList, {
+			props: { chapters, currentTime: 75 },
+		});
+
+		expect(activeIndex(container)).toBe(1);
+	});
+
+	test("moves the highlight as currentTime advances (CH-05)", async () => {
+		const { container, rerender } = render(ChapterList, {
+			props: { chapters, currentTime: 10 },
+		});
+
+		expect(activeIndex(container)).toBe(0);
+
+		await rerender({ chapters, currentTime: 65 });
+		expect(activeIndex(container)).toBe(1);
+
+		await rerender({ chapters, currentTime: 130 });
+		expect(activeIndex(container)).toBe(2);
+	});
+
+	test("no chapter is active before the first chapter's startTime", () => {
+		const before: Chapter[] = [{ title: "Late start", startTime: 30 }];
+		const { container } = render(ChapterList, {
+			props: { chapters: before, currentTime: 10 },
+		});
+
+		expect(activeIndex(container)).toBe(-1);
+	});
+
+	test("clicking a chapter dispatches a seek and the highlight follows the resulting currentTime (CH-06)", async () => {
+		const seek = vi.fn();
+		const { container, rerender } = render(ChapterList, {
+			props: { chapters, currentTime: 0 },
+			events: { seek },
+		});
+
+		expect(activeIndex(container)).toBe(0);
+
+		const buttons = container.querySelectorAll(".chapter-item");
+		await fireEvent.click(buttons[2]);
+
+		expect(seek).toHaveBeenCalledTimes(1);
+		expect(seek.mock.calls[0][0].detail).toEqual({ time: 120 });
+
+		// The parent seeks; reflecting that back as currentTime must move the
+		// highlight onto the clicked chapter.
+		await rerender({ chapters, currentTime: 120 });
+		expect(activeIndex(container)).toBe(2);
+	});
+
+	test("exposes aria-controls / list id and per-chapter seek labels (CH-04)", () => {
+		const { container } = render(ChapterList, {
+			props: { chapters, currentTime: 0 },
+		});
+
+		const header = container.querySelector(
+			".chapter-header",
+		) as HTMLButtonElement;
+		const list = container.querySelector(".chapters") as HTMLUListElement;
+
+		expect(list.id).toBeTruthy();
+		expect(header.getAttribute("aria-controls")).toBe(list.id);
+
+		const labels = Array.from(container.querySelectorAll(".chapter-item")).map(
+			(b) => b.getAttribute("aria-label"),
+		);
+		expect(labels).toEqual([
+			"Jump to Intro",
+			"Jump to Main topic",
+			"Jump to Wrap up",
+		]);
+	});
+});

--- a/src/ui/PodcastView/EpisodeListItem.svelte
+++ b/src/ui/PodcastView/EpisodeListItem.svelte
@@ -2,6 +2,7 @@
 	import type { Episode } from "src/types/Episode";
 	import { createEventDispatcher } from "svelte";
 	import ImageLoader from "../common/ImageLoader.svelte";
+	import Icon from "../obsidian/Icon.svelte";
 
 	export let episode: Episode;
 	export let episodeFinished: boolean = false;
@@ -15,6 +16,7 @@
 		year: "numeric"
 	});
 	const formattedDateCache = new Map<string, string>();
+	let overflowEl: HTMLDivElement;
 
 	function onClickEpisode() {
 		dispatch("clickEpisode", { episode });
@@ -22,6 +24,20 @@
 
 	function onContextMenu(event: MouseEvent) {
 		dispatch("contextMenu", { episode, event });
+	}
+
+	// Open the same menu from the overflow button so it is reachable on mobile
+	// (tap) and via keyboard, where right-click is unavailable. Anchor the menu
+	// to the button's bounding box (the bound element, valid regardless of event
+	// timing) instead of a MouseEvent; spawnEpisodeContextMenu accepts an {x, y}
+	// position. Enter/Space activate the underlying <button> as a click.
+	function onOverflowClick() {
+		if (!overflowEl) return;
+		const rect = overflowEl.getBoundingClientRect();
+		dispatch("contextMenu", {
+			episode,
+			event: { x: rect.left, y: rect.bottom },
+		});
 	}
 
 	function parseEpisodeDate(rawDate?: Date | string): Date | null {
@@ -53,56 +69,73 @@
 	$: date = formatEpisodeDate(episode);
 </script>
 
-<button
-	type="button"
-	class="podcast-episode-item" 
-	on:click={onClickEpisode} 
-	on:contextmenu={onContextMenu}
-	title={unavailableReason ?? episode.title}
->
-	{#if showEpisodeImage && episode?.artworkUrl} 
-		<div class="podcast-episode-thumbnail-container">
-			<ImageLoader
-				src={episode.artworkUrl}
-				alt={episode.title}
-				fadeIn={true}
-				width="100%"
-				height="100%"
-				class="podcast-episode-thumbnail"
-			/>
-		</div>
-	{:else if showEpisodeImage}
-		<div class="podcast-episode-thumbnail-container"></div>
-	{/if}
-	<div class="podcast-episode-information">
-		<span class="episode-item-date">{date}</span>
-		<span class={`episode-item-title ${episodeFinished && "strikeout"}`}>{episode.title}</span>
-		{#if unavailableReason}
-			<span class="episode-item-status">{unavailableReason}</span>
+<div class="podcast-episode-row">
+	<button
+		type="button"
+		class="podcast-episode-item"
+		on:click={onClickEpisode}
+		on:contextmenu={onContextMenu}
+		title={unavailableReason ?? episode.title}
+	>
+		{#if showEpisodeImage && episode?.artworkUrl}
+			<div class="podcast-episode-thumbnail-container">
+				<ImageLoader
+					src={episode.artworkUrl}
+					alt={episode.title}
+					fadeIn={true}
+					width="100%"
+					height="100%"
+					class="podcast-episode-thumbnail"
+				/>
+			</div>
+		{:else if showEpisodeImage}
+			<div class="podcast-episode-thumbnail-container"></div>
 		{/if}
+		<div class="podcast-episode-information">
+			<span class="episode-item-date">{date}</span>
+			<span class={`episode-item-title ${episodeFinished && "strikeout"}`}>{episode.title}</span>
+			{#if unavailableReason}
+				<span class="episode-item-status">{unavailableReason}</span>
+			{/if}
+		</div>
+	</button>
+
+	<div class="podcast-episode-overflow" bind:this={overflowEl}>
+		<Icon
+			icon="more-vertical"
+			size={20}
+			label={`More options for ${episode.title}`}
+			on:click={onOverflowClick}
+		/>
 	</div>
-</button>
+</div>
 
 <style>
+	.podcast-episode-row {
+		position: relative;
+		display: flex;
+		align-items: stretch;
+		border-bottom: 1px solid var(--background-modifier-border);
+	}
+
+	.podcast-episode-row:last-child {
+		border-bottom: none;
+	}
+
 	.podcast-episode-item {
 		display: flex;
 		flex-direction: row;
 		justify-content: flex-start;
 		align-items: center;
-		padding: 0.625rem 0.75rem;
+		padding: 0.625rem 2.5rem 0.625rem 0.75rem;
 		min-height: 4.5rem;
 		width: 100%;
 		border: none;
-		border-bottom: 1px solid var(--background-modifier-border);
 		gap: 0.75rem;
 		background: transparent;
 		text-align: left;
 		cursor: pointer;
 		transition: background-color 120ms ease;
-	}
-
-	.podcast-episode-item:last-child {
-		border-bottom: none;
 	}
 
 	.podcast-episode-item:focus-visible {
@@ -117,6 +150,32 @@
 
 	.podcast-episode-item:active {
 		background-color: var(--background-modifier-border);
+	}
+
+	.podcast-episode-overflow {
+		position: absolute;
+		top: 50%;
+		right: 0.25rem;
+		transform: translateY(-50%);
+		display: flex;
+		align-items: center;
+	}
+
+	.podcast-episode-overflow :global(.icon-button) {
+		padding: 0.35rem;
+		border-radius: 0.375rem;
+		color: var(--text-muted);
+		transition: background-color 120ms ease, color 120ms ease;
+	}
+
+	.podcast-episode-overflow :global(.icon-button:hover) {
+		background-color: var(--background-modifier-hover);
+		color: var(--text-normal);
+	}
+
+	.podcast-episode-overflow :global(.icon-button:focus-visible) {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: -2px;
 	}
 
 	.strikeout {

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -107,17 +107,12 @@
 			return lists;
 		});
 
-		// Remove the finished episode from the queue by composite key too, so a
-		// same-titled episode from a DIFFERENT podcast that happens to be queued is
-		// not dropped as collateral (queue.remove matches title-only). The finished
-		// episode is usually already gone from the queue (subscribeQueueToCurrentEpisode
-		// drops it when it became current), so this is otherwise a no-op (PB-07).
-		queue.update((playlist) => {
-			playlist.episodes = playlist.episodes.filter(
-				(ep) => !episodeMatchesKey(ep, currentKey),
-			);
-			return playlist;
-		});
+		// The queue is title-identified everywhere (add/remove/dedupe by title; see
+		// src/store/index.ts), so remove the finished episode from it by title to
+		// stay consistent with that identity. The finished episode is usually already
+		// gone from the queue (subscribeQueueToCurrentEpisode drops it when it became
+		// current), so this is otherwise a no-op (PB-07 / Codex review #214).
+		queue.remove($currentEpisode);
 	}
 
 	function onEpisodeEnded() {

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -31,7 +31,7 @@
 	import { ViewState } from "src/types/ViewState";
 	import { createMediaUrlObjectFromFilePath } from "src/utility/createMediaUrlObjectFromFilePath";
 	import Image from "../common/Image.svelte";
-	import { episodeMatchesKey, getEpisodeKey } from "src/utility/episodeKey";
+	import { episodeMatchesKey, getEpisodeKey, isSameStoredEpisode } from "src/utility/episodeKey";
 	import {
 		normalizePlaybackRate,
 		PLAYBACK_RATE_MAX,
@@ -93,14 +93,14 @@
 	}
 
 	function removeEpisodeFromPlaylists() {
-		// Match by composite key (podcastName::title) so a same-titled episode
-		// from another podcast is not removed, while legacy title-only entries
-		// still match (episodeMatchesKey handles both).
-		const currentKey = getEpisodeKey($currentEpisode);
+		// Match by composite identity so a same-titled episode from another podcast
+		// is not removed, while a LEGACY entry saved without podcastName still
+		// matches by title (isSameStoredEpisode handles both — plain composite-key
+		// matching would skip those legacy entries on finish).
 		playlists.update((lists) => {
 			Object.values(lists).forEach((playlist) => {
 				playlist.episodes = playlist.episodes.filter(
-					(ep) => !episodeMatchesKey(ep, currentKey)
+					(ep) => !isSameStoredEpisode(ep, $currentEpisode)
 				);
 			});
 

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -93,17 +93,31 @@
 	}
 
 	function removeEpisodeFromPlaylists() {
+		// Match by composite key (podcastName::title) so a same-titled episode
+		// from another podcast is not removed, while legacy title-only entries
+		// still match (episodeMatchesKey handles both).
+		const currentKey = getEpisodeKey($currentEpisode);
 		playlists.update((lists) => {
 			Object.values(lists).forEach((playlist) => {
 				playlist.episodes = playlist.episodes.filter(
-					(ep) => ep.title !== $currentEpisode.title
+					(ep) => !episodeMatchesKey(ep, currentKey)
 				);
 			});
 
 			return lists;
 		});
 
-		queue.remove($currentEpisode);
+		// Remove the finished episode from the queue by composite key too, so a
+		// same-titled episode from a DIFFERENT podcast that happens to be queued is
+		// not dropped as collateral (queue.remove matches title-only). The finished
+		// episode is usually already gone from the queue (subscribeQueueToCurrentEpisode
+		// drops it when it became current), so this is otherwise a no-op (PB-07).
+		queue.update((playlist) => {
+			playlist.episodes = playlist.episodes.filter(
+				(ep) => !episodeMatchesKey(ep, currentKey),
+			);
+			return playlist;
+		});
 	}
 
 	function onEpisodeEnded() {
@@ -138,6 +152,29 @@
 
 	function onChapterSeek(event: CustomEvent<{ time: number }>) {
 		seekPlaybackTo(event.detail.time);
+	}
+
+	function enterFullscreen() {
+		// Prefer fullscreening the container so the custom overlay/controls stay
+		// usable; fall back to the bare <video> element on iOS Safari/WKWebView,
+		// where requestFullscreen on a div is unsupported and only the media
+		// element itself can go fullscreen.
+		const container = mediaElement?.closest(
+			".episode-video-container",
+		) as HTMLElement | null;
+		if (container?.requestFullscreen) {
+			void container.requestFullscreen();
+			return;
+		}
+
+		const video = mediaElement as
+			| (HTMLMediaElement & { webkitEnterFullscreen?: () => void })
+			| null;
+		if (video?.requestFullscreen) {
+			void video.requestFullscreen();
+		} else if (video?.webkitEnterFullscreen) {
+			video.webkitEnterFullscreen();
+		}
 	}
 
 	function seekPlaybackTo(time: number) {
@@ -197,8 +234,19 @@
 	) {
 		const key = getEpisodeKey(currentEp);
 
-		// Check composite key first, then fallback to title-only for backwards compat
-		const playedData = (key && playedEps[key]) || playedEps[currentEp.title];
+		// Check composite key first, then fall back to the title-only key for
+		// backwards compat — but only accept the legacy title-only entry when its
+		// stored podcastName is absent or matches the current episode, so a
+		// same-titled episode from another podcast can't resume at the wrong
+		// position (mirrors isSamePlayedEpisode's alias logic).
+		const titleOnlyData = playedEps[currentEp.title];
+		const titleOnlyMatches =
+			!!titleOnlyData &&
+			(!titleOnlyData.podcastName ||
+				!currentEp.podcastName ||
+				titleOnlyData.podcastName === currentEp.podcastName);
+		const playedData =
+			(key && playedEps[key]) || (titleOnlyMatches ? titleOnlyData : undefined);
 
 		if (playedData?.time) {
 			currentTime.set(playedData.time);
@@ -322,12 +370,19 @@
 			}
 			hasSeenFirstEpisodeFire = true;
 
-			// Fetch chapters when episode changes
+			// Fetch chapters when episode changes. Clear the previous episode's
+			// chapters immediately so they never flash against the incoming
+			// episode while the new fetch is in flight, and drop superseded /
+			// out-of-order fetch results by checking the request is still latest.
 			const chaptersUrl = episode?.chaptersUrl;
 			if (chaptersUrl && chaptersUrl !== lastChaptersUrl) {
 				lastChaptersUrl = chaptersUrl;
-				fetchChapters(chaptersUrl).then((c) => {
-					chapters = c;
+				chapters = [];
+				const requestedUrl = chaptersUrl;
+				fetchChapters(requestedUrl).then((c) => {
+					if (requestedUrl === lastChaptersUrl) {
+						chapters = c;
+					}
 				});
 			} else if (!chaptersUrl) {
 				lastChaptersUrl = undefined;
@@ -487,6 +542,15 @@
 					<Icon icon={$isPaused ? "play" : "pause"} clickable={false} />
 				</button>
 			{/if}
+
+			<button
+				type="button"
+				class="podcast-video-fullscreen"
+				on:click={enterFullscreen}
+				aria-label="Enter fullscreen"
+			>
+				<Icon icon="maximize" clickable={false} />
+			</button>
 		</div>
 	{:else}
 		<div class="episode-image-container">
@@ -549,10 +613,12 @@
 
 	<div class="status-container">
 		<span>{formatSeconds($currentTime, "HH:mm:ss")}</span>
-		<Progressbar 
+		<Progressbar
 			on:click={onClickProgressbar}
 			value={$currentTime}
 			max={$duration}
+			ariaLabel="Seek within episode"
+			valueText={`${formatSeconds($currentTime, "HH:mm:ss")} of ${formatSeconds($duration, "HH:mm:ss")}`}
 		/>
 		<span>{formatSeconds($duration - $currentTime, "HH:mm:ss")}</span>
 	</div>
@@ -734,6 +800,37 @@
 	.podcast-video-overlay:focus-visible {
 		outline: 2px solid var(--background-modifier-border-focus);
 		outline-offset: -4px;
+	}
+
+	.podcast-video-fullscreen {
+		position: absolute;
+		right: 0.5rem;
+		bottom: 0.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.35rem;
+		border: none;
+		border-radius: 0.375rem;
+		background: rgba(0, 0, 0, 0.45);
+		color: var(--text-on-accent);
+		cursor: pointer;
+		opacity: 0;
+		transition: opacity 200ms ease, background-color 120ms ease;
+	}
+
+	.episode-video-container:hover .podcast-video-fullscreen,
+	.podcast-video-fullscreen:focus-visible {
+		opacity: 1;
+	}
+
+	.podcast-video-fullscreen:hover {
+		background: rgba(0, 0, 0, 0.65);
+	}
+
+	.podcast-video-fullscreen:focus-visible {
+		outline: 2px solid var(--background-modifier-border-focus);
+		outline-offset: 2px;
 	}
 
 	.podcast-artwork-isloading-overlay {

--- a/src/ui/PodcastView/EpisodePlayer.test.ts
+++ b/src/ui/PodcastView/EpisodePlayer.test.ts
@@ -12,7 +12,9 @@ import {
 	activePlaybackSegment,
 	playbackRate,
 	playedEpisodes,
+	playlists,
 	plugin,
+	queue,
 	requestedPlaybackTime,
 } from "src/store";
 import type { Episode } from "src/types/Episode";
@@ -38,6 +40,14 @@ beforeEach(() => {
 	playedEpisodes.set({});
 	requestedPlaybackTime.set(null);
 	downloadedEpisodes.set({});
+	playlists.set({});
+	queue.set({
+		icon: "list-ordered",
+		name: "Queue",
+		episodes: [],
+		shouldEpisodeRemoveAfterPlay: false,
+		shouldRepeat: false,
+	});
 	HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
 	HTMLMediaElement.prototype.pause = vi.fn();
 	plugin.set({
@@ -223,6 +233,37 @@ describe("EpisodePlayer", () => {
 		expect(get(playedEpisodes)[episodeKey]).toBeUndefined();
 	});
 
+	test("on episode end only removes the matching episode from playlists, keeping same-titled episodes from other podcasts (PB-07)", async () => {
+		const otherPodcastSameTitle: Episode = {
+			...testEpisode,
+			podcastName: "Other Podcast",
+			streamUrl: "https://other.example.com/audio.mp3",
+		};
+		playlists.set({
+			"My List": {
+				icon: "list-ordered",
+				name: "My List",
+				episodes: [testEpisode, otherPodcastSameTitle],
+				shouldEpisodeRemoveAfterPlay: false,
+				shouldRepeat: false,
+			},
+		});
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+		await fireEvent.loadedMetadata(audio);
+
+		currentTime.set(3600);
+		await fireEvent.ended(audio);
+
+		const remaining = get(playlists)["My List"].episodes;
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0].podcastName).toBe("Other Podcast");
+	});
+
 	test("ignores stale requested timestamp for a different episode", async () => {
 		playedEpisodes.setEpisodeTime(testEpisode, 1800, 3600, false);
 		requestedPlaybackTime.set({
@@ -241,6 +282,52 @@ describe("EpisodePlayer", () => {
 		expect(get(currentTime)).toBe(1800);
 		expect(get(isPaused)).toBe(false);
 		expect(get(requestedPlaybackTime)).toBeNull();
+	});
+
+	test("does not restore a title-only saved position from a different podcast's same-titled episode (PB-06)", async () => {
+		// Legacy title-only entry that actually belongs to another podcast.
+		playedEpisodes.set({
+			[testEpisode.title]: {
+				title: testEpisode.title,
+				podcastName: "A Different Podcast",
+				time: 1800,
+				duration: 3600,
+				finished: false,
+			},
+		});
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+		await fireEvent.loadedMetadata(audio);
+
+		// The current episode is "Test Podcast" — the other podcast's saved
+		// position must be ignored, resuming from 0 instead of 1800.
+		expect(get(currentTime)).toBe(0);
+	});
+
+	test("restores a legacy title-only saved position for the same episode (PB-06)", async () => {
+		// Legacy entry with no podcastName recorded — must still resume.
+		playedEpisodes.set({
+			[testEpisode.title]: {
+				title: testEpisode.title,
+				podcastName: "",
+				time: 900,
+				duration: 3600,
+				finished: false,
+			},
+		});
+
+		const { container } = render(EpisodePlayer);
+		await waitFor(() => {
+			expect(container.querySelector("audio")).not.toBeNull();
+		});
+		const audio = container.querySelector("audio") as HTMLAudioElement;
+		await fireEvent.loadedMetadata(audio);
+
+		expect(get(currentTime)).toBe(900);
 	});
 
 	test("keeps the audio element and slider label in sync with playbackRate store", async () => {

--- a/src/ui/PodcastView/PlaylistCard.svelte
+++ b/src/ui/PodcastView/PlaylistCard.svelte
@@ -17,10 +17,12 @@
 	type="button"
 	class="playlist-card"
 	aria-label={playlist.name}
+	title={playlist.name}
 	on:click={onClickPlaylist}
 >
-	<Icon icon={playlist.icon} size={40} clickable={false}/>
-	<span>
+	<Icon icon={playlist.icon} size={32} clickable={false}/>
+	<span class="playlist-card-name">{playlist.name}</span>
+	<span class="playlist-card-count">
 		({playlist.episodes.length})
 	</span>
 </button>
@@ -35,6 +37,9 @@
 		width: 100%;
 		min-height: 5rem;
 		padding: 0.75rem 0.5rem;
+		/* `min-height` is a floor, not a cap: the card must grow to fit icon +
+		   name + count. The grid uses min-content rows, so the row grows with it. */
+		height: auto;
 		border: 1px solid var(--background-modifier-border);
 		border-radius: 0.5rem;
 		text-align: center;
@@ -54,8 +59,31 @@
 		transform: scale(0.98);
 	}
 
-	.playlist-card span {
+	/* Keep the icon, name, and count at their natural height so flexbox never
+	   compresses/clips a label to fit the min-height (the bug where the name
+	   overlapped the count). The card grows instead. */
+	.playlist-card-name,
+	.playlist-card-count {
+		flex-shrink: 0;
+	}
+
+	.playlist-card :global(.icon-static) {
+		flex-shrink: 0;
+	}
+
+	.playlist-card-name {
+		max-width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-size: 0.85rem;
+		line-height: 1.3;
+		color: var(--text-normal);
+	}
+
+	.playlist-card-count {
 		font-size: 0.8rem;
+		line-height: 1.3;
 		color: var(--text-muted);
 	}
 </style>

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -63,10 +63,15 @@
 	});
 
 	$: loadingFeedNames = Array.from(loadingFeeds);
+	// Exclude the selected feed from the banner: its loading state is already
+	// shown by the inline EpisodeList spinner, so the banner would duplicate it.
+	$: bannerFeedNames = loadingFeedNames.filter(
+		(name) => name !== selectedFeed?.title,
+	);
 	$: loadingFeedSummary =
-		loadingFeedNames.length > 3
-			? `${loadingFeedNames.slice(0, 3).join(", ")} +${loadingFeedNames.length - 3} more`
-			: loadingFeedNames.join(", ");
+		bannerFeedNames.length > 3
+			? `${bannerFeedNames.slice(0, 3).join(", ")} +${bannerFeedNames.length - 3} more`
+			: bannerFeedNames.join(", ");
 	$: isFetchingEpisodes = loadingFeedNames.length > 0;
 
 	onMount(() => {
@@ -89,11 +94,19 @@
 			];
 		};
 
+		// Refresh both the grid tiles AND an open playlist's episode list so a
+		// context-menu add/remove updates the currently-viewed list immediately
+		// (PL-04).
+		const refreshPlaylists = () => {
+			updateDisplayedPlaylists();
+			updateDisplayedPlaylistEpisodesIfSelected();
+		};
+
 		const playlistUnsubscribers = [
-			playlists.subscribe(updateDisplayedPlaylists),
+			playlists.subscribe(refreshPlaylists),
 			queue.subscribe(updateDisplayedPlaylists),
-			favorites.subscribe(updateDisplayedPlaylists),
-			localFiles.subscribe(updateDisplayedPlaylists),
+			favorites.subscribe(refreshPlaylists),
+			localFiles.subscribe(refreshPlaylists),
 			// Recompute when the plugin store re-emits so toggling the autoQueue
 			// setting hides/shows the empty Queue tile immediately (issue #108).
 			plugin.subscribe(updateDisplayedPlaylists),
@@ -179,6 +192,7 @@
 	async function fetchEpisodes(
 		feed: PodcastFeed,
 		useCache: boolean = true,
+		notifyOnError: boolean = false,
 	): Promise<Episode[]> {
 		const cacheEnabled = isFeedCacheEnabled();
 		const cacheTtlMs = getFeedCacheTtlMs();
@@ -247,6 +261,15 @@
 				}
 			}
 
+			// No cache/download fallback recovered episodes. Surface a Notice
+			// only for the interactive single-feed path; the bulk/background
+			// path stays quiet to avoid spamming on refresh or initial load.
+			if (notifyOnError) {
+				new Notice(
+					`Could not load episodes for ${feed.title}. Check your connection and try again.`,
+				);
+			}
+
 			return [];
 		}
 	}
@@ -261,7 +284,10 @@
 		return feeds.filter((feed) => playedPodcastNames.has(feed.title));
 	}
 
-	async function fetchFullEpisodes(feed: PodcastFeed): Promise<Episode[]> {
+	async function fetchFullEpisodes(
+		feed: PodcastFeed,
+		notifyOnError: boolean = false,
+	): Promise<Episode[]> {
 		const cacheEnabled = isFeedCacheEnabled();
 		const persistedEpisodes = cacheEnabled
 			? getCachedEpisodes(feed, getFeedCacheTtlMs())
@@ -272,22 +298,23 @@
 			return inMemoryEpisodes;
 		}
 
-		return fetchEpisodes(feed, false);
+		return fetchEpisodes(feed, false, notifyOnError);
 	}
 
 	async function fetchEpisodesByStrategy(
 		feed: PodcastFeed,
 		strategy: EpisodeFetchStrategy = "cached",
+		notifyOnError: boolean = false,
 	): Promise<Episode[]> {
 		if (strategy === "network") {
-			return fetchEpisodes(feed, false);
+			return fetchEpisodes(feed, false, notifyOnError);
 		}
 
 		if (strategy === "full") {
-			return fetchFullEpisodes(feed);
+			return fetchFullEpisodes(feed, notifyOnError);
 		}
 
-		return fetchEpisodes(feed, true);
+		return fetchEpisodes(feed, true, notifyOnError);
 	}
 
 	function getPlayedPlaylist(): Playlist {
@@ -361,6 +388,37 @@
 		updateDisplayedPlayedEpisodes();
 	}
 
+	// Keep an OPEN playlist's episode list in sync when its backing store changes
+	// (e.g. a context-menu add/remove). Without this the list view only reflected
+	// the snapshot taken at click time and went stale until the user navigated
+	// away and back (PL-04). The virtual Played list and the Queue (which routes
+	// to the player) are handled elsewhere, so they are skipped here.
+	function updateDisplayedPlaylistEpisodesIfSelected() {
+		if (!selectedPlaylist || selectedPlaylist.isVirtual) return;
+
+		const name = selectedPlaylist.name;
+		if (name === get(queue).name) return;
+
+		let live: Playlist | undefined;
+		if (name === get(favorites).name) live = get(favorites);
+		else if (name === get(localFiles).name) live = get(localFiles);
+		else {
+			live = get(playlists)[name];
+			if (!live) {
+				// A custom playlist deleted while open: fall back to Latest Episodes.
+				showLatestEpisodes();
+				return;
+			}
+		}
+
+		if (!live) return;
+
+		selectedPlaylist = live;
+		displayedEpisodes = currentSearchQuery
+			? searchEpisodes(currentSearchQuery, live.episodes)
+			: live.episodes;
+	}
+
 	function showLatestEpisodes() {
 		selectedFeed = null;
 		selectedPlaylist = null;
@@ -428,7 +486,7 @@
 		setFeedLoading(feed.title, true);
 
 		try {
-			const episodes = await fetchFullEpisodes(feed);
+			const episodes = await fetchFullEpisodes(feed, true);
 			displayedEpisodes = currentSearchQuery
 				? searchEpisodes(currentSearchQuery, episodes)
 				: episodes;
@@ -481,6 +539,15 @@
 			return;
 		}
 
+		// Latest Episodes view (no feed and no playlist selected): refresh all
+		// feeds over the network so the aggregated list actually updates. The
+		// latestEpisodes readable + its subscriber repopulate displayedEpisodes,
+		// and setFeedLoading inside fetchEpisodesInAllFeeds drives the banner.
+		if (!selectedFeed && !selectedPlaylist) {
+			await fetchEpisodesInAllFeeds(feeds, "network");
+			return;
+		}
+
 		if (!selectedFeed) return;
 
 		setFeedLoading(selectedFeed.title, true);
@@ -489,6 +556,7 @@
 			const episodes = await fetchEpisodesByStrategy(
 				selectedFeed,
 				"network",
+				true,
 			);
 			displayedEpisodeEntries = null;
 			displayedEpisodes = currentSearchQuery
@@ -582,14 +650,14 @@
 	{#if $viewState === ViewState.Player}
 		<EpisodePlayer />
 	{:else if $viewState === ViewState.EpisodeList}
-		{#if loadingFeedNames.length > 0}
+		{#if bannerFeedNames.length > 0}
 			<div class="feed-loading-banner">
 				<div class="feed-loading-spinner">
 					<Icon icon="loader-2" size={18} clickable={false} />
 				</div>
 				<div class="feed-loading-text">
 					<span>
-						Updating {loadingFeedNames.length} feed{loadingFeedNames.length === 1 ? "" : "s"}
+						Updating {bannerFeedNames.length} feed{bannerFeedNames.length === 1 ? "" : "s"}
 					</span>
 					{#if loadingFeedSummary}
 						<span class="feed-loading-names">{loadingFeedSummary}</span>

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.test.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.test.ts
@@ -1,0 +1,67 @@
+import { Menu } from "obsidian";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import spawnEpisodeContextMenu from "./spawnEpisodeContextMenu";
+import { playedEpisodes, playlists, queue } from "src/store";
+import type { Episode } from "src/types/Episode";
+
+const episode: Episode = {
+	title: "Episode",
+	streamUrl: "https://example.com/a.mp3",
+	url: "https://example.com/a",
+	description: "",
+	content: "",
+	podcastName: "Podcast",
+} as Episode;
+
+// Disable every menu section so the menu has no store/plugin dependencies and we
+// can assert purely on how it is anchored.
+const allDisabled = {
+	play: true,
+	markPlayed: true,
+	download: true,
+	createNote: true,
+	favorite: true,
+	queue: true,
+	playlists: true,
+};
+
+beforeEach(() => {
+	queue.set({
+		icon: "list-ordered",
+		name: "Queue",
+		episodes: [],
+		shouldEpisodeRemoveAfterPlay: true,
+		shouldRepeat: false,
+	});
+	playlists.set({});
+	playedEpisodes.set({});
+});
+
+describe("spawnEpisodeContextMenu anchoring (CM-general)", () => {
+	test("opens at the mouse position for a MouseEvent anchor (right-click)", () => {
+		const atMouse = vi.spyOn(Menu.prototype, "showAtMouseEvent");
+		const atPos = vi.spyOn(Menu.prototype, "showAtPosition");
+
+		spawnEpisodeContextMenu(episode, new MouseEvent("contextmenu"), allDisabled);
+
+		expect(atMouse).toHaveBeenCalledTimes(1);
+		expect(atPos).not.toHaveBeenCalled();
+
+		atMouse.mockRestore();
+		atPos.mockRestore();
+	});
+
+	test("opens at an explicit {x,y} for the keyboard/mobile kebab affordance", () => {
+		const atMouse = vi.spyOn(Menu.prototype, "showAtMouseEvent");
+		const atPos = vi.spyOn(Menu.prototype, "showAtPosition");
+
+		spawnEpisodeContextMenu(episode, { x: 12, y: 34 }, allDisabled);
+
+		expect(atPos).toHaveBeenCalledWith({ x: 12, y: 34 });
+		expect(atMouse).not.toHaveBeenCalled();
+
+		atMouse.mockRestore();
+		atPos.mockRestore();
+	});
+});

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.ts
@@ -164,7 +164,14 @@ export default function spawnEpisodeContextMenu(
 	}
 
 	if (!disabledMenuItems?.queue) {
-		const episodeIsInQueue = get(queue).episodes.find(e => episodeMatchesKey(e, episodeKey));
+		// The queue identifies episodes by TITLE everywhere (queue.add dedupes and
+		// queue.remove filters by title; see src/store/index.ts), so this membership
+		// check and the reorder lookup below must match by title too. A composite-key
+		// check would offer "Add to Queue" for a same-titled episode from another
+		// podcast, but queue.add would then no-op (Codex review #214).
+		const episodeIsInQueue = get(queue).episodes.find(
+			(e) => e.title === episode.title,
+		);
 		menu.addItem(item => item
 			.setIcon("list-ordered")
 			.setTitle(`${episodeIsInQueue ? "Remove from" : "Add to"} Queue`)
@@ -197,7 +204,7 @@ export default function spawnEpisodeContextMenu(
 						// episode ends and playNext advances it) between opening
 						// the menu and clicking.
 						const index = get(queue).episodes.findIndex(
-							e => episodeMatchesKey(e, episodeKey),
+							(e) => e.title === episode.title,
 						);
 						if (index === -1) return;
 

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.ts
@@ -10,6 +10,7 @@ import type { PodcastFeed } from "src/types/PodcastFeed";
 import { ViewState } from "src/types/ViewState";
 import { get } from "svelte/store";
 import { isEpisodeFinished } from "src/utility/episodeStatus";
+import { episodeMatchesKey, getEpisodeKey } from "src/utility/episodeKey";
 import { buildQueueReorderMenuItems } from "./queueReorderMenu";
 
 interface DisabledMenuItems {
@@ -22,13 +23,23 @@ interface DisabledMenuItems {
 	playlists: boolean;
 }
 
+/**
+ * A screen position to open the menu at. Used when there is no MouseEvent to
+ * anchor against (keyboard activation / mobile tap of the overflow button).
+ */
+export interface MenuPosition {
+	x: number;
+	y: number;
+}
+
 export default function spawnEpisodeContextMenu(
 	episode: Episode,
-	event: MouseEvent,
+	anchor: MouseEvent | MenuPosition,
 	disabledMenuItems?: Partial<DisabledMenuItems>,
 	playedEpisodeKey?: string,
 ) {
 	const menu = new Menu();
+	const episodeKey = getEpisodeKey(episode);
 
 	if (!disabledMenuItems?.play) {
 		menu.addItem(item => item
@@ -74,11 +85,14 @@ export default function spawnEpisodeContextMenu(
 				} else {
 					// The path template always yields a per-episode file via
 					// safeDownloadBasename (#183), so no empty-path guard is needed —
-					// this matches the Download command in main.ts.
-					downloadEpisodeWithProgessNotice(
+					// this matches the Download command in main.ts. Settle the
+					// promise so a failure can't surface as an unhandled rejection
+					// (the in-notice error is the user-facing message), matching the
+					// adjacent void removeDownloadedEpisode(...).
+					void downloadEpisodeWithProgessNotice(
 						episode,
 						get(plugin).settings.download.path,
-					);
+					).catch((e) => console.error("PodNotes: download failed", e));
 				}
 			}));
 	}
@@ -128,14 +142,14 @@ export default function spawnEpisodeContextMenu(
 	}
 
 	if (!disabledMenuItems?.favorite) {
-		const episodeIsFavorite = get(favorites).episodes.find(e => e.title === episode.title);
+		const episodeIsFavorite = get(favorites).episodes.find(e => episodeMatchesKey(e, episodeKey));
 		menu.addItem(item => item
 			.setIcon("lucide-star")
 			.setTitle(`${episodeIsFavorite ? "Remove from" : "Add to"} Favorites`)
 			.onClick(() => {
 				if (episodeIsFavorite) {
 					favorites.update(playlist => {
-						playlist.episodes = playlist.episodes.filter(e => e.title !== episode.title);
+						playlist.episodes = playlist.episodes.filter(e => !episodeMatchesKey(e, episodeKey));
 						return playlist;
 					});
 				} else {
@@ -150,7 +164,7 @@ export default function spawnEpisodeContextMenu(
 	}
 
 	if (!disabledMenuItems?.queue) {
-		const episodeIsInQueue = get(queue).episodes.find(e => e.title === episode.title);
+		const episodeIsInQueue = get(queue).episodes.find(e => episodeMatchesKey(e, episodeKey));
 		menu.addItem(item => item
 			.setIcon("list-ordered")
 			.setTitle(`${episodeIsInQueue ? "Remove from" : "Add to"} Queue`)
@@ -183,7 +197,7 @@ export default function spawnEpisodeContextMenu(
 						// episode ends and playNext advances it) between opening
 						// the menu and clicking.
 						const index = get(queue).episodes.findIndex(
-							e => e.title === episode.title,
+							e => episodeMatchesKey(e, episodeKey),
 						);
 						if (index === -1) return;
 
@@ -207,36 +221,46 @@ export default function spawnEpisodeContextMenu(
 	}
 
 	if (!disabledMenuItems?.playlists) {
-		menu.addSeparator();
-
 		const playlistsInStore = get(playlists);
-		for (const playlist of Object.values(playlistsInStore)) {
-			const episodeIsInPlaylist = playlist.episodes.find(e => e.title === episode.title);
+		const entries = Object.values(playlistsInStore);
 
-			menu.addItem(item => item
-				.setIcon(playlist.icon)
-				.setTitle(`${episodeIsInPlaylist ? "Remove from" : "Add to"} ${playlist.name}`)
-				.onClick(() => {
-					if (episodeIsInPlaylist) {
-						playlists.update(playlists => {
-							playlists[playlist.name].episodes = playlists[playlist.name].episodes.filter(e => e.title !== episode.title);
+		// Only emit the divider when there is at least one custom playlist to
+		// render, mirroring the reorder section's guard — otherwise a stray
+		// trailing separator is left at the bottom of the menu (CM-09).
+		if (entries.length > 0) {
+			menu.addSeparator();
 
-							return playlists;
-						});
-					} else {
-						playlists.update(playlists => {
-							const newEpisodes = [...playlists[playlist.name].episodes, episode];
-							playlists[playlist.name].episodes = newEpisodes;
+			for (const playlist of entries) {
+				const episodeIsInPlaylist = playlist.episodes.find(e => episodeMatchesKey(e, episodeKey));
 
-							return playlists;
-						});
-					}
-				}));
+				menu.addItem(item => item
+					.setIcon(playlist.icon)
+					.setTitle(`${episodeIsInPlaylist ? "Remove from" : "Add to"} ${playlist.name}`)
+					.onClick(() => {
+						if (episodeIsInPlaylist) {
+							playlists.update(playlists => {
+								playlists[playlist.name].episodes = playlists[playlist.name].episodes.filter(e => !episodeMatchesKey(e, episodeKey));
+
+								return playlists;
+							});
+						} else {
+							playlists.update(playlists => {
+								const newEpisodes = [...playlists[playlist.name].episodes, episode];
+								playlists[playlist.name].episodes = newEpisodes;
+
+								return playlists;
+							});
+						}
+					}));
+			}
 		}
 	}
 
-	menu.showAtMouseEvent(event);
-
+	if (anchor instanceof MouseEvent) {
+		menu.showAtMouseEvent(anchor);
+	} else {
+		menu.showAtPosition(anchor);
+	}
 }
 
 /**

--- a/src/ui/PodcastView/spawnEpisodeContextMenu.ts
+++ b/src/ui/PodcastView/spawnEpisodeContextMenu.ts
@@ -10,7 +10,7 @@ import type { PodcastFeed } from "src/types/PodcastFeed";
 import { ViewState } from "src/types/ViewState";
 import { get } from "svelte/store";
 import { isEpisodeFinished } from "src/utility/episodeStatus";
-import { episodeMatchesKey, getEpisodeKey } from "src/utility/episodeKey";
+import { isSameStoredEpisode } from "src/utility/episodeKey";
 import { buildQueueReorderMenuItems } from "./queueReorderMenu";
 
 interface DisabledMenuItems {
@@ -39,7 +39,6 @@ export default function spawnEpisodeContextMenu(
 	playedEpisodeKey?: string,
 ) {
 	const menu = new Menu();
-	const episodeKey = getEpisodeKey(episode);
 
 	if (!disabledMenuItems?.play) {
 		menu.addItem(item => item
@@ -142,14 +141,14 @@ export default function spawnEpisodeContextMenu(
 	}
 
 	if (!disabledMenuItems?.favorite) {
-		const episodeIsFavorite = get(favorites).episodes.find(e => episodeMatchesKey(e, episodeKey));
+		const episodeIsFavorite = get(favorites).episodes.find(e => isSameStoredEpisode(e, episode));
 		menu.addItem(item => item
 			.setIcon("lucide-star")
 			.setTitle(`${episodeIsFavorite ? "Remove from" : "Add to"} Favorites`)
 			.onClick(() => {
 				if (episodeIsFavorite) {
 					favorites.update(playlist => {
-						playlist.episodes = playlist.episodes.filter(e => !episodeMatchesKey(e, episodeKey));
+						playlist.episodes = playlist.episodes.filter(e => !isSameStoredEpisode(e, episode));
 						return playlist;
 					});
 				} else {
@@ -238,7 +237,7 @@ export default function spawnEpisodeContextMenu(
 			menu.addSeparator();
 
 			for (const playlist of entries) {
-				const episodeIsInPlaylist = playlist.episodes.find(e => episodeMatchesKey(e, episodeKey));
+				const episodeIsInPlaylist = playlist.episodes.find(e => isSameStoredEpisode(e, episode));
 
 				menu.addItem(item => item
 					.setIcon(playlist.icon)
@@ -246,7 +245,7 @@ export default function spawnEpisodeContextMenu(
 					.onClick(() => {
 						if (episodeIsInPlaylist) {
 							playlists.update(playlists => {
-								playlists[playlist.name].episodes = playlists[playlist.name].episodes.filter(e => !episodeMatchesKey(e, episodeKey));
+								playlists[playlist.name].episodes = playlists[playlist.name].episodes.filter(e => !isSameStoredEpisode(e, episode));
 
 								return playlists;
 							});

--- a/src/ui/ReorderQueue.svelte
+++ b/src/ui/ReorderQueue.svelte
@@ -62,35 +62,35 @@
 						<Icon
 							icon="chevrons-up"
 							label="Move to top"
-							size={18}
+							size={20}
 							disabled={index === 0}
 							on:click={() => moveToTop(episode)}
 						/>
 						<Icon
 							icon="chevron-up"
 							label="Move up"
-							size={18}
+							size={20}
 							disabled={index === 0}
 							on:click={() => moveUp(episode)}
 						/>
 						<Icon
 							icon="chevron-down"
 							label="Move down"
-							size={18}
+							size={20}
 							disabled={index === episodes.length - 1}
 							on:click={() => moveDown(episode)}
 						/>
 						<Icon
 							icon="chevrons-down"
 							label="Move to bottom"
-							size={18}
+							size={20}
 							disabled={index === episodes.length - 1}
 							on:click={() => moveToBottom(episode)}
 						/>
 						<Icon
 							icon="x"
 							label="Remove from queue"
-							size={18}
+							size={20}
 							on:click={() => removeFromQueue(episode)}
 						/>
 					</div>
@@ -173,8 +173,19 @@
 	.queue-reorder-actions {
 		display: flex;
 		align-items: center;
-		gap: 0.125rem;
+		gap: 0.375rem;
 		flex: 0 0 auto;
+	}
+
+	/*
+	 * This modal is the designated mobile reorder surface, so its move/remove
+	 * controls need a comfortable touch target. Scope the sizing to the modal's
+	 * own buttons so the shared Icon component stays untouched elsewhere.
+	 */
+	.queue-reorder-actions :global(.icon-button) {
+		min-width: 2.25rem;
+		min-height: 2.25rem;
+		padding: 0.25rem;
 	}
 
 	.queue-reorder-footer {

--- a/src/ui/common/Progressbar.svelte
+++ b/src/ui/common/Progressbar.svelte
@@ -5,6 +5,8 @@ import { createEventDispatcher } from "svelte";
 
 export let max: number;
 export let value: number;
+export let ariaLabel = "Seek";
+export let valueText: string | undefined = undefined;
 export { _styled as style };
 
 let isDragging: boolean = false;
@@ -76,9 +78,11 @@ function handleKeyDown(event: KeyboardEvent) {
 	class="progress"
 	role="slider"
 	tabindex="0"
+	aria-label={ariaLabel}
 	aria-valuemin="0"
 	aria-valuemax={max}
 	aria-valuenow={value}
+	aria-valuetext={valueText}
 	style={styles}
 	on:click={forwardClick}
 	on:mousedown={onDragStart}

--- a/src/ui/obsidian/Dropdown.svelte
+++ b/src/ui/obsidian/Dropdown.svelte
@@ -21,6 +21,19 @@
 		updateDropdownAttributes(dropdown);
 	});
 
+	// Keep the rendered dropdown in sync when `value` is changed from the
+	// outside (e.g. a parent resetting bind:value after Add). The guard avoids
+	// redundant DOM writes; setValue does not re-fire onChange.
+	$: if (dropdown && value !== undefined && getDropdownValue(dropdown) !== value) {
+		dropdown.setValue(value);
+	}
+
+	function getDropdownValue(component: DropdownComponent): string | undefined {
+		return typeof component.getValue === "function"
+			? component.getValue()
+			: component.selectEl?.value;
+	}
+
 	function updateDropdownAttributes(dropdown: DropdownComponent) {
 		if (options) dropdown.addOptions(options);
 		if (value) dropdown.setValue(value);

--- a/src/ui/settings/PlaylistItem.svelte
+++ b/src/ui/settings/PlaylistItem.svelte
@@ -9,6 +9,13 @@
 	let clickedDelete: boolean = false;
 	const dispatch = createEventDispatcher();
 
+	// Reset the delete-confirm state whenever the bound playlist changes so a
+	// store update can never leave an armed "Confirm deletion" pointing at a
+	// different playlist (defense in depth alongside the keyed {#each}).
+	$: if (playlist) {
+		clickedDelete = false;
+	}
+
 	function onClickedDelete() {
 		if (clickedDelete) {
 			dispatch("delete", { value: playlist });
@@ -20,10 +27,6 @@
 		setTimeout(() => {
 			clickedDelete = false;
 		}, 2000);
-	}
-
-	function onClickedRepeat() {
-		dispatch("toggleRepeat", { value: playlist });
 	}
 </script>
 

--- a/src/ui/settings/PlaylistManager.svelte
+++ b/src/ui/settings/PlaylistManager.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { Notice } from "obsidian";
 	import { get } from "svelte/store";
-	import { favorites, playlists, queue } from "src/store";
+	import { favorites, localFiles, playlists, queue } from "src/store";
+	import { PLAYED_SETTINGS } from "src/constants";
 	import type { Playlist } from "src/types/Playlist";
 	import { onMount } from "svelte";
 	import Button from "../obsidian/Button.svelte";
@@ -36,6 +37,21 @@
 
 		if (!name) {
 			new Notice("Playlist name cannot be empty.");
+			return;
+		}
+
+		// Reject the built-in playlist names (Queue/Favorites/Local Files/Played):
+		// those tiles come from separate stores, so a custom playlist sharing one of
+		// their names is ambiguous and makes an open playlist silently switch to the
+		// built-in list on refresh (Codex review #214).
+		const reservedNames = new Set([
+			get(queue).name,
+			get(favorites).name,
+			get(localFiles).name,
+			PLAYED_SETTINGS.name,
+		]);
+		if (reservedNames.has(name)) {
+			new Notice(`"${name}" is a reserved playlist name.`);
 			return;
 		}
 

--- a/src/ui/settings/PlaylistManager.svelte
+++ b/src/ui/settings/PlaylistManager.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { Notice } from "obsidian";
+	import { get } from "svelte/store";
 	import { favorites, playlists, queue } from "src/store";
 	import type { Playlist } from "src/types/Playlist";
 	import { onMount } from "svelte";
@@ -30,9 +32,21 @@
 	});
 
 	function onAddPlaylist() {
+		const name = playlistInput.trim();
+
+		if (!name) {
+			new Notice("Playlist name cannot be empty.");
+			return;
+		}
+
+		if (Object.prototype.hasOwnProperty.call(get(playlists), name)) {
+			new Notice("A playlist with that name already exists.");
+			return;
+		}
+
 		playlists.update((value) => {
-			value[playlistInput] = {
-				name: playlistInput,
+			value[name] = {
+				name,
 				icon: icon,
 				episodes: [],
 				shouldEpisodeRemoveAfterPlay: false,
@@ -56,14 +70,6 @@
 			return value;
 		});
 	}
-
-	function onToggleRepeat(event: CustomEvent<{ value: Playlist }>) {
-		playlists.update((value) => {
-			value[event.detail.value.name].shouldRepeat =
-				!value[event.detail.value.name].shouldRepeat;
-			return value;
-		});
-	}
 </script>
 
 <div class="playlist-manager-container">
@@ -76,11 +82,10 @@
 			playlist={$favorites}
 			showDeleteButton={false}
 		/>
-		{#each playlistArr as playlist}
+		{#each playlistArr as playlist (playlist.name)}
 			<PlaylistItem
 				{playlist}
 				on:delete={onDeletePlaylist}
-				on:toggleRepeat={onToggleRepeat}
 			/>
 		{/each}
 	</div>

--- a/src/ui/settings/PlaylistManager.test.ts
+++ b/src/ui/settings/PlaylistManager.test.ts
@@ -1,9 +1,22 @@
-import { render } from "@testing-library/svelte";
-import { describe, expect, test } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import * as obsidian from "obsidian";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { playlists } from "src/store";
 import PlaylistManager from "./PlaylistManager.svelte";
 
+function typeName(input: HTMLInputElement, value: string) {
+	input.value = value;
+	return fireEvent.input(input);
+}
+
 describe("PlaylistManager", () => {
+	beforeEach(() => {
+		playlists.set({});
+		vi.restoreAllMocks();
+	});
+
 	// Regression test for the #109-class icon-only button: the add-playlist
 	// control previously used an icon-only "+" Button with no text and no
 	// aria-label, so on iPad it rendered as an empty box and was invisible to
@@ -16,5 +29,90 @@ describe("PlaylistManager", () => {
 		expect(addButton).toBeInTheDocument();
 		expect(addButton.textContent?.trim()).toBe("Add");
 		expect(addButton.classList.contains("mod-cta")).toBe(true);
+	});
+
+	// PL-01: a non-empty, non-duplicate name is added to the store and the
+	// input is cleared on success.
+	test("adds a playlist with the trimmed name as both key and name", async () => {
+		const { getByRole, getByPlaceholderText } = render(PlaylistManager);
+		const input = getByPlaceholderText("Playlist name") as HTMLInputElement;
+
+		await typeName(input, "  My Shows  ");
+		await fireEvent.click(getByRole("button", { name: "Add playlist" }));
+
+		const stored = get(playlists);
+		expect(Object.keys(stored)).toEqual(["My Shows"]);
+		expect(stored["My Shows"].name).toBe("My Shows");
+		expect(input.value).toBe("");
+	});
+
+	// PL-01 + MX-03: an empty/whitespace-only name is rejected with a Notice,
+	// nothing is added, and the input is left intact so the user can correct it.
+	test("rejects an empty name with a Notice and adds nothing", async () => {
+		const noticeSpy = vi.spyOn(obsidian, "Notice");
+		const { getByRole, getByPlaceholderText } = render(PlaylistManager);
+		const input = getByPlaceholderText("Playlist name") as HTMLInputElement;
+
+		await typeName(input, "   ");
+		await fireEvent.click(getByRole("button", { name: "Add playlist" }));
+
+		expect(get(playlists)).toEqual({});
+		expect(noticeSpy).toHaveBeenCalledWith("Playlist name cannot be empty.");
+		expect(input.value).toBe("   ");
+	});
+
+	// MX-03: adding a playlist whose trimmed name already exists must NOT
+	// overwrite the existing one (silent data loss). It is rejected with a
+	// Notice and the original playlist is preserved.
+	test("rejects a duplicate name without overwriting the existing playlist", async () => {
+		const existing = {
+			name: "Favorites Mix",
+			icon: "list" as const,
+			episodes: [],
+			shouldEpisodeRemoveAfterPlay: false,
+			shouldRepeat: false,
+		};
+		playlists.set({ "Favorites Mix": existing });
+
+		const noticeSpy = vi.spyOn(obsidian, "Notice");
+		const { getByRole, getByPlaceholderText } = render(PlaylistManager);
+		const input = getByPlaceholderText("Playlist name") as HTMLInputElement;
+
+		await typeName(input, "Favorites Mix");
+		await fireEvent.click(getByRole("button", { name: "Add playlist" }));
+
+		const stored = get(playlists);
+		expect(Object.keys(stored)).toEqual(["Favorites Mix"]);
+		expect(stored["Favorites Mix"]).toBe(existing);
+		expect(noticeSpy).toHaveBeenCalledWith(
+			"A playlist with that name already exists.",
+		);
+		// The duplicate name was rejected, so the input is left for correction.
+		expect(input.value).toBe("Favorites Mix");
+	});
+
+	// MX-03: a trimmed name that collides with an existing key after trimming is
+	// still treated as a duplicate.
+	test("treats a name as duplicate after trimming", async () => {
+		const existing = {
+			name: "Daily",
+			icon: "list" as const,
+			episodes: [],
+			shouldEpisodeRemoveAfterPlay: false,
+			shouldRepeat: false,
+		};
+		playlists.set({ Daily: existing });
+
+		const noticeSpy = vi.spyOn(obsidian, "Notice");
+		const { getByRole, getByPlaceholderText } = render(PlaylistManager);
+		const input = getByPlaceholderText("Playlist name") as HTMLInputElement;
+
+		await typeName(input, "  Daily ");
+		await fireEvent.click(getByRole("button", { name: "Add playlist" }));
+
+		expect(Object.keys(get(playlists))).toEqual(["Daily"]);
+		expect(noticeSpy).toHaveBeenCalledWith(
+			"A playlist with that name already exists.",
+		);
 	});
 });

--- a/src/ui/settings/PlaylistManager.test.ts
+++ b/src/ui/settings/PlaylistManager.test.ts
@@ -46,6 +46,21 @@ describe("PlaylistManager", () => {
 		expect(input.value).toBe("");
 	});
 
+	// #214: a built-in playlist name (Queue/Favorites/Local Files/Played) is
+	// reserved, so a custom playlist can't shadow a built-in and make an open
+	// playlist silently switch lists on refresh.
+	test("rejects a reserved built-in name with a Notice and adds nothing", async () => {
+		const noticeSpy = vi.spyOn(obsidian, "Notice");
+		const { getByRole, getByPlaceholderText } = render(PlaylistManager);
+		const input = getByPlaceholderText("Playlist name") as HTMLInputElement;
+
+		await typeName(input, "Favorites");
+		await fireEvent.click(getByRole("button", { name: "Add playlist" }));
+
+		expect(get(playlists)).toEqual({});
+		expect(noticeSpy).toHaveBeenCalledWith('"Favorites" is a reserved playlist name.');
+	});
+
 	// PL-01 + MX-03: an empty/whitespace-only name is rejected with a Notice,
 	// nothing is added, and the input is left intact so the user can correct it.
 	test("rejects an empty name with a Notice and adds nothing", async () => {

--- a/src/ui/settings/PodcastQueryGrid.svelte
+++ b/src/ui/settings/PodcastQueryGrid.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { debounce } from "obsidian";
+	import { debounce, Notice } from "obsidian";
 	import { queryiTunesPodcasts } from "src/iTunesAPIConsumer";
 	import FeedParser from "src/parser/feedParser";
 	import { savedFeeds, podcastsUpdated } from "src/store";
@@ -13,6 +13,8 @@
 	let searchResults: PodcastFeed[] = [];
 	let gridSizeClass: string = "grid-3";
 	let searchQuery: string = "";
+	let isSearching: boolean = false;
+	let searchError: string = "";
 
 	let searchInput: HTMLInputElement;
 
@@ -50,17 +52,42 @@
 	}
 
 	const debouncedUpdate = debounce(
-		async ({detail: { value }}: CustomEvent<{ value: string }>) => {	
+		async ({detail: { value }}: CustomEvent<{ value: string }>) => {
 			searchQuery = value;
+			searchError = "";
 			const customFeedUrl = checkStringIsUrl(value);
-			
-			if (customFeedUrl) {
-				const feed = await (new FeedParser().getFeed(customFeedUrl.href));
-				searchResults = [feed];
+
+			// Only treat the input as a feed URL when it is an http(s) URL, so
+			// things like "podcast:name" don't get parsed as feeds.
+			const isFeedUrl =
+				customFeedUrl?.protocol === "http:" ||
+				customFeedUrl?.protocol === "https:";
+
+			if (isFeedUrl && customFeedUrl) {
+				isSearching = true;
+				try {
+					const feed = await new FeedParser().getFeed(customFeedUrl.href);
+					searchResults = [feed];
+				} catch (e) {
+					searchResults = [];
+					const msg = e instanceof Error ? e.message : String(e);
+					searchError = `Could not load feed: ${msg}`;
+					new Notice(searchError);
+				} finally {
+					isSearching = false;
+				}
 			} else if (value.trim() === "") {
 				updateSearchResults();
 			} else {
-				searchResults = await queryiTunesPodcasts(value);
+				isSearching = true;
+				try {
+					searchResults = await queryiTunesPodcasts(value);
+				} catch (e) {
+					searchResults = [];
+					searchError = "Could not search podcasts. Please try again.";
+				} finally {
+					isSearching = false;
+				}
 			}
 		},
 		300,
@@ -95,6 +122,20 @@
 		bind:el={searchInput}
 	/>
 
+	{#if isSearching}
+		<div class="podcast-query-status" role="status" aria-live="polite">
+			Searching...
+		</div>
+	{:else if searchError}
+		<div class="podcast-query-status podcast-query-error" role="alert">
+			{searchError}
+		</div>
+	{:else if searchQuery.trim() !== "" && searchResults.length === 0}
+		<div class="podcast-query-status" role="status" aria-live="polite">
+			No results.
+		</div>
+	{/if}
+
 	<div class="podcast-query-results" role="list" aria-label="Podcast search results">
 		{#each searchResults as podcast (podcast.url)}
 			<div role="listitem">
@@ -112,6 +153,16 @@
 <style>
 	.podcast-query-container {
 		margin-bottom: 1.5rem;
+	}
+
+	.podcast-query-status {
+		margin-bottom: 0.75rem;
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	.podcast-query-error {
+		color: var(--text-error);
 	}
 
 	.podcast-query-results {

--- a/src/utility/episodeKey.test.ts
+++ b/src/utility/episodeKey.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { Episode } from "src/types/Episode";
+import { isSameStoredEpisode } from "./episodeKey";
+
+function ep(title: string, podcastName?: string): Episode {
+	return {
+		title,
+		podcastName,
+		streamUrl: "",
+		url: "",
+		description: "",
+		content: "",
+	} as unknown as Episode;
+}
+
+describe("isSameStoredEpisode (#214)", () => {
+	it("matches the same podcast + title (composite key)", () => {
+		expect(isSameStoredEpisode(ep("E1", "Pod"), ep("E1", "Pod"))).toBe(true);
+	});
+
+	it("does NOT match a same-titled episode from a different podcast", () => {
+		// The PB-07 invariant: a different podcast's same title must not match.
+		expect(isSameStoredEpisode(ep("E1", "Other"), ep("E1", "Pod"))).toBe(false);
+	});
+
+	it("matches a LEGACY stored entry (no podcastName) by title against a composite current episode", () => {
+		// episodeMatchesKey alone returns false here; this is the regression #214 fixes.
+		expect(isSameStoredEpisode(ep("E1"), ep("E1", "Pod"))).toBe(true);
+	});
+
+	it("does not match different titles", () => {
+		expect(isSameStoredEpisode(ep("E1", "Pod"), ep("E2", "Pod"))).toBe(false);
+		expect(isSameStoredEpisode(ep("E1"), ep("E2", "Pod"))).toBe(false);
+	});
+
+	it("returns false for null/undefined inputs", () => {
+		expect(isSameStoredEpisode(undefined, ep("E1", "Pod"))).toBe(false);
+		expect(isSameStoredEpisode(ep("E1", "Pod"), null)).toBe(false);
+	});
+});

--- a/src/utility/episodeKey.ts
+++ b/src/utility/episodeKey.ts
@@ -33,3 +33,28 @@ export function episodeMatchesKey(episode: Episode | null | undefined, key: stri
 	// Also check title-only for backwards compatibility
 	return episode.title === key;
 }
+
+/**
+ * Whether a STORED playlist/favorite entry refers to the same episode as
+ * `current`. Matches on the composite key (podcastName::title) and, for LEGACY
+ * entries saved before podcastName existed (the entry has no podcastName), by
+ * title alone — but never matches a same-titled episode from a DIFFERENT podcast
+ * (an entry that does carry a podcastName).
+ *
+ * episodeMatchesKey alone misses a legacy (title-only) entry when the current
+ * episode's key is composite, so a legacy favorite/playlist entry looked absent
+ * and got duplicated (or skipped on cleanup). This restores that legacy match
+ * without reintroducing the cross-podcast title collision.
+ */
+export function isSameStoredEpisode(
+	entry: Episode | null | undefined,
+	current: Episode | null | undefined,
+): boolean {
+	if (!entry || !current) {
+		return false;
+	}
+	if (episodeMatchesKey(entry, getEpisodeKey(current))) {
+		return true;
+	}
+	return !entry.podcastName && !!current.title && entry.title === current.title;
+}

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -323,6 +323,8 @@ export class Menu {
 	}
 
 	showAtMouseEvent() {}
+
+	showAtPosition() {}
 }
 
 export const debounce = <T extends (...args: unknown[]) => unknown>(fn: T) => {


### PR DESCRIPTION
## Summary

Part 2 of 2 of the behavioral-audit fixes: the UI / interaction half (player, chapters, context menu, playlists, podcast view). This supersedes #214, which GitHub auto-closed when its stacked base branch was deleted on the #213 merge; the branch is unchanged in content and has been rebased onto `master` (which now contains #213).

#214 reached CI green + Codex sign-off (👍) with all review threads resolved before it was closed; this PR is that same reviewed branch, rebased.

## What's added / fixed

**Player, chapters, accessible seek**
- Video fullscreen button (no native controls, iOS fallback).
- Chapter-list active highlight tracks playback time and follows a clicked chapter; stale chapters cleared on episode switch; out-of-order fetches ignored.
- Progress bar accessible name + `aria-valuetext`; chapter list `aria-controls` + descriptive seek labels.
- Restore-position and end-of-episode cleanup match by composite identity (with a legacy title-only fallback), so a same-titled episode from another podcast isn't resumed/removed by mistake.

**Context menu, playlists, validation**
- Keyboard/mobile reachable overflow (kebab) opens the episode menu via `showAtPosition` (was right-click only).
- Playlist separator only renders when there are playlists; dropped download promise is settled.
- Playlist/queue grid tiles show their name (card grows so the name can't clip/overlap the count).
- Playlist name validation: reject empty, duplicate, and reserved built-in names; never overwrite an existing playlist; keyed list so per-row delete state can't drift; icon dropdown resets after add.
- Queue context-menu/cleanup checks stay title-based (the queue is title-identified by design).
- Removed unreachable repeat-toggle dead code; reorder-modal buttons enlarged to a comfortable touch target.

**Podcast view**
- Refresh actually refreshes all feeds in the Latest Episodes view; no duplicate loading indicators for a selected feed.
- Whitespace-only search treated as empty; open playlist live-updates; feed-load and search failures (invalid feed URL, iTunes errors) surfaced instead of failing silently.

## Verification
- `lint`, `format:check`, `typecheck`, `build`, `check:a11y`: clean.
- Vitest: 743 passing (includes the regression tests added for every Codex finding during #214's review).
- Real Obsidian (dev vault): progress-bar aria, reorder touch targets, playlist tile names (no overlap), empty/duplicate/reserved name guards, and the focusable kebab confirmed live with no console errors.
