### PR TITLE
fix(timestamp): escape live table-cell pipe after an escaped backslash

### DIFF
--- a/src/utility/prepareTimestampInsertion.test.ts
+++ b/src/utility/prepareTimestampInsertion.test.ts
@@ -91,6 +91,24 @@ describe("escapeForTableCell", () => {
 		expect(escapeForTableCell("a \\| b")).toBe("a \\| b");
 	});
 
+	it("escapes a live pipe that follows an escaped backslash (\\\\|)", () => {
+		// `\\|` is an escaped backslash followed by a genuinely live pipe. A
+		// naive `(?<!\\)` lookbehind sees the backslash and skips the pipe,
+		// leaving it active and breaking the row. The even-length (2) backslash
+		// run means the pipe is live and must be escaped.
+		expect(escapeForTableCell("a\\\\|b")).toBe("a\\\\\\|b");
+	});
+
+	it("leaves a pipe escaped after an odd-length backslash run (\\\\\\|)", () => {
+		// Three backslashes = an escaped backslash plus an already-escaped pipe;
+		// the pipe must be left alone so the cell is never double-escaped.
+		expect(escapeForTableCell("a\\\\\\|b")).toBe("a\\\\\\|b");
+	});
+
+	it("escapes both of two adjacent live pipes", () => {
+		expect(escapeForTableCell("a||b")).toBe("a\\|\\|b");
+	});
+
 	it("collapses newlines (LF, CRLF, CR) to single spaces", () => {
 		expect(escapeForTableCell("line1\nline2")).toBe("line1 line2");
 		expect(escapeForTableCell("line1\r\nline2")).toBe("line1 line2");

--- a/src/utility/prepareTimestampInsertion.ts
+++ b/src/utility/prepareTimestampInsertion.ts
@@ -80,9 +80,19 @@ export function isInsideTable(
  * space (a raw newline would end the row) and escape any unescaped pipe (a raw
  * pipe would open a new column). Already-escaped pipes (`\|`) are left alone so
  * the cell is never double-escaped.
+ *
+ * A pipe is "already escaped" only when it follows an odd-length run of
+ * backslashes; an even-length run (including zero) leaves the pipe live. Keying
+ * on the parity of the preceding backslash run - rather than the mere presence
+ * of one backslash - neutralizes pipes after an escaped backslash (`\\|`) and
+ * adjacent pipes (`||`), both of which a simple `(?<!\\)` lookbehind misses.
  */
 export function escapeForTableCell(text: string): string {
-	return text.replace(/\r\n?|\n/g, " ").replace(/(?<!\\)\|/g, "\\|");
+	return text
+		.replace(/\r\n?|\n/g, " ")
+		.replace(/(\\*)\|/g, (match, backslashes: string) =>
+			backslashes.length % 2 === 0 ? `${backslashes}\\|` : match,
+		);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes deepsec finding **`other-escaping-gap-3d20dd1596`** (true-positive).

`escapeForTableCell` in `src/utility/prepareTimestampInsertion.ts` makes a captured timestamp safe to drop into a single GFM table cell by escaping live pipes (a raw `|` would open a new column). It used a negative-lookbehind regex:

```ts
text.replace(/(?<!\\)\|/g, "\\|")
```

The lookbehind treats *any* pipe preceded by a backslash as already escaped. But the sequence `\\|` is an **escaped backslash** followed by a **genuinely live pipe** - the lookbehind sees the backslash, skips the pipe, and leaves it active, breaking the table row. Adjacent pipes (`||`) share the same class of gap.

## Root cause

A pipe is "already escaped" only when it follows an **odd-length** run of backslashes. The old check keyed on the *presence* of one backslash rather than the *parity* of the run, so even-length runs (`\\|`, `\\\\|`, ...) and back-to-back pipes slipped through.

## Fix

Key the escape on backslash-run parity. The greedy `(\\*)` captures the complete run preceding each pipe; an even-length run (including zero) means the pipe is live and gets escaped exactly once, an odd-length run means it is already escaped and is left untouched:

```ts
text
  .replace(/\r\n?|\n/g, " ")
  .replace(/(\\*)\|/g, (match, backslashes) =>
    backslashes.length % 2 === 0 ? `${backslashes}\\|` : match,
  );
```

This neutralizes a pipe inside a table cell regardless of any preceding backslashes, and is strictly more correct than a consuming-group regex like `(^|[^\\])((?:\\\\)*)\|` which mis-handles adjacent pipes (`a||c` -> `a\||c`, leaving the second pipe live).

## Behavior

| input | before | after |
| --- | --- | --- |
| `a\|b` | `a\\\|b` | `a\\\|b` (unchanged - single live pipe) |
| `a\\\|b` (escaped pipe) | `a\\\|b` | `a\\\|b` (unchanged - not double-escaped) |
| `a\\\\\|b` (escaped backslash + live pipe) | `a\\\\\|b` **(bug: pipe live)** | `a\\\\\\\|b` **(fixed)** |
| `a\|\|b` (adjacent) | `a\\\|\|b` **(2nd pipe live)** | `a\\\|\\\|b` **(fixed)** |

(Legitimate/common captures such as `- 0:01:23 ` and a plain `[1:23](obsidian://...)` link are untouched.)

## Tests

Adds unit tests for the escaped-backslash-then-pipe (`a\\|b`), odd-run (`a\\\|b`), and adjacent-pipe (`a||b`) cases in `prepareTimestampInsertion.test.ts`.

## Validation

- `npm run lint`, `format:check`, `typecheck`, `build`, `test` (862 passed) - all green.
- Verified in the isolated worktree Obsidian runtime: plugin loads, and the escaping produces `a\\|b` -> `a\\\|b`, `a||b` -> `a\|\|b` in the Electron V8 runtime.
- Adversarial self-review (200k-case fuzz vs an independent oracle): no live pipe survives, no escaped pipe double-escaped.

## Scope

Single utility + its test. Collision-free with the deepsec-note-injection finding, which owns `TemplateEngine.ts`.