### PR TITLE
fix(download): stream episode downloads to disk to avoid iOS OOM (#113)

### DIFF
--- a/src/download/mediaSignatures.test.ts
+++ b/src/download/mediaSignatures.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { detectAudioFileExtension } from "./mediaSignatures";
+
+function bytes(...values: number[]): ArrayBuffer {
+	return new Uint8Array(values).buffer;
+}
+
+// Build a minimal ISO-BMFF header: a 4-byte box size, the 'ftyp' box type at
+// offset 4, and the 4-character major brand at offset 8 (#DL-06).
+function ftyp(brand: string): ArrayBuffer {
+	const head = bytes(0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70);
+	const brandBytes = new TextEncoder().encode(brand.padEnd(4, " ").slice(0, 4));
+	const out = new Uint8Array(head.byteLength + brandBytes.byteLength);
+	out.set(new Uint8Array(head), 0);
+	out.set(brandBytes, head.byteLength);
+	return out.buffer;
+}
+
+describe("detectAudioFileExtension", () => {
+	it("matches exact signatures (ID3 -> mp3, RIFF -> wav)", () => {
+		expect(detectAudioFileExtension(bytes(0x49, 0x44, 0x33, 0x04))).toBe("mp3");
+		expect(detectAudioFileExtension(bytes(0x52, 0x49, 0x46, 0x46))).toBe("wav");
+	});
+
+	it("detects real ISO-BMFF m4a/mp4 by the ftyp major brand at offset 8 (#DL-06)", () => {
+		// The major brand lives at offset 8, not offset 0 — the old offset-0 'M4A '
+		// signature never matched a genuine m4a/mp4 file.
+		expect(detectAudioFileExtension(ftyp("M4A "))).toBe("m4a");
+		expect(detectAudioFileExtension(ftyp("M4B "))).toBe("mp4");
+		expect(detectAudioFileExtension(ftyp("M4V "))).toBe("m4v");
+		expect(detectAudioFileExtension(ftyp("qt  "))).toBe("mov");
+		expect(detectAudioFileExtension(ftyp("mp42"))).toBe("mp4");
+		expect(detectAudioFileExtension(ftyp("isom"))).toBe("mp4");
+		// An unknown brand still resolves to a generic mp4 container.
+		expect(detectAudioFileExtension(ftyp("zzzz"))).toBe("mp4");
+	});
+
+	it("does not treat a bare 'M4A ' (no ftyp box) as ISO-BMFF", () => {
+		// Four bytes with no ftyp box type at offset 4 are not an MP4 file.
+		expect(detectAudioFileExtension(bytes(0x4d, 0x34, 0x41, 0x20))).toBeNull();
+	});
+
+	it("applies the masked MPEG frame-sync signature", () => {
+		expect(detectAudioFileExtension(bytes(0xff, 0xfb, 0x90, 0x00))).toBe("mp3");
+	});
+
+	it("returns null for unknown content", () => {
+		expect(detectAudioFileExtension(bytes(0x00, 0x01, 0x02, 0x03))).toBeNull();
+	});
+
+	it("does not crash on a buffer shorter than the longest signature", () => {
+		expect(detectAudioFileExtension(bytes(0xff))).toBeNull();
+		expect(detectAudioFileExtension(new ArrayBuffer(0))).toBeNull();
+	});
+});

--- a/src/download/mediaSignatures.ts
+++ b/src/download/mediaSignatures.ts
@@ -1,0 +1,112 @@
+// Binary magic-number / ISO-BMFF detection for downloaded media. Pure functions
+// over the leading header bytes — no vault, network, or Obsidian dependency — so
+// they're trivially unit-testable in isolation.
+
+interface AudioSignature {
+	signature: number[];
+	mask?: number[];
+	fileExtension: string;
+}
+
+/**
+ * Map an ISO-BMFF (MP4/QuickTime) major brand to its file extension. Real m4a/mp4
+ * files carry `ftyp` at offset 4 and the 4-byte major brand at offset 8 (not at
+ * offset 0), so the old offset-0 `M4A ` signature never matched (#DL-06). Known
+ * audio brands resolve to `m4a`; video brands to their own extension; everything
+ * else defaults to `mp4` (or `m4a` when the caller hints the media is audio).
+ */
+function detectIsoBmffExtension(arr: Uint8Array): string | null {
+	// Need 4 bytes of box size + 'ftyp' + the 4-byte major brand.
+	if (arr.length < 12) return null;
+
+	const isFtyp =
+		arr[4] === 0x66 && arr[5] === 0x74 && arr[6] === 0x79 && arr[7] === 0x70;
+	if (!isFtyp) return null;
+
+	const brand = String.fromCharCode(arr[8], arr[9], arr[10], arr[11]);
+
+	if (brand.startsWith("M4A")) return "m4a";
+	if (brand.startsWith("M4V")) return "m4v";
+	if (brand === "qt  ") return "mov";
+
+	// `M4B `/`M4P ` are audiobook/protected-audio brands; the rest are generic
+	// MP4 brands. All map to mp4 here — `inferFileExtensionFromDownload` /
+	// `normalizeAudioExtension` re-map mp4 -> m4a when the media hint is audio.
+	switch (brand) {
+		case "mp42":
+		case "isom":
+		case "iso2":
+		case "mp41":
+		case "dash":
+		case "M4B ":
+		case "M4P ":
+			return "mp4";
+		default:
+			return "mp4";
+	}
+}
+
+export function detectAudioFileExtension(data: ArrayBuffer): string | null {
+	const audioSignatures: AudioSignature[] = [
+		{ signature: [0xff, 0xe0], mask: [0xff, 0xe0], fileExtension: "mp3" },
+		{ signature: [0x49, 0x44, 0x33], fileExtension: "mp3" },
+		{ signature: [0x52, 0x49, 0x46, 0x46], fileExtension: "wav" },
+		{ signature: [0x4f, 0x67, 0x67, 0x53], fileExtension: "ogg" },
+		{ signature: [0x66, 0x4c, 0x61, 0x43], fileExtension: "flac" },
+		{
+			signature: [0x30, 0x26, 0xb2, 0x75, 0x8e, 0x66, 0xcf, 0x11],
+			fileExtension: "wma",
+		},
+		{
+			signature: [0x23, 0x21, 0x41, 0x4d, 0x52, 0x0a],
+			fileExtension: "amr",
+		},
+	];
+
+	// The ftyp brand lives at offset 8, past every offset-0 signature, so read a
+	// header window long enough to cover both before zero-copy-viewing it.
+	const maxSignatureLength = Math.max(
+		12,
+		...audioSignatures.map((sig) => sig.signature.length),
+	);
+	// Zero-copy view over just the header bytes — no Blob slice, no FileReader,
+	// no extra full-file allocation.
+	const arr = new Uint8Array(
+		data,
+		0,
+		Math.min(maxSignatureLength, data.byteLength),
+	);
+
+	// ISO-BMFF is special-cased first: its brand sits at offset 8, so it can't be
+	// expressed as an offset-0 signature like the entries above.
+	const isoBmffExtension = detectIsoBmffExtension(arr);
+	if (isoBmffExtension) {
+		return isoBmffExtension;
+	}
+
+	for (const { signature, mask, fileExtension } of audioSignatures) {
+		if (signature.length > arr.length) {
+			continue;
+		}
+
+		let matches = true;
+		for (let i = 0; i < signature.length; i++) {
+			if (mask) {
+				if ((arr[i] & mask[i]) !== (signature[i] & mask[i])) {
+					matches = false;
+					break;
+				}
+			} else {
+				if (arr[i] !== signature[i]) {
+					matches = false;
+					break;
+				}
+			}
+		}
+		if (matches) {
+			return fileExtension;
+		}
+	}
+
+	return null;
+}

--- a/src/download/streaming.test.ts
+++ b/src/download/streaming.test.ts
@@ -70,6 +70,23 @@ describe("probeAndFetchFirstChunk", () => {
 		});
 	});
 
+	it("leaves totalSize null for a 206 with an unknown total (/*), ignoring the partial Content-Length (#218)", async () => {
+		requestUrlMock.mockResolvedValue(
+			res(206, [1, 2, 3, 4], {
+				"content-type": "audio/mpeg",
+				"content-range": "bytes 0-3/*",
+				"content-length": "4",
+			}),
+		);
+
+		const p = await probeAndFetchFirstChunk("https://x/ep.mp3", 4);
+
+		expect(p.supportsRange).toBe(true);
+		// Must NOT adopt the 4-byte partial Content-Length as the total, or the
+		// writer would stop after one chunk and truncate the file.
+		expect(p.totalSize).toBeNull();
+	});
+
 	it("treats a 200 (ignored Range) as the whole body with supportsRange=false", async () => {
 		requestUrlMock.mockResolvedValue(
 			res(200, [1, 2, 3, 4, 5], {

--- a/src/download/streaming.test.ts
+++ b/src/download/streaming.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requestUrl } from "obsidian";
+import {
+	probeAndFetchFirstChunk,
+	writeStreamedFile,
+	type RangeProbe,
+} from "./streaming";
+
+vi.mock("obsidian", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("obsidian")>();
+	return { ...actual, requestUrl: vi.fn() };
+});
+
+const requestUrlMock = vi.mocked(requestUrl);
+
+function res(status: number, body: number[], headers: Record<string, string> = {}) {
+	return {
+		status,
+		headers,
+		arrayBuffer: new Uint8Array(body).buffer,
+	} as unknown as Awaited<ReturnType<typeof requestUrl>>;
+}
+
+function setupAdapter() {
+	const writes = new Map<string, number[]>();
+	const writeBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
+		writes.set(path, [...new Uint8Array(data)]);
+	});
+	const appendBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
+		writes.set(path, [...(writes.get(path) ?? []), ...new Uint8Array(data)]);
+	});
+	(globalThis as { app?: unknown }).app = {
+		vault: { adapter: { writeBinary, appendBinary } },
+	};
+	return { writes, writeBinary, appendBinary };
+}
+
+function probe(overrides: Partial<RangeProbe> = {}): RangeProbe {
+	return {
+		firstChunk: new Uint8Array([1, 2]).buffer,
+		contentType: "audio/mpeg",
+		supportsRange: true,
+		totalSize: 6,
+		...overrides,
+	};
+}
+
+beforeEach(() => requestUrlMock.mockReset());
+afterEach(() => {
+	(globalThis as { app?: unknown }).app = undefined;
+});
+
+describe("probeAndFetchFirstChunk", () => {
+	it("parses a 206 Content-Range into supportsRange + totalSize and uses chunkSize in the Range header", async () => {
+		requestUrlMock.mockResolvedValue(
+			res(206, [1, 2, 3, 4], {
+				"content-type": "audio/mpeg",
+				"content-range": "bytes 0-3/10",
+			}),
+		);
+
+		const p = await probeAndFetchFirstChunk("https://x/ep.mp3", 4);
+
+		expect(p.supportsRange).toBe(true);
+		expect(p.totalSize).toBe(10);
+		expect(p.contentType).toBe("audio/mpeg");
+		expect(new Uint8Array(p.firstChunk)).toHaveLength(4);
+		expect(requestUrlMock.mock.calls[0][0]).toMatchObject({
+			headers: { Range: "bytes=0-3" },
+		});
+	});
+
+	it("treats a 200 (ignored Range) as the whole body with supportsRange=false", async () => {
+		requestUrlMock.mockResolvedValue(
+			res(200, [1, 2, 3, 4, 5], {
+				"content-type": "audio/mpeg",
+				"content-length": "5",
+			}),
+		);
+
+		const p = await probeAndFetchFirstChunk("https://x/ep.mp3", 4);
+
+		expect(p.supportsRange).toBe(false);
+		expect(p.totalSize).toBe(5);
+	});
+
+	it("throws on a non-2xx status", async () => {
+		requestUrlMock.mockResolvedValue(res(404, []));
+		await expect(probeAndFetchFirstChunk("https://x/ep.mp3", 4)).rejects.toThrow(
+			/HTTP 404/,
+		);
+	});
+});
+
+describe("writeStreamedFile", () => {
+	it("appends sequential range chunks to disk with a small chunk size", async () => {
+		const a = setupAdapter();
+		requestUrlMock
+			.mockResolvedValueOnce(res(206, [3, 4], { "content-range": "bytes 2-3/6" }))
+			.mockResolvedValueOnce(res(206, [5, 6], { "content-range": "bytes 4-5/6" }));
+
+		const total = await writeStreamedFile(
+			"https://x/ep.mp3",
+			"out.mp3",
+			probe({ totalSize: 6 }),
+			undefined,
+			2,
+		);
+
+		expect(total).toBe(6);
+		expect(a.writeBinary).toHaveBeenCalledTimes(1);
+		expect(a.appendBinary).toHaveBeenCalledTimes(2);
+		expect(a.writes.get("out.mp3")).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(requestUrlMock.mock.calls[0][0]).toMatchObject({
+			headers: { Range: "bytes=2-3" },
+		});
+		expect(requestUrlMock.mock.calls[1][0]).toMatchObject({
+			headers: { Range: "bytes=4-5" },
+		});
+	});
+
+	it("writes only the first chunk and makes no further requests when Range was ignored (200)", async () => {
+		const a = setupAdapter();
+
+		const total = await writeStreamedFile(
+			"https://x/ep.mp3",
+			"out.mp3",
+			probe({ firstChunk: new Uint8Array([1, 2, 3]).buffer, supportsRange: false, totalSize: 3 }),
+			undefined,
+			2,
+		);
+
+		expect(total).toBe(3);
+		expect(a.writeBinary).toHaveBeenCalledTimes(1);
+		expect(a.appendBinary).not.toHaveBeenCalled();
+		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+
+	it("stops on a short chunk when the total size is unknown (EOF heuristic)", async () => {
+		const a = setupAdapter();
+		requestUrlMock
+			.mockResolvedValueOnce(res(206, [3, 4]))
+			.mockResolvedValueOnce(res(206, [5]));
+
+		const total = await writeStreamedFile(
+			"https://x/ep.mp3",
+			"out.mp3",
+			probe({ totalSize: null }),
+			undefined,
+			2,
+		);
+
+		expect(total).toBe(5);
+		expect(a.writes.get("out.mp3")).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("throws on a non-206 mid-stream response", async () => {
+		setupAdapter();
+		requestUrlMock.mockResolvedValueOnce(res(500, []));
+
+		await expect(
+			writeStreamedFile("https://x/ep.mp3", "out.mp3", probe({ totalSize: 6 }), undefined, 2),
+		).rejects.toThrow(/Range request failed/);
+	});
+});

--- a/src/download/streaming.ts
+++ b/src/download/streaming.ts
@@ -68,12 +68,17 @@ export async function probeAndFetchFirstChunk(
 	const supportsRange = response.status === 206;
 
 	let totalSize: number | null = null;
-	const contentRange = readHeader(response.headers, "content-range");
-	if (supportsRange && contentRange) {
-		const match = contentRange.match(/\/(\d+)\s*$/);
+	if (supportsRange) {
+		// The total is the value after the slash in Content-Range
+		// ("bytes 0-N/TOTAL"). An unknown total ("bytes 0-N/*") leaves totalSize
+		// null on purpose — writeStreamedFile then terminates on the short-chunk
+		// EOF heuristic. Content-Length on a 206 is only the partial chunk size, so
+		// it must NOT be used as the total (it would truncate the download — #218).
+		const contentRange = readHeader(response.headers, "content-range");
+		const match = contentRange?.match(/\/(\d+)\s*$/);
 		if (match) totalSize = Number.parseInt(match[1], 10);
-	}
-	if (totalSize === null) {
+	} else {
+		// 200: Range ignored, so the whole file is in this single response.
 		const contentLength = readHeader(response.headers, "content-length");
 		if (contentLength) {
 			const parsed = Number.parseInt(contentLength, 10);

--- a/src/download/streaming.ts
+++ b/src/download/streaming.ts
@@ -1,0 +1,149 @@
+import { requestUrl } from "obsidian";
+import { encodeUrlForRequest } from "../utility/encodeUrlForRequest";
+
+// ---- Streaming download (issue #113) ---------------------------------------
+// Mobile WebViews have a tight per-process memory budget. Buffering a whole
+// episode (hundreds of MB) via requestUrl().arrayBuffer — plus the native->JS
+// bridge copy — used to OOM-kill Obsidian on iOS. Instead we pull the file in
+// bounded HTTP Range chunks and append each straight to disk, so peak heap
+// stays at roughly one chunk regardless of episode size.
+
+export const DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MiB per range request
+
+export interface BinaryAppendAdapter {
+	writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+	appendBinary?(path: string, data: ArrayBuffer): Promise<void>;
+}
+
+export interface RangeProbe {
+	firstChunk: ArrayBuffer;
+	contentType: string;
+	supportsRange: boolean;
+	totalSize: number | null;
+}
+
+// `appendBinary` exists at runtime on the mobile CapacitorAdapter (and the
+// desktop adapter) but isn't in Obsidian's public DataAdapter typings. Keep the
+// single unsafe cast here so the "where we step outside the types" boundary is
+// greppable in one place.
+export function appendableAdapter(): BinaryAppendAdapter {
+	return app.vault.adapter as unknown as BinaryAppendAdapter;
+}
+
+function readHeader(
+	headers: Record<string, string> | undefined,
+	name: string,
+): string | undefined {
+	if (!headers) return undefined;
+	const direct = headers[name] ?? headers[name.toLowerCase()];
+	if (direct !== undefined) return direct;
+	const lower = name.toLowerCase();
+	for (const key of Object.keys(headers)) {
+		if (key.toLowerCase() === lower) return headers[key];
+	}
+	return undefined;
+}
+
+// Fetch the first chunk with a Range header and learn whether the server
+// supports ranged requests (206 + Content-Range) and the total size. A server
+// that ignores Range answers 200 with the whole body — the legacy single-buffer
+// behaviour — which we detect and treat as already-complete.
+export async function probeAndFetchFirstChunk(
+	url: string,
+	chunkSize: number = DOWNLOAD_CHUNK_SIZE,
+): Promise<RangeProbe> {
+	const encodedUrl = encodeUrlForRequest(url);
+	const response = await requestUrl({
+		url: encodedUrl,
+		method: "GET",
+		headers: { Range: `bytes=0-${chunkSize - 1}` },
+		throw: false,
+	});
+
+	if (response.status !== 200 && response.status !== 206) {
+		throw new Error(`Could not download episode (HTTP ${response.status}).`);
+	}
+
+	const contentType = readHeader(response.headers, "content-type") ?? "";
+	const supportsRange = response.status === 206;
+
+	let totalSize: number | null = null;
+	const contentRange = readHeader(response.headers, "content-range");
+	if (supportsRange && contentRange) {
+		const match = contentRange.match(/\/(\d+)\s*$/);
+		if (match) totalSize = Number.parseInt(match[1], 10);
+	}
+	if (totalSize === null) {
+		const contentLength = readHeader(response.headers, "content-length");
+		if (contentLength) {
+			const parsed = Number.parseInt(contentLength, 10);
+			if (Number.isFinite(parsed)) totalSize = parsed;
+		}
+	}
+
+	return {
+		firstChunk: response.arrayBuffer,
+		contentType,
+		supportsRange,
+		totalSize,
+	};
+}
+
+// Write the already-fetched first chunk, then pull the remaining bytes in
+// bounded Range requests, appending each straight to disk. Peak memory is one
+// chunk, not the whole file. Returns the total number of bytes written.
+export async function writeStreamedFile(
+	url: string,
+	filePath: string,
+	probe: RangeProbe,
+	onProgress?: (written: number, total: number | null) => void,
+	chunkSize: number = DOWNLOAD_CHUNK_SIZE,
+): Promise<number> {
+	const adapter = appendableAdapter();
+
+	await adapter.writeBinary(filePath, probe.firstChunk);
+	let written = probe.firstChunk.byteLength;
+	onProgress?.(written, probe.totalSize);
+
+	// Server returned the whole body (ignored Range), or this adapter can't
+	// append: the first response already holds everything we can get.
+	if (!probe.supportsRange || typeof adapter.appendBinary !== "function") {
+		return written;
+	}
+
+	const encodedUrl = encodeUrlForRequest(url);
+	for (;;) {
+		if (probe.totalSize !== null && written >= probe.totalSize) break;
+
+		const rangeEnd =
+			probe.totalSize !== null
+				? Math.min(written + chunkSize, probe.totalSize) - 1
+				: written + chunkSize - 1;
+
+		const response = await requestUrl({
+			url: encodedUrl,
+			method: "GET",
+			headers: { Range: `bytes=${written}-${rangeEnd}` },
+			throw: false,
+		});
+
+		if (response.status === 416) break; // requested past end of file
+		if (response.status !== 206) {
+			throw new Error(
+				`Range request failed (HTTP ${response.status}) at byte ${written}.`,
+			);
+		}
+
+		const chunk = response.arrayBuffer;
+		if (chunk.byteLength === 0) break;
+
+		await adapter.appendBinary(filePath, chunk);
+		written += chunk.byteLength;
+		onProgress?.(written, probe.totalSize);
+
+		// Unknown total: a short chunk means we hit EOF.
+		if (probe.totalSize === null && chunk.byteLength < chunkSize) break;
+	}
+
+	return written;
+}

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -23,12 +23,14 @@ function bytes(...values: number[]): ArrayBuffer {
 }
 
 function setupVault({ streaming = false }: { streaming?: boolean } = {}) {
-	const present = new Set<string>();
+	const present = new Set<string>(); // vault index (getAbstractFileByPath)
+	const disk = new Set<string>(); // raw filesystem (adapter.exists)
 	const createdFolders: string[] = [];
 	const written = new Map<string, number>();
 
 	const createBinary = vi.fn(async (path: string, _data: ArrayBuffer) => {
 		present.add(path);
+		disk.add(path);
 		return new TFile();
 	});
 	const createFolder = vi.fn(async (path: string) => {
@@ -36,17 +38,31 @@ function setupVault({ streaming = false }: { streaming?: boolean } = {}) {
 		createdFolders.push(path);
 	});
 	const deleteFile = vi.fn(async (_file: unknown) => {});
+	const removeFile = vi.fn(async (path: string) => {
+		disk.delete(path);
+	});
 
-	// The streaming download path needs adapter.writeBinary + appendBinary; the
-	// legacy path needs neither (and falls back to vault.createBinary). Toggle
-	// `streaming` to exercise each branch.
+	// Adapter writes land on "disk" but NOT in the vault index (present),
+	// mirroring how getAbstractFileByPath can miss a freshly adapter-written file
+	// until the watcher reconciles it. The streaming download path additionally
+	// needs writeBinary + appendBinary; the legacy path uses neither and falls
+	// back to vault.createBinary.
 	const writeBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
-		present.add(path);
+		disk.add(path);
 		written.set(path, data.byteLength);
 	});
 	const appendBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
 		written.set(path, (written.get(path) ?? 0) + data.byteLength);
 	});
+
+	const adapter: Record<string, unknown> = {
+		exists: async (path: string) => disk.has(path) || present.has(path),
+		remove: removeFile,
+	};
+	if (streaming) {
+		adapter.writeBinary = writeBinary;
+		adapter.appendBinary = appendBinary;
+	}
 
 	(globalThis as { app?: unknown }).app = {
 		vault: {
@@ -55,16 +71,18 @@ function setupVault({ streaming = false }: { streaming?: boolean } = {}) {
 			createBinary,
 			createFolder,
 			delete: deleteFile,
-			adapter: streaming ? { writeBinary, appendBinary } : {},
+			adapter,
 		},
 	};
 
 	return {
 		present,
+		disk,
 		createdFolders,
 		createBinary,
 		createFolder,
 		deleteFile,
+		removeFile,
 		writeBinary,
 		appendBinary,
 		written,
@@ -1229,7 +1247,7 @@ describe("downloadEpisodeWithNotice (streaming range path)", () => {
 		expect(get(downloadedEpisodes)["Pod"]?.[0]?.size).toBe(8);
 	});
 
-	it("deletes the partial file and rethrows on a mid-stream failure", async () => {
+	it("removes the partial file via the adapter (not yet vault-indexed) and rethrows on a mid-stream failure", async () => {
 		const v = setupVault({ streaming: true });
 		requestUrlMock
 			.mockResolvedValueOnce(
@@ -1244,7 +1262,10 @@ describe("downloadEpisodeWithNotice (streaming range path)", () => {
 			downloadEpisodeWithNotice(makeEpisode(), "Podcasts/{{title}}"),
 		).rejects.toThrow(/Range request failed/);
 
-		expect(v.deleteFile).toHaveBeenCalledTimes(1);
+		// The partial was written through the adapter, so it isn't in the vault
+		// index — cleanup must fall back to adapter.remove (#218).
+		expect(v.deleteFile).not.toHaveBeenCalled();
+		expect(v.removeFile).toHaveBeenCalledTimes(1);
 		expect(get(downloadedEpisodes)["Pod"]).toBeUndefined();
 	});
 });

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { get } from "svelte/store";
 import { Notice, requestUrl, TFile } from "obsidian";
 import downloadEpisodeWithNotice, {
-	detectAudioFileExtension,
 	downloadEpisode,
 	getEpisodeAudioBuffer,
 	safeDownloadBasename,
@@ -93,55 +92,6 @@ beforeEach(() => {
 
 afterEach(() => {
 	(globalThis as { app?: unknown }).app = undefined;
-});
-
-// Build a minimal ISO-BMFF header: a 4-byte box size, the 'ftyp' box type at
-// offset 4, and the 4-character major brand at offset 8 (#DL-06).
-function ftyp(brand: string): ArrayBuffer {
-	const head = bytes(0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70);
-	const brandBytes = new TextEncoder().encode(brand.padEnd(4, " ").slice(0, 4));
-	const out = new Uint8Array(head.byteLength + brandBytes.byteLength);
-	out.set(new Uint8Array(head), 0);
-	out.set(brandBytes, head.byteLength);
-	return out.buffer;
-}
-
-describe("detectAudioFileExtension", () => {
-	it("matches exact signatures (ID3 -> mp3, RIFF -> wav)", () => {
-		expect(detectAudioFileExtension(bytes(0x49, 0x44, 0x33, 0x04))).toBe("mp3");
-		expect(detectAudioFileExtension(bytes(0x52, 0x49, 0x46, 0x46))).toBe("wav");
-	});
-
-	it("detects real ISO-BMFF m4a/mp4 by the ftyp major brand at offset 8 (#DL-06)", () => {
-		// The major brand lives at offset 8, not offset 0 — the old offset-0 'M4A '
-		// signature never matched a genuine m4a/mp4 file.
-		expect(detectAudioFileExtension(ftyp("M4A "))).toBe("m4a");
-		expect(detectAudioFileExtension(ftyp("M4B "))).toBe("mp4");
-		expect(detectAudioFileExtension(ftyp("M4V "))).toBe("m4v");
-		expect(detectAudioFileExtension(ftyp("qt  "))).toBe("mov");
-		expect(detectAudioFileExtension(ftyp("mp42"))).toBe("mp4");
-		expect(detectAudioFileExtension(ftyp("isom"))).toBe("mp4");
-		// An unknown brand still resolves to a generic mp4 container.
-		expect(detectAudioFileExtension(ftyp("zzzz"))).toBe("mp4");
-	});
-
-	it("does not treat a bare 'M4A ' (no ftyp box) as ISO-BMFF", () => {
-		// Four bytes with no ftyp box type at offset 4 are not an MP4 file.
-		expect(detectAudioFileExtension(bytes(0x4d, 0x34, 0x41, 0x20))).toBeNull();
-	});
-
-	it("applies the masked MPEG frame-sync signature", () => {
-		expect(detectAudioFileExtension(bytes(0xff, 0xfb, 0x90, 0x00))).toBe("mp3");
-	});
-
-	it("returns null for unknown content", () => {
-		expect(detectAudioFileExtension(bytes(0x00, 0x01, 0x02, 0x03))).toBeNull();
-	});
-
-	it("does not crash on a buffer shorter than the longest signature", () => {
-		expect(detectAudioFileExtension(bytes(0xff))).toBeNull();
-		expect(detectAudioFileExtension(new ArrayBuffer(0))).toBeNull();
-	});
 });
 
 describe("downloadEpisodeWithNotice (download command path)", () => {

--- a/src/downloadEpisode.test.ts
+++ b/src/downloadEpisode.test.ts
@@ -23,9 +23,10 @@ function bytes(...values: number[]): ArrayBuffer {
 	return new Uint8Array(values).buffer;
 }
 
-function setupVault() {
+function setupVault({ streaming = false }: { streaming?: boolean } = {}) {
 	const present = new Set<string>();
 	const createdFolders: string[] = [];
+	const written = new Map<string, number>();
 
 	const createBinary = vi.fn(async (path: string, _data: ArrayBuffer) => {
 		present.add(path);
@@ -35,6 +36,18 @@ function setupVault() {
 		present.add(path);
 		createdFolders.push(path);
 	});
+	const deleteFile = vi.fn(async (_file: unknown) => {});
+
+	// The streaming download path needs adapter.writeBinary + appendBinary; the
+	// legacy path needs neither (and falls back to vault.createBinary). Toggle
+	// `streaming` to exercise each branch.
+	const writeBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
+		present.add(path);
+		written.set(path, data.byteLength);
+	});
+	const appendBinary = vi.fn(async (path: string, data: ArrayBuffer) => {
+		written.set(path, (written.get(path) ?? 0) + data.byteLength);
+	});
 
 	(globalThis as { app?: unknown }).app = {
 		vault: {
@@ -42,10 +55,21 @@ function setupVault() {
 				present.has(path) ? new TFile() : null,
 			createBinary,
 			createFolder,
+			delete: deleteFile,
+			adapter: streaming ? { writeBinary, appendBinary } : {},
 		},
 	};
 
-	return { present, createdFolders, createBinary, createFolder };
+	return {
+		present,
+		createdFolders,
+		createBinary,
+		createFolder,
+		deleteFile,
+		writeBinary,
+		appendBinary,
+		written,
+	};
 }
 
 function makeEpisode(overrides: Partial<Episode> = {}): Episode {
@@ -1196,5 +1220,81 @@ describe("getEpisodeAudioBuffer (issue #107)", () => {
 		expect(result.extension).toBe("m4a");
 		expect(result.basename).toBe("recording");
 		expect(requestUrlMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("downloadEpisodeWithNotice (streaming range path)", () => {
+	// A server that returns short bodies regardless of the requested range size
+	// lets us exercise multi-chunk streaming without allocating real 4 MiB buffers
+	// (the loop advances by the ACTUAL bytes returned, not the requested span).
+	function rangeResponse(
+		status: number,
+		body: number[],
+		headers: Record<string, string> = {},
+	) {
+		return {
+			status,
+			headers,
+			arrayBuffer: new Uint8Array(body).buffer,
+		} as unknown as Awaited<ReturnType<typeof requestUrl>>;
+	}
+
+	it("streams a ranged (206) download in chunks via writeBinary + appendBinary", async () => {
+		const v = setupVault({ streaming: true });
+		requestUrlMock
+			.mockResolvedValueOnce(
+				rangeResponse(206, [1, 2, 3, 4, 5, 6, 7, 8], {
+					"content-type": "audio/mpeg",
+					"content-range": "bytes 0-7/16",
+				}),
+			)
+			.mockResolvedValueOnce(
+				rangeResponse(206, [9, 10, 11, 12, 13, 14, 15, 16], {
+					"content-range": "bytes 8-15/16",
+				}),
+			);
+
+		await downloadEpisodeWithNotice(makeEpisode(), "Podcasts/{{title}}");
+
+		expect(v.writeBinary).toHaveBeenCalledTimes(1);
+		expect(v.appendBinary).toHaveBeenCalledTimes(1);
+		expect(v.createBinary).not.toHaveBeenCalled();
+		const recorded = get(downloadedEpisodes)["Pod"]?.[0];
+		expect(recorded?.filePath).toBe("Podcasts/My Title.mp3");
+		expect(recorded?.size).toBe(16);
+	});
+
+	it("writes the whole body in one shot when the server ignores Range (200)", async () => {
+		const v = setupVault({ streaming: true });
+		requestUrlMock.mockResolvedValue(
+			rangeResponse(200, [0xff, 0xfb, 0x90, 0x00, 1, 2, 3, 4], {
+				"content-type": "audio/mpeg",
+			}),
+		);
+
+		await downloadEpisodeWithNotice(makeEpisode(), "Podcasts/{{title}}");
+
+		expect(v.writeBinary).toHaveBeenCalledTimes(1);
+		expect(v.appendBinary).not.toHaveBeenCalled();
+		expect(get(downloadedEpisodes)["Pod"]?.[0]?.size).toBe(8);
+	});
+
+	it("deletes the partial file and rethrows on a mid-stream failure", async () => {
+		const v = setupVault({ streaming: true });
+		requestUrlMock
+			.mockResolvedValueOnce(
+				rangeResponse(206, [1, 2, 3, 4, 5, 6, 7, 8], {
+					"content-type": "audio/mpeg",
+					"content-range": "bytes 0-7/16",
+				}),
+			)
+			.mockResolvedValueOnce(rangeResponse(500, []));
+
+		await expect(
+			downloadEpisodeWithNotice(makeEpisode(), "Podcasts/{{title}}"),
+		).rejects.toThrow(/Range request failed/);
+
+		expect(v.deleteFile).toHaveBeenCalledTimes(1);
+		expect(get(downloadedEpisodes)["Pod"]).toBeUndefined();
 	});
 });

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -22,6 +22,12 @@ import {
 	isPlayableMediaExtension,
 	isSameMediaSource,
 } from "./utility/mediaType";
+import {
+	appendableAdapter,
+	probeAndFetchFirstChunk,
+	writeStreamedFile,
+} from "./download/streaming";
+import { detectAudioFileExtension } from "./download/mediaSignatures";
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -65,35 +71,6 @@ async function downloadFile(url: string): Promise<DownloadedFile> {
 	}
 }
 
-// ---- Streaming download (issue #113) ---------------------------------------
-// Mobile WebViews have a tight per-process memory budget. Buffering a whole
-// episode (hundreds of MB) via requestUrl().arrayBuffer — plus the native->JS
-// bridge copy — used to OOM-kill Obsidian on iOS. Instead we pull the file in
-// bounded HTTP Range chunks and append each straight to disk, so peak heap
-// stays at roughly one chunk regardless of episode size.
-
-const DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MiB per range request
-
-interface BinaryAppendAdapter {
-	writeBinary(path: string, data: ArrayBuffer): Promise<void>;
-	appendBinary?(path: string, data: ArrayBuffer): Promise<void>;
-}
-
-interface RangeProbe {
-	firstChunk: ArrayBuffer;
-	contentType: string;
-	supportsRange: boolean;
-	totalSize: number | null;
-}
-
-// `appendBinary` exists at runtime on the mobile CapacitorAdapter (and the
-// desktop adapter) but isn't in Obsidian's public DataAdapter typings. Keep the
-// single unsafe cast here so the "where we step outside the types" boundary is
-// greppable in one place.
-function appendableAdapter(): BinaryAppendAdapter {
-	return app.vault.adapter as unknown as BinaryAppendAdapter;
-}
-
 function parentFolderPath(filePath: string): string {
 	return filePath.split("/").slice(0, -1).join("/");
 }
@@ -102,124 +79,6 @@ function parentFolderPath(filePath: string): string {
 // requests for the same episode (e.g. a double-tap, or several queued at once)
 // into a single transfer so they can't stack N full downloads in memory.
 const downloadsInFlight = new Map<string, Promise<string>>();
-
-function readHeader(
-	headers: Record<string, string> | undefined,
-	name: string,
-): string | undefined {
-	if (!headers) return undefined;
-	const direct = headers[name] ?? headers[name.toLowerCase()];
-	if (direct !== undefined) return direct;
-	const lower = name.toLowerCase();
-	for (const key of Object.keys(headers)) {
-		if (key.toLowerCase() === lower) return headers[key];
-	}
-	return undefined;
-}
-
-// Fetch the first chunk with a Range header and learn whether the server
-// supports ranged requests (206 + Content-Range) and the total size. A server
-// that ignores Range answers 200 with the whole body — the legacy single-buffer
-// behaviour — which we detect and treat as already-complete.
-async function probeAndFetchFirstChunk(
-	url: string,
-	chunkSize: number,
-): Promise<RangeProbe> {
-	const encodedUrl = encodeUrlForRequest(url);
-	const response = await requestUrl({
-		url: encodedUrl,
-		method: "GET",
-		headers: { Range: `bytes=0-${chunkSize - 1}` },
-		throw: false,
-	});
-
-	if (response.status !== 200 && response.status !== 206) {
-		throw new Error(`Could not download episode (HTTP ${response.status}).`);
-	}
-
-	const contentType = readHeader(response.headers, "content-type") ?? "";
-	const supportsRange = response.status === 206;
-
-	let totalSize: number | null = null;
-	const contentRange = readHeader(response.headers, "content-range");
-	if (supportsRange && contentRange) {
-		const match = contentRange.match(/\/(\d+)\s*$/);
-		if (match) totalSize = Number.parseInt(match[1], 10);
-	}
-	if (totalSize === null) {
-		const contentLength = readHeader(response.headers, "content-length");
-		if (contentLength) {
-			const parsed = Number.parseInt(contentLength, 10);
-			if (Number.isFinite(parsed)) totalSize = parsed;
-		}
-	}
-
-	return {
-		firstChunk: response.arrayBuffer,
-		contentType,
-		supportsRange,
-		totalSize,
-	};
-}
-
-// Write the already-fetched first chunk, then pull the remaining bytes in
-// bounded Range requests, appending each straight to disk. Peak memory is one
-// chunk, not the whole file. Returns the total number of bytes written.
-async function writeStreamedFile(
-	url: string,
-	filePath: string,
-	probe: RangeProbe,
-	chunkSize: number,
-	onProgress?: (written: number, total: number | null) => void,
-): Promise<number> {
-	const adapter = appendableAdapter();
-
-	await adapter.writeBinary(filePath, probe.firstChunk);
-	let written = probe.firstChunk.byteLength;
-	onProgress?.(written, probe.totalSize);
-
-	// Server returned the whole body (ignored Range), or this adapter can't
-	// append: the first response already holds everything we can get.
-	if (!probe.supportsRange || typeof adapter.appendBinary !== "function") {
-		return written;
-	}
-
-	const encodedUrl = encodeUrlForRequest(url);
-	for (;;) {
-		if (probe.totalSize !== null && written >= probe.totalSize) break;
-
-		const rangeEnd =
-			probe.totalSize !== null
-				? Math.min(written + chunkSize, probe.totalSize) - 1
-				: written + chunkSize - 1;
-
-		const response = await requestUrl({
-			url: encodedUrl,
-			method: "GET",
-			headers: { Range: `bytes=${written}-${rangeEnd}` },
-			throw: false,
-		});
-
-		if (response.status === 416) break; // requested past end of file
-		if (response.status !== 206) {
-			throw new Error(
-				`Range request failed (HTTP ${response.status}) at byte ${written}.`,
-			);
-		}
-
-		const chunk = response.arrayBuffer;
-		if (chunk.byteLength === 0) break;
-
-		await adapter.appendBinary(filePath, chunk);
-		written += chunk.byteLength;
-		onProgress?.(written, probe.totalSize);
-
-		// Unknown total: a short chunk means we hit EOF.
-		if (probe.totalSize === null && chunk.byteLength < chunkSize) break;
-	}
-
-	return written;
-}
 
 // Single source of truth for "what extension and on-disk path does this download
 // get, and is it even playable". Shared by the streaming and legacy paths so the
@@ -251,6 +110,24 @@ async function downloadEpisodeToDisk(
 	downloadPathTemplate: string,
 	onProgress?: (written: number, total: number | null) => void,
 ): Promise<string> {
+	// Fast path: if this episode is already on disk under the extension its URL
+	// implies, skip the (potentially multi-MB) Range probe entirely. The probe is
+	// only needed to discover the extension when the URL lacks one, or to confirm
+	// the final path when the URL's extension is wrong — both still handled below.
+	const urlExtension = getUrlExtension(episode.streamUrl);
+	if (urlExtension) {
+		const provisionalPath = safeDownloadFilePath(
+			downloadPathTemplate,
+			episode,
+			urlExtension,
+		);
+		const cached = app.vault.getAbstractFileByPath(provisionalPath);
+		if (cached instanceof TFile) {
+			downloadedEpisodes.addEpisode(episode, provisionalPath, cached.stat.size);
+			return provisionalPath;
+		}
+	}
+
 	const adapter = appendableAdapter();
 	const canStream =
 		typeof adapter.writeBinary === "function" &&
@@ -268,10 +145,7 @@ async function downloadEpisodeToDisk(
 		return filePath;
 	}
 
-	const probe = await probeAndFetchFirstChunk(
-		episode.streamUrl,
-		DOWNLOAD_CHUNK_SIZE,
-	);
+	const probe = await probeAndFetchFirstChunk(episode.streamUrl);
 	const { filePath } = resolveDownloadTarget(
 		episode,
 		downloadPathTemplate,
@@ -296,7 +170,6 @@ async function downloadEpisodeToDisk(
 			episode.streamUrl,
 			filePath,
 			probe,
-			DOWNLOAD_CHUNK_SIZE,
 			onProgress,
 		);
 	} catch (error) {
@@ -336,7 +209,7 @@ export default async function downloadEpisodeWithNotice(
 		// Dedupe by episode identity (podcast + title — the same key the download
 		// registry uses), so a double-tap collapses onto one transfer while two
 		// genuinely different episodes never block each other.
-		const key = `${episode.podcastName} ${episode.title}`;
+		const key = `${episode.podcastName}\u0000${episode.title}`;
 
 		const inProgress = downloadsInFlight.get(key);
 		if (inProgress) {
@@ -960,111 +833,5 @@ function getFileBasename(filePath: string): string {
 	return dot > 0 ? fileName.slice(0, dot) : fileName;
 }
 
-interface AudioSignature {
-	signature: number[];
-	mask?: number[];
-	fileExtension: string;
-}
-
-/**
- * Map an ISO-BMFF (MP4/QuickTime) major brand to its file extension. Real m4a/mp4
- * files carry `ftyp` at offset 4 and the 4-byte major brand at offset 8 (not at
- * offset 0), so the old offset-0 `M4A ` signature never matched (#DL-06). Known
- * audio brands resolve to `m4a`; video brands to their own extension; everything
- * else defaults to `mp4` (or `m4a` when the caller hints the media is audio).
- */
-function detectIsoBmffExtension(arr: Uint8Array): string | null {
-	// Need 4 bytes of box size + 'ftyp' + the 4-byte major brand.
-	if (arr.length < 12) return null;
-
-	const isFtyp =
-		arr[4] === 0x66 && arr[5] === 0x74 && arr[6] === 0x79 && arr[7] === 0x70;
-	if (!isFtyp) return null;
-
-	const brand = String.fromCharCode(arr[8], arr[9], arr[10], arr[11]);
-
-	if (brand.startsWith("M4A")) return "m4a";
-	if (brand.startsWith("M4V")) return "m4v";
-	if (brand === "qt  ") return "mov";
-
-	// `M4B `/`M4P ` are audiobook/protected-audio brands; the rest are generic
-	// MP4 brands. All map to mp4 here — `inferFileExtensionFromDownload` /
-	// `normalizeAudioExtension` re-map mp4 -> m4a when the media hint is audio.
-	switch (brand) {
-		case "mp42":
-		case "isom":
-		case "iso2":
-		case "mp41":
-		case "dash":
-		case "M4B ":
-		case "M4P ":
-			return "mp4";
-		default:
-			return "mp4";
-	}
-}
-
-export function detectAudioFileExtension(data: ArrayBuffer): string | null {
-	const audioSignatures: AudioSignature[] = [
-		{ signature: [0xff, 0xe0], mask: [0xff, 0xe0], fileExtension: "mp3" },
-		{ signature: [0x49, 0x44, 0x33], fileExtension: "mp3" },
-		{ signature: [0x52, 0x49, 0x46, 0x46], fileExtension: "wav" },
-		{ signature: [0x4f, 0x67, 0x67, 0x53], fileExtension: "ogg" },
-		{ signature: [0x66, 0x4c, 0x61, 0x43], fileExtension: "flac" },
-		{
-			signature: [0x30, 0x26, 0xb2, 0x75, 0x8e, 0x66, 0xcf, 0x11],
-			fileExtension: "wma",
-		},
-		{
-			signature: [0x23, 0x21, 0x41, 0x4d, 0x52, 0x0a],
-			fileExtension: "amr",
-		},
-	];
-
-	// The ftyp brand lives at offset 8, past every offset-0 signature, so read a
-	// header window long enough to cover both before zero-copy-viewing it.
-	const maxSignatureLength = Math.max(
-		12,
-		...audioSignatures.map((sig) => sig.signature.length),
-	);
-	// Zero-copy view over just the header bytes — no Blob slice, no FileReader,
-	// no extra full-file allocation.
-	const arr = new Uint8Array(
-		data,
-		0,
-		Math.min(maxSignatureLength, data.byteLength),
-	);
-
-	// ISO-BMFF is special-cased first: its brand sits at offset 8, so it can't be
-	// expressed as an offset-0 signature like the entries above.
-	const isoBmffExtension = detectIsoBmffExtension(arr);
-	if (isoBmffExtension) {
-		return isoBmffExtension;
-	}
-
-	for (const { signature, mask, fileExtension } of audioSignatures) {
-		if (signature.length > arr.length) {
-			continue;
-		}
-
-		let matches = true;
-		for (let i = 0; i < signature.length; i++) {
-			if (mask) {
-				if ((arr[i] & mask[i]) !== (signature[i] & mask[i])) {
-					matches = false;
-					break;
-				}
-			} else {
-				if (arr[i] !== signature[i]) {
-					matches = false;
-					break;
-				}
-			}
-		}
-		if (matches) {
-			return fileExtension;
-		}
-	}
-
-	return null;
-}
+// Binary signature detection lives in ./download/mediaSignatures
+// (detectAudioFileExtension), imported above.

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -379,6 +379,15 @@ async function deleteEpisodeFile(filePath: string): Promise<void> {
 		const file = app.vault.getAbstractFileByPath(filePath);
 		if (file instanceof TFile) {
 			await app.vault.delete(file);
+			return;
+		}
+		// Streamed downloads are written through the adapter, so the vault index
+		// may not have reconciled the file yet and getAbstractFileByPath can miss a
+		// freshly written partial. Remove it directly through the adapter so a
+		// failed streamed download never leaves bytes behind (#218).
+		const { adapter } = app.vault;
+		if (await adapter.exists(filePath)) {
+			await adapter.remove(filePath);
 		}
 	} catch (error) {
 		console.error(`Failed to delete downloaded file "${filePath}":`, error);

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -39,13 +39,10 @@ interface DownloadedFile {
 	byteLength: number;
 }
 
-async function downloadFile(
-	url: string,
-	options?: Partial<{
-		onFinished: () => void;
-		onError: (error: Error) => void;
-	}>,
-): Promise<DownloadedFile> {
+// Whole-file download: only the legacy fallback (adapters without binary append)
+// and transcription's getEpisodeAudioBuffer still need the entire buffer at once.
+// The Download command streams instead — see downloadEpisodeToDisk.
+async function downloadFile(url: string): Promise<DownloadedFile> {
 	const encodedUrl = encodeUrlForRequest(url);
 	try {
 		const response = await requestUrl({ url: encodedUrl, method: "GET" });
@@ -54,25 +51,17 @@ async function downloadFile(
 			throw new Error("Could not download episode.");
 		}
 
-		// Read the decoded buffer once and keep that single reference. `requestUrl`
-		// has no streaming API, so this 1x copy is unavoidable; everything
-		// downstream reuses it instead of allocating further copies.
 		const data = response.arrayBuffer;
 		const contentType =
 			response.headers["content-type"] ??
 			response.headers["Content-Type"] ??
 			"";
 
-		options?.onFinished?.();
-
 		return { data, contentType, byteLength: data.byteLength };
 	} catch (error: unknown) {
-		const err = new Error(
+		throw new Error(
 			`Failed to download ${url}:\n\n${getErrorMessage(error)}`,
 		);
-		options?.onError?.(err);
-
-		throw err;
 	}
 }
 
@@ -97,7 +86,19 @@ interface RangeProbe {
 	totalSize: number | null;
 }
 
-// In-flight downloads keyed by stream URL: collapses duplicate/concurrent
+// `appendBinary` exists at runtime on the mobile CapacitorAdapter (and the
+// desktop adapter) but isn't in Obsidian's public DataAdapter typings. Keep the
+// single unsafe cast here so the "where we step outside the types" boundary is
+// greppable in one place.
+function appendableAdapter(): BinaryAppendAdapter {
+	return app.vault.adapter as unknown as BinaryAppendAdapter;
+}
+
+function parentFolderPath(filePath: string): string {
+	return filePath.split("/").slice(0, -1).join("/");
+}
+
+// In-flight downloads keyed by episode identity: collapses duplicate/concurrent
 // requests for the same episode (e.g. a double-tap, or several queued at once)
 // into a single transfer so they can't stack N full downloads in memory.
 const downloadsInFlight = new Map<string, Promise<string>>();
@@ -171,7 +172,7 @@ async function writeStreamedFile(
 	chunkSize: number,
 	onProgress?: (written: number, total: number | null) => void,
 ): Promise<number> {
-	const adapter = app.vault.adapter as unknown as BinaryAppendAdapter;
+	const adapter = appendableAdapter();
 
 	await adapter.writeBinary(filePath, probe.firstChunk);
 	let written = probe.firstChunk.byteLength;
@@ -220,52 +221,63 @@ async function writeStreamedFile(
 	return written;
 }
 
-// Download an episode to a vault file with bounded memory. Falls back to the
-// legacy whole-file path only when the adapter lacks binary append (so we never
-// truncate the output). Returns the on-disk path.
+// Single source of truth for "what extension and on-disk path does this download
+// get, and is it even playable". Shared by the streaming and legacy paths so the
+// playability rule (#DL-07 / #213) and path resolution live in exactly one place.
+// `headerBytes` only needs the first chunk — the signature sniff reads ~12 bytes.
+function resolveDownloadTarget(
+	episode: Episode,
+	downloadPathTemplate: string,
+	headerBytes: ArrayBuffer,
+	contentType: string,
+): { extension: string; filePath: string } {
+	const extension =
+		inferFileExtensionFromDownload(episode, headerBytes, contentType) ?? "mp3";
+	if (!downloadAppearsPlayable(contentType, extension, episode.mediaType)) {
+		throw new Error("Not a playable media file");
+	}
+	return {
+		extension,
+		filePath: safeDownloadFilePath(downloadPathTemplate, episode, extension),
+	};
+}
+
+// Download an episode to a vault file with bounded memory. Streams via Range
+// chunks when the adapter supports binary append; otherwise falls back to the
+// legacy whole-file buffer (so a non-appendable adapter is never truncated).
+// Returns the on-disk path.
 async function downloadEpisodeToDisk(
 	episode: Episode,
 	downloadPathTemplate: string,
 	onProgress?: (written: number, total: number | null) => void,
 ): Promise<string> {
-	const adapter = app.vault.adapter as unknown as BinaryAppendAdapter;
+	const adapter = appendableAdapter();
 	const canStream =
 		typeof adapter.writeBinary === "function" &&
 		typeof adapter.appendBinary === "function";
 
 	if (!canStream) {
-		// Legacy fallback (adapters without binary append): a single buffer.
 		const { data, contentType } = await downloadFile(episode.streamUrl);
-		const extension =
-			inferFileExtensionFromDownload(episode, data, contentType) ?? "mp3";
-		if (!downloadAppearsPlayable(contentType, extension, episode.mediaType)) {
-			throw new Error(
-				`Downloaded file is not an audio or video file (type "${contentType}").`,
-			);
-		}
+		const { extension, filePath } = resolveDownloadTarget(
+			episode,
+			downloadPathTemplate,
+			data,
+			contentType,
+		);
 		await createEpisodeFile({ episode, downloadPathTemplate, data, extension });
-		return safeDownloadFilePath(downloadPathTemplate, episode, extension);
+		return filePath;
 	}
 
 	const probe = await probeAndFetchFirstChunk(
 		episode.streamUrl,
 		DOWNLOAD_CHUNK_SIZE,
 	);
-	const extension =
-		inferFileExtensionFromDownload(
-			episode,
-			probe.firstChunk,
-			probe.contentType,
-		) ?? "mp3";
-	if (
-		!downloadAppearsPlayable(probe.contentType, extension, episode.mediaType)
-	) {
-		throw new Error(
-			`Downloaded file is not an audio or video file (type "${probe.contentType}").`,
-		);
-	}
-
-	const filePath = safeDownloadFilePath(downloadPathTemplate, episode, extension);
+	const { filePath } = resolveDownloadTarget(
+		episode,
+		downloadPathTemplate,
+		probe.firstChunk,
+		probe.contentType,
+	);
 
 	const existing = app.vault.getAbstractFileByPath(filePath);
 	if (existing instanceof TFile) {
@@ -273,16 +285,31 @@ async function downloadEpisodeToDisk(
 		return filePath;
 	}
 
-	const folderPath = filePath.split("/").slice(0, -1).join("/");
-	await ensureFolderExists(folderPath);
+	await ensureFolderExists(parentFolderPath(filePath));
 
-	const total = await writeStreamedFile(
-		episode.streamUrl,
-		filePath,
-		probe,
-		DOWNLOAD_CHUNK_SIZE,
-		onProgress,
-	);
+	// Clean up a half-written file on any mid-stream failure so a later attempt
+	// can't mistake a truncated partial for a complete download — the legacy
+	// createBinary path was atomic, but chunked appendBinary is not.
+	let total: number;
+	try {
+		total = await writeStreamedFile(
+			episode.streamUrl,
+			filePath,
+			probe,
+			DOWNLOAD_CHUNK_SIZE,
+			onProgress,
+		);
+	} catch (error) {
+		await deleteEpisodeFile(filePath);
+		throw error;
+	}
+	if (probe.totalSize !== null && total !== probe.totalSize) {
+		await deleteEpisodeFile(filePath);
+		throw new Error(
+			`Incomplete download: got ${total} of ${probe.totalSize} bytes.`,
+		);
+	}
+
 	downloadedEpisodes.addEpisode(episode, filePath, total);
 	return filePath;
 }
@@ -295,25 +322,29 @@ export default async function downloadEpisodeWithNotice(
 	const SOME_LARGE_INT_SO_THE_BOX_DOESNT_AUTO_CLOSE = 999999999;
 	const notice = new Notice(doc, SOME_LARGE_INT_SO_THE_BOX_DOESNT_AUTO_CLOSE);
 
-	// `finally` schedules the dismissal exactly once for every terminal state —
-	// success, write failure, download error, or the non-playable rejection below
-	// — so a failed download's notice can no longer linger forever (#DL-03).
-	try {
-		const key = episode.streamUrl || episode.title;
+	const showSuccess = () =>
+		update((bodyEl) =>
+			bodyEl.createEl("p", {
+				text: `Successfully downloaded "${episode.title}" from ${episode.podcastName}.`,
+			}),
+		);
 
-		// Collapse a concurrent download of the same episode into the in-flight one
-		// instead of starting a second full transfer.
+	// This UX wrapper reports every failure as a Notice and always dismisses it
+	// exactly once (#DL-03), then rethrows so the (fire-and-forget) caller can log
+	// it. Callers that need the resulting path call downloadEpisodeToDisk directly.
+	try {
+		// Dedupe by episode identity (podcast + title — the same key the download
+		// registry uses), so a double-tap collapses onto one transfer while two
+		// genuinely different episodes never block each other.
+		const key = `${episode.podcastName} ${episode.title}`;
+
 		const inProgress = downloadsInFlight.get(key);
 		if (inProgress) {
 			update((bodyEl) =>
 				bodyEl.createEl("p", { text: "Already downloading this episode..." }),
 			);
 			await inProgress;
-			update((bodyEl) =>
-				bodyEl.createEl("p", {
-					text: `Successfully downloaded "${episode.title}" from ${episode.podcastName}.`,
-				}),
-			);
+			showSuccess();
 			return;
 		}
 
@@ -339,11 +370,7 @@ export default async function downloadEpisodeWithNotice(
 			downloadsInFlight.delete(key);
 		}
 
-		update((bodyEl) =>
-			bodyEl.createEl("p", {
-				text: `Successfully downloaded "${episode.title}" from ${episode.podcastName}.`,
-			}),
-		);
+		showSuccess();
 	} catch (error: unknown) {
 		update((bodyEl) => {
 			const errorEl = bodyEl.createEl("p", {
@@ -351,6 +378,7 @@ export default async function downloadEpisodeWithNotice(
 			});
 			errorEl.style.fontStyle = "italic";
 		});
+		throw error;
 	} finally {
 		setTimeout(() => notice.hide(), 10000);
 	}

--- a/src/downloadEpisode.ts
+++ b/src/downloadEpisode.ts
@@ -76,6 +76,217 @@ async function downloadFile(
 	}
 }
 
+// ---- Streaming download (issue #113) ---------------------------------------
+// Mobile WebViews have a tight per-process memory budget. Buffering a whole
+// episode (hundreds of MB) via requestUrl().arrayBuffer — plus the native->JS
+// bridge copy — used to OOM-kill Obsidian on iOS. Instead we pull the file in
+// bounded HTTP Range chunks and append each straight to disk, so peak heap
+// stays at roughly one chunk regardless of episode size.
+
+const DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024; // 4 MiB per range request
+
+interface BinaryAppendAdapter {
+	writeBinary(path: string, data: ArrayBuffer): Promise<void>;
+	appendBinary?(path: string, data: ArrayBuffer): Promise<void>;
+}
+
+interface RangeProbe {
+	firstChunk: ArrayBuffer;
+	contentType: string;
+	supportsRange: boolean;
+	totalSize: number | null;
+}
+
+// In-flight downloads keyed by stream URL: collapses duplicate/concurrent
+// requests for the same episode (e.g. a double-tap, or several queued at once)
+// into a single transfer so they can't stack N full downloads in memory.
+const downloadsInFlight = new Map<string, Promise<string>>();
+
+function readHeader(
+	headers: Record<string, string> | undefined,
+	name: string,
+): string | undefined {
+	if (!headers) return undefined;
+	const direct = headers[name] ?? headers[name.toLowerCase()];
+	if (direct !== undefined) return direct;
+	const lower = name.toLowerCase();
+	for (const key of Object.keys(headers)) {
+		if (key.toLowerCase() === lower) return headers[key];
+	}
+	return undefined;
+}
+
+// Fetch the first chunk with a Range header and learn whether the server
+// supports ranged requests (206 + Content-Range) and the total size. A server
+// that ignores Range answers 200 with the whole body — the legacy single-buffer
+// behaviour — which we detect and treat as already-complete.
+async function probeAndFetchFirstChunk(
+	url: string,
+	chunkSize: number,
+): Promise<RangeProbe> {
+	const encodedUrl = encodeUrlForRequest(url);
+	const response = await requestUrl({
+		url: encodedUrl,
+		method: "GET",
+		headers: { Range: `bytes=0-${chunkSize - 1}` },
+		throw: false,
+	});
+
+	if (response.status !== 200 && response.status !== 206) {
+		throw new Error(`Could not download episode (HTTP ${response.status}).`);
+	}
+
+	const contentType = readHeader(response.headers, "content-type") ?? "";
+	const supportsRange = response.status === 206;
+
+	let totalSize: number | null = null;
+	const contentRange = readHeader(response.headers, "content-range");
+	if (supportsRange && contentRange) {
+		const match = contentRange.match(/\/(\d+)\s*$/);
+		if (match) totalSize = Number.parseInt(match[1], 10);
+	}
+	if (totalSize === null) {
+		const contentLength = readHeader(response.headers, "content-length");
+		if (contentLength) {
+			const parsed = Number.parseInt(contentLength, 10);
+			if (Number.isFinite(parsed)) totalSize = parsed;
+		}
+	}
+
+	return {
+		firstChunk: response.arrayBuffer,
+		contentType,
+		supportsRange,
+		totalSize,
+	};
+}
+
+// Write the already-fetched first chunk, then pull the remaining bytes in
+// bounded Range requests, appending each straight to disk. Peak memory is one
+// chunk, not the whole file. Returns the total number of bytes written.
+async function writeStreamedFile(
+	url: string,
+	filePath: string,
+	probe: RangeProbe,
+	chunkSize: number,
+	onProgress?: (written: number, total: number | null) => void,
+): Promise<number> {
+	const adapter = app.vault.adapter as unknown as BinaryAppendAdapter;
+
+	await adapter.writeBinary(filePath, probe.firstChunk);
+	let written = probe.firstChunk.byteLength;
+	onProgress?.(written, probe.totalSize);
+
+	// Server returned the whole body (ignored Range), or this adapter can't
+	// append: the first response already holds everything we can get.
+	if (!probe.supportsRange || typeof adapter.appendBinary !== "function") {
+		return written;
+	}
+
+	const encodedUrl = encodeUrlForRequest(url);
+	for (;;) {
+		if (probe.totalSize !== null && written >= probe.totalSize) break;
+
+		const rangeEnd =
+			probe.totalSize !== null
+				? Math.min(written + chunkSize, probe.totalSize) - 1
+				: written + chunkSize - 1;
+
+		const response = await requestUrl({
+			url: encodedUrl,
+			method: "GET",
+			headers: { Range: `bytes=${written}-${rangeEnd}` },
+			throw: false,
+		});
+
+		if (response.status === 416) break; // requested past end of file
+		if (response.status !== 206) {
+			throw new Error(
+				`Range request failed (HTTP ${response.status}) at byte ${written}.`,
+			);
+		}
+
+		const chunk = response.arrayBuffer;
+		if (chunk.byteLength === 0) break;
+
+		await adapter.appendBinary(filePath, chunk);
+		written += chunk.byteLength;
+		onProgress?.(written, probe.totalSize);
+
+		// Unknown total: a short chunk means we hit EOF.
+		if (probe.totalSize === null && chunk.byteLength < chunkSize) break;
+	}
+
+	return written;
+}
+
+// Download an episode to a vault file with bounded memory. Falls back to the
+// legacy whole-file path only when the adapter lacks binary append (so we never
+// truncate the output). Returns the on-disk path.
+async function downloadEpisodeToDisk(
+	episode: Episode,
+	downloadPathTemplate: string,
+	onProgress?: (written: number, total: number | null) => void,
+): Promise<string> {
+	const adapter = app.vault.adapter as unknown as BinaryAppendAdapter;
+	const canStream =
+		typeof adapter.writeBinary === "function" &&
+		typeof adapter.appendBinary === "function";
+
+	if (!canStream) {
+		// Legacy fallback (adapters without binary append): a single buffer.
+		const { data, contentType } = await downloadFile(episode.streamUrl);
+		const extension =
+			inferFileExtensionFromDownload(episode, data, contentType) ?? "mp3";
+		if (!downloadAppearsPlayable(contentType, extension, episode.mediaType)) {
+			throw new Error(
+				`Downloaded file is not an audio or video file (type "${contentType}").`,
+			);
+		}
+		await createEpisodeFile({ episode, downloadPathTemplate, data, extension });
+		return safeDownloadFilePath(downloadPathTemplate, episode, extension);
+	}
+
+	const probe = await probeAndFetchFirstChunk(
+		episode.streamUrl,
+		DOWNLOAD_CHUNK_SIZE,
+	);
+	const extension =
+		inferFileExtensionFromDownload(
+			episode,
+			probe.firstChunk,
+			probe.contentType,
+		) ?? "mp3";
+	if (
+		!downloadAppearsPlayable(probe.contentType, extension, episode.mediaType)
+	) {
+		throw new Error(
+			`Downloaded file is not an audio or video file (type "${probe.contentType}").`,
+		);
+	}
+
+	const filePath = safeDownloadFilePath(downloadPathTemplate, episode, extension);
+
+	const existing = app.vault.getAbstractFileByPath(filePath);
+	if (existing instanceof TFile) {
+		downloadedEpisodes.addEpisode(episode, filePath, existing.stat.size);
+		return filePath;
+	}
+
+	const folderPath = filePath.split("/").slice(0, -1).join("/");
+	await ensureFolderExists(folderPath);
+
+	const total = await writeStreamedFile(
+		episode.streamUrl,
+		filePath,
+		probe,
+		DOWNLOAD_CHUNK_SIZE,
+		onProgress,
+	);
+	downloadedEpisodes.addEpisode(episode, filePath, total);
+	return filePath;
+}
+
 export default async function downloadEpisodeWithNotice(
 	episode: Episode,
 	downloadPathTemplate: string,
@@ -88,74 +299,58 @@ export default async function downloadEpisodeWithNotice(
 	// success, write failure, download error, or the non-playable rejection below
 	// — so a failed download's notice can no longer linger forever (#DL-03).
 	try {
-		update((bodyEl) => bodyEl.createEl("p", { text: "Starting download..." }));
+		const key = episode.streamUrl || episode.title;
 
-		update((bodyEl) => {
-			bodyEl.createEl("p", { text: "Downloading..." });
-		});
-
-		const { data, contentType } = await downloadFile(episode.streamUrl, {
-			onFinished: () => {
-				update((bodyEl) =>
-					bodyEl.createEl("p", { text: "Download complete!" }),
-				);
-			},
-			onError: (error) => {
-				update((bodyEl) =>
-					bodyEl.createEl("p", {
-						text: `Download failed: ${error.message}`,
-					}),
-				);
-			},
-		});
-
-		const inferredExtension = inferFileExtensionFromDownload(
-			episode,
-			data,
-			contentType,
-		);
-
-		if (
-			!downloadAppearsPlayable(contentType, inferredExtension, episode.mediaType)
-		) {
-			update((bodyEl) => {
-				bodyEl.createEl("p", {
-					text: `Downloaded file is not an audio or video file. It is of type "${contentType}". File: ${data.byteLength} bytes.`,
-				});
-			});
-
-			throw new Error("Not a playable media file");
-		}
-
-		const fileExtension = inferredExtension ?? "mp3";
-
-		try {
-			update((bodyEl) => bodyEl.createEl("p", { text: "Creating file..." }));
-
-			await createEpisodeFile({
-				episode,
-				downloadPathTemplate,
-				data,
-				extension: fileExtension,
-			});
-
+		// Collapse a concurrent download of the same episode into the in-flight one
+		// instead of starting a second full transfer.
+		const inProgress = downloadsInFlight.get(key);
+		if (inProgress) {
+			update((bodyEl) =>
+				bodyEl.createEl("p", { text: "Already downloading this episode..." }),
+			);
+			await inProgress;
 			update((bodyEl) =>
 				bodyEl.createEl("p", {
 					text: `Successfully downloaded "${episode.title}" from ${episode.podcastName}.`,
 				}),
 			);
-		} catch (error: unknown) {
-			update((bodyEl) => {
-				bodyEl.createEl("p", {
-					text: `Failed to create file for downloaded episode "${episode.title}" from ${episode.podcastName}.`,
-				});
-
-				const errorMsgEl = bodyEl.createEl("p", {
-					text: getErrorMessage(error),
-				});
-				errorMsgEl.style.fontStyle = "italic";
-			});
+			return;
 		}
+
+		update((bodyEl) => bodyEl.createEl("p", { text: "Starting download..." }));
+
+		const work = downloadEpisodeToDisk(
+			episode,
+			downloadPathTemplate,
+			(written, total) => {
+				const mb = (written / (1024 * 1024)).toFixed(1);
+				const pct =
+					total && total > 0 ? ` ${Math.round((written / total) * 100)}%` : "";
+				update((bodyEl) =>
+					bodyEl.createEl("p", { text: `Downloading...${pct} (${mb} MB)` }),
+				);
+			},
+		);
+		downloadsInFlight.set(key, work);
+
+		try {
+			await work;
+		} finally {
+			downloadsInFlight.delete(key);
+		}
+
+		update((bodyEl) =>
+			bodyEl.createEl("p", {
+				text: `Successfully downloaded "${episode.title}" from ${episode.podcastName}.`,
+			}),
+		);
+	} catch (error: unknown) {
+		update((bodyEl) => {
+			const errorEl = bodyEl.createEl("p", {
+				text: `Download failed: ${getErrorMessage(error)}`,
+			});
+			errorEl.style.fontStyle = "italic";
+		});
 	} finally {
 		setTimeout(() => notice.hide(), 10000);
 	}


### PR DESCRIPTION
## Problem

Downloading an episode crashes Obsidian on iOS (#113). The download path buffered the **entire** episode in memory — `requestUrl()` → `response.arrayBuffer` → `vault.createBinary` — with no streaming. On iOS's tight per-process WebView memory budget, a large episode (long audio, audiobooks, video) exceeds the limit and the OS kills the app. Desktop has the headroom, so it only reproduces on mobile.

## Fix

Stream the download instead of buffering it:

- **Chunked HTTP Range download** (`download/streaming.ts`): probe the first 4 MiB with a `Range` header, then pull the rest in 4 MiB chunks, appending each straight to disk via `adapter.writeBinary` (first chunk) + `adapter.appendBinary` (rest). Peak heap is ~one chunk regardless of episode size. `requestUrl` is kept (it bypasses mobile CORS); a server that ignores `Range` (answers `200`) falls back to a single whole-file write, and an adapter without binary append falls back to the legacy `createBinary` path — so nothing is ever truncated.
- **Mid-stream failure safety**: a failed/partial transfer deletes the half-written file and is size-validated before being registered, so a truncated partial can't later be served as a complete download (the old `createBinary` path was atomic; chunked append is not).
- **Concurrency**: duplicate/concurrent downloads of the same episode collapse into one in-flight transfer.
- **Skip redundant work**: if the episode is already on disk under its URL's extension, skip the probe entirely (the Download command is ungated and previously re-probed every time).

## Verification

Reproduced and fixed on a physical iPhone (iOS 26.5.1) via the WebKit Web Inspector:

- **Before**: a 5.2h / 218 MB episode buffered whole; 8 concurrent downloads OOM-killed the WebView in ~30s (reproduced).
- **After**: the same episode streams to disk in 4 MiB chunks, byte-perfect (228,751,240 bytes), app stays alive; the 8× concurrent burst now survives. Re-triggering a download of an already-present file dropped from ~1.2s (wasted network probe) to ~20ms with no request.
- Full unit suite green (**753 tests / 66 files**); `vite build` clean.

## Notes

- `src/downloadEpisode.ts` split into focused modules (`download/streaming.ts`, `download/mediaSignatures.ts`) with co-located unit tests; the file drops from 1070 to 837 lines.
- The pre-existing `npm run typecheck` failures are confined to `tests/e2e/` (missing `obsidian-e2e` module) and are unrelated to this change.

Closes #113

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->