### PR TITLE
fix(template): neutralize feed-controlled note injection

### DIFF
--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -41,6 +41,15 @@ describe("replaceIllegalFileNameCharactersInString (via DownloadPathTemplateEngi
 		expect(sanitizeTitle("a#b%c&d{e}f")).toBe("abcdef");
 	});
 
+	it("strips square brackets so a feed title cannot inject a wikilink", () => {
+		// '[' and ']' are wikilink-significant; a feed <title> must not be able to
+		// smuggle a [[wikilink]] through a file-name/link tag (other-wikilink-injection).
+		expect(sanitizeTitle("Real]] [[Victims Private Note")).toBe(
+			"Real Victims Private Note",
+		);
+		expect(sanitizeTitle("a[b]c")).toBe("abc");
+	});
+
 	it("replaces every control character with a space (global), not just the first", () => {
 		expect(sanitizeTitle("a\nb\nc")).toBe("a b c");
 		expect(sanitizeTitle("a\tb\rc")).toBe("a b c");
@@ -244,10 +253,12 @@ describe("NoteTemplateEngine renders URL tags verbatim (#160 review)", () => {
 
 	it("does not mutate {{url}}/{{episodeurl}} — local-file wikilinks pass through", () => {
 		// For local-file episodes episode.url is a wikilink, not a URL
-		// (getContextMenuHandler stores generateMarkdownLink). The engine must not
-		// strip characters from it, or the link would point at a different file.
+		// (getContextMenuHandler stores generateMarkdownLink, and the episode has
+		// podcastName "local file"). The engine must not strip characters from a
+		// trusted vault link, or it would point at a different file.
 		const localFile = {
 			...demoEpisode,
+			podcastName: "local file",
 			url: '[[Talk "A".mp3]]',
 		} as Episode;
 		expect(NoteTemplateEngine("{{url}}", localFile)).toBe('[[Talk "A".mp3]]');
@@ -289,7 +300,9 @@ describe("default note template renders valid frontmatter (#160)", () => {
 			...demoEpisode,
 			title: 'Why "AI": a deep dive: part 2',
 			url: '[[Audio/Talk "A".mp3]]',
-			podcastName: "My Show",
+			// A local-file episode (podcastName "local file") is the only case where
+			// {{url}} is a trusted vault wikilink that passes through verbatim.
+			podcastName: "local file",
 		};
 		const rendered = NoteTemplateEngine(
 			DEFAULT_SETTINGS.note.template,
@@ -301,7 +314,7 @@ describe("default note template renders valid frontmatter (#160)", () => {
 
 		// The podcast link is quoted so its leading [[ isn't read as a flow sequence.
 		expect(line("podcast")).toBe(
-			'podcast: "[[PodNotes/Podcasts/My Show|My Show]]"',
+			'podcast: "[[PodNotes/Podcasts/local file|local file]]"',
 		);
 		// The url is NOT in the frontmatter (it could carry a quote for local files).
 		expect(line("url")).toBeUndefined();
@@ -373,17 +386,19 @@ describe("FeedNoteTemplateEngine (#163)", () => {
 		expect(FeedNoteTemplateEngine("{{url}}", { ...feed, link: undefined })).toBe("");
 	});
 
-	it("strips quote/backslash from URL tags so quoted YAML frontmatter stays valid", () => {
+	it("percent-encodes quote/backslash in URL tags so quoted YAML frontmatter and Markdown targets stay valid", () => {
 		const malformed: PodcastFeed = {
 			...feed,
 			link: 'https://example.com/a?x="b"\\c',
 			artworkUrl: 'https://example.com/art".png',
 		};
+		// Encoded (not stripped) so the value stays a working URL while no raw quote
+		// or backslash can terminate the quoted YAML scalar.
 		expect(FeedNoteTemplateEngine("{{url}}", malformed)).toBe(
-			"https://example.com/a?x=bc",
+			"https://example.com/a?x=%22b%22%5Cc",
 		);
 		expect(FeedNoteTemplateEngine("{{artwork}}", malformed)).toBe(
-			"https://example.com/art.png",
+			"https://example.com/art%22.png",
 		);
 	});
 });
@@ -652,5 +667,210 @@ describe("TranscriptTemplateEngine new tags (#75/#34/#88)", () => {
 		expect(
 			TranscriptTemplateEngine("[{{episodeNumber}}][{{duration}}]", blank, "t"),
 		).toBe("[][]");
+	});
+});
+
+describe("feed content injection is neutralized (deepsec other-markdown-injection)", () => {
+	beforeEach(() => {
+		plugin.set({
+			settings: {
+				feedNote: { path: "PodNotes/Podcasts/{{podcast}}.md" },
+				savedFeeds: {},
+			},
+		} as never);
+		downloadedEpisodes.set({});
+	});
+
+	// The headline attack from the finding: a crafted artwork URL tries to break
+	// out of the default template's `![]({{artwork}})` to inject extra external
+	// images (tracking pixels) and links.
+	it("prevents an artwork URL from breaking out of ![]() to inject images/links", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			artworkUrl: "x)![pwn](http://attacker.example/leak.png) [click](http://phish)",
+		};
+		const rendered = NoteTemplateEngine("![]({{artwork}})", malicious);
+
+		// Exactly one image, and the wrapping parens are the only parens left, so
+		// nothing escaped the target. The attacker's image/link markdown is inert.
+		expect((rendered.match(/!\[/g) ?? []).length).toBe(1);
+		expect(rendered).toMatch(/^!\[\]\([^()]*\)$/);
+		expect(rendered).not.toContain("](http://attacker.example/leak.png)");
+		expect(rendered).not.toContain("[click](http://phish)");
+	});
+
+	it("neutralizes a feed {{url}}/{{stream}} that injects Markdown on a bare line", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			podcastName: "Evil Pod", // not a local file -> feed-controlled URL
+			url: "x](http://phish) [more](http://evil)",
+			streamUrl: "x)![pwn](http://attacker.example/s.png)",
+		};
+		const url = NoteTemplateEngine("{{url}}", malicious);
+		const stream = NoteTemplateEngine("{{stream}}", malicious);
+
+		for (const value of [url, stream]) {
+			// No raw Markdown link/image metacharacters survive to form a link/image.
+			expect(value).not.toMatch(/[[\]()]/);
+			expect(value).not.toContain("](");
+		}
+	});
+
+	it("collapses newlines and neutralizes Markdown in a raw {{title}}", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			title:
+				"Real Title\n\n# Injected Heading\n\n![pixel](http://attacker.example/t.png)",
+		};
+		const rendered = NoteTemplateEngine("# {{title}}", malicious);
+
+		// Stays a single line: the title can no longer inject extra blocks/headings.
+		expect(rendered.split("\n")).toHaveLength(1);
+		// The image marker is escaped so it cannot load an external (tracking) image.
+		expect(rendered).not.toMatch(/!\[pixel\]\(/);
+		expect(rendered).toContain("\\[pixel\\]");
+	});
+
+	it("renders an injected ```dataviewjs code block inert while keeping normal formatting", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			// htmlToMarkdown is a passthrough in the test mock, so this is what a feed
+			// <content:encoded> would yield after conversion.
+			content:
+				"```dataviewjs\napp.vault.getFiles().forEach(f => f.unlink())\n```\n\nSome [docs](https://example.com) and a normal block:\n\n```js\nconsole.log(1)\n```",
+		};
+		const rendered = NoteTemplateEngine("{{content}}", malicious);
+
+		// The executable language is dropped; the code remains visible but inert.
+		expect(rendered).not.toContain("```dataviewjs");
+		expect(rendered).toContain("```text");
+		expect(rendered).toContain("app.vault.getFiles()");
+		// Legitimate formatting (links, ordinary code fences) is preserved.
+		expect(rendered).toContain("[docs](https://example.com)");
+		expect(rendered).toContain("```js");
+	});
+
+	it("neutralizes ~~~dataview and case/spacing variants of executable fences", () => {
+		const variants: Episode = {
+			...demoEpisode,
+			content: "~~~ DataViewJS\n42\n~~~",
+		};
+		const rendered = NoteTemplateEngine("{{content}}", variants);
+		expect(rendered.toLowerCase()).not.toContain("dataviewjs");
+		expect(rendered).toContain("~~~text");
+		expect(rendered).toContain("42");
+	});
+
+	// Regression: htmlToMarkdown nests feed HTML in blockquotes/callouts and list
+	// items, which would hide an executable fence from a line-anchored scanner.
+	it("neutralizes a dataviewjs fence nested in a blockquote, callout, or list item", () => {
+		const blockquoted: Episode = {
+			...demoEpisode,
+			content: "> ```dataviewjs\n> evil()\n> ```",
+		};
+		const callout: Episode = {
+			...demoEpisode,
+			content: "> [!note]\n> ```dataview\n> TABLE file.name\n> ```",
+		};
+		const listIndented: Episode = {
+			...demoEpisode,
+			content: "- item\n\n    ```dataviewjs\n    evil()\n    ```",
+		};
+
+		for (const ep of [blockquoted, callout, listIndented]) {
+			const rendered = NoteTemplateEngine("{{content}}", ep).toLowerCase();
+			expect(rendered).not.toContain("```dataviewjs");
+			expect(rendered).not.toContain("```dataview");
+		}
+	});
+
+	// Regression: a closing fence shorter than the opener must not desync a scanner
+	// into skipping a later executable fence.
+	it("neutralizes a dataviewjs fence that follows a longer fenced block", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			content: "`````text\n```\n`````\n```dataviewjs\nevil()\n```",
+		};
+		const rendered = NoteTemplateEngine("{{content}}", malicious);
+		expect(rendered).not.toContain("```dataviewjs");
+	});
+
+	it("preserves legitimate episode metadata verbatim", () => {
+		// A normal episode must be unaffected by the sanitizers.
+		expect(NoteTemplateEngine("# {{title}}", demoEpisode)).toBe("# Episode 1");
+		expect(NoteTemplateEngine("{{url}}|{{artwork}}", demoEpisode)).toBe(
+			"https://example.com/ep1|https://example.com/ep1.png",
+		);
+		// A title with ordinary punctuation (dots, colons, quotes, parens) is kept.
+		const punctuated: Episode = {
+			...demoEpisode,
+			title: 'Ep. 5: A.I. & You (Part 1)',
+		};
+		expect(NoteTemplateEngine("# {{title}}", punctuated)).toBe(
+			"# Ep. 5: A.I. & You (Part 1)",
+		);
+	});
+});
+
+describe("feed-controlled wikilink injection is neutralized (deepsec other-wikilink-injection)", () => {
+	beforeEach(() => {
+		plugin.set({
+			settings: {
+				feedNote: { path: "PodNotes/Podcasts/{{podcast}}.md" },
+				savedFeeds: {},
+			},
+		} as never);
+		downloadedEpisodes.set({});
+	});
+
+	it("strips brackets from a feed title so getFeedNoteWikilink emits a single wikilink", () => {
+		const link = getFeedNoteWikilink("Real]] [[Victims Private Note");
+		expect(link).toBe(
+			"[[PodNotes/Podcasts/Real Victims Private Note|Real Victims Private Note]]",
+		);
+		// No extra wikilink boundary smuggled in.
+		expect(link).not.toContain("]] [[");
+	});
+
+	it("prevents a feed podcastName from injecting a wikilink into {{podcastlink}}/{{podcast}}/{{safetitle}}", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			podcastName: "Real]] [[Victims Private Note",
+		};
+		const podcastlink = NoteTemplateEngine("{{podcastlink}}", malicious);
+		expect(podcastlink).not.toContain("]] [[");
+		expect(podcastlink).toBe(
+			"[[PodNotes/Podcasts/Real Victims Private Note|Real Victims Private Note]]",
+		);
+
+		expect(NoteTemplateEngine("{{podcast}}", malicious)).toBe(
+			"Real Victims Private Note",
+		);
+		expect(
+			NoteTemplateEngine("{{safetitle}}", {
+				...demoEpisode,
+				title: "Title]] [[Injected",
+			}),
+		).toBe("Title Injected");
+	});
+
+	it("keeps a real local-file wikilink in {{url}} intact (no false positives)", () => {
+		const local: Episode = {
+			...demoEpisode,
+			podcastName: "local file",
+			url: "[[Audio/My Talk.mp3]]",
+		};
+		expect(NoteTemplateEngine("{{url}}", local)).toBe("[[Audio/My Talk.mp3]]");
+	});
+
+	it("neutralizes a feed episode whose url forges a wikilink", () => {
+		const forged: Episode = {
+			...demoEpisode,
+			podcastName: "Evil Pod", // a feed, so the url is untrusted
+			url: "[[Victims Private Note]]",
+		};
+		const rendered = NoteTemplateEngine("{{url}}", forged);
+		expect(rendered).not.toContain("[[");
+		expect(rendered).not.toContain("]]");
 	});
 });

--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -253,12 +253,13 @@ describe("NoteTemplateEngine renders URL tags verbatim (#160 review)", () => {
 
 	it("does not mutate {{url}}/{{episodeurl}} — local-file wikilinks pass through", () => {
 		// For local-file episodes episode.url is a wikilink, not a URL
-		// (getContextMenuHandler stores generateMarkdownLink, and the episode has
-		// podcastName "local file"). The engine must not strip characters from a
-		// trusted vault link, or it would point at a different file.
+		// (getContextMenuHandler stores generateMarkdownLink, podcastName "local
+		// file", and a plugin-set filePath). The engine must not strip characters
+		// from a trusted vault link, or it would point at a different file.
 		const localFile = {
 			...demoEpisode,
 			podcastName: "local file",
+			filePath: "Audio/Talk \"A\".mp3",
 			url: '[[Talk "A".mp3]]',
 		} as Episode;
 		expect(NoteTemplateEngine("{{url}}", localFile)).toBe('[[Talk "A".mp3]]');
@@ -296,14 +297,15 @@ describe("default note template renders valid frontmatter (#160)", () => {
 		// title carries quotes/colons and {{url}} is a wikilink containing a quote.
 		// Both must stay in the BODY (never a quoted frontmatter scalar) so the
 		// frontmatter always parses. See issue #160 review.
-		const episode: Episode = {
+		const episode = {
 			...demoEpisode,
 			title: 'Why "AI": a deep dive: part 2',
 			url: '[[Audio/Talk "A".mp3]]',
-			// A local-file episode (podcastName "local file") is the only case where
-			// {{url}} is a trusted vault wikilink that passes through verbatim.
+			// A local-file episode (podcastName "local file" + plugin-set filePath) is
+			// the only case where {{url}} is a trusted vault wikilink passed verbatim.
 			podcastName: "local file",
-		};
+			filePath: 'Audio/Talk "A".mp3',
+		} as Episode;
 		const rendered = NoteTemplateEngine(
 			DEFAULT_SETTINGS.note.template,
 			episode,
@@ -855,11 +857,12 @@ describe("feed-controlled wikilink injection is neutralized (deepsec other-wikil
 	});
 
 	it("keeps a real local-file wikilink in {{url}} intact (no false positives)", () => {
-		const local: Episode = {
+		const local = {
 			...demoEpisode,
 			podcastName: "local file",
+			filePath: "Audio/My Talk.mp3", // plugin-set marker; a feed cannot forge it
 			url: "[[Audio/My Talk.mp3]]",
-		};
+		} as Episode;
 		expect(NoteTemplateEngine("{{url}}", local)).toBe("[[Audio/My Talk.mp3]]");
 	});
 
@@ -870,6 +873,22 @@ describe("feed-controlled wikilink injection is neutralized (deepsec other-wikil
 			url: "[[Victims Private Note]]",
 		};
 		const rendered = NoteTemplateEngine("{{url}}", forged);
+		expect(rendered).not.toContain("[[");
+		expect(rendered).not.toContain("]]");
+	});
+
+	it("does not trust a feed whose <title> is forged to 'local file' (no filePath) — P1 #228", () => {
+		// isLocalFile() alone (podcastName === "local file") is feed-controlled: the
+		// feed parser sets podcastName from the channel <title>. Without a plugin-set
+		// filePath the url stays untrusted and must be sanitized, so the bare {{url}}
+		// line cannot be used to inject a wikilink/Markdown after this forgery.
+		const forgedLocal: Episode = {
+			...demoEpisode,
+			podcastName: "local file", // forged feed title, but NO filePath
+			feedUrl: "https://evil.example/feed.xml",
+			url: "[[Victims Private Note]]",
+		};
+		const rendered = NoteTemplateEngine("{{url}}", forgedLocal);
 		expect(rendered).not.toContain("[[");
 		expect(rendered).not.toContain("]]");
 	});

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -12,6 +12,7 @@ import { parseEpisodeNumberFromTitle } from "./utility/parseEpisodeNumber";
 import buildEpisodeResumeLink from "./utility/buildEpisodeResumeLink";
 import addExtension from "./utility/addExtension";
 import { enforceMaxPathLength } from "./utility/enforceMaxPathLength";
+import { isLocalFile } from "./utility/isLocalFile";
 import type { PodcastSegmentTimes } from "./utility/podcastSegment";
 import type { Chapter } from "./types/Chapter";
 import { normalizeChapters } from "./utility/normalizeChapters";
@@ -166,6 +167,75 @@ function escapeMarkdownText(text: string): string {
 		.replace(/([`*_{}[\]()#+.!|-])/g, "\\$1");
 }
 
+/**
+ * Neutralize Markdown/HTML injection in a raw, feed-controlled single-line value
+ * (an episode/feed title or author) while keeping it human-readable. Newlines and
+ * other control characters are collapsed to spaces so the value can never break
+ * out of its line (e.g. the `# {{title}}` heading) and inject extra blocks, and
+ * the characters that introduce links, images, inline code, or raw HTML are
+ * escaped so a crafted title cannot embed a tracking pixel, phishing link, or
+ * markup. Ordinary punctuation (dots, dashes, parentheses, colons, quotes) is
+ * preserved so legitimate titles render verbatim - this is deliberately lighter
+ * than `escapeMarkdownText` (which backslash-escapes `.`/`-`/`(`/`)` etc.), which
+ * would make a normal title like "Ep. 5 - A.I. (Part 1)" unreadable in source.
+ */
+function sanitizeInlineText(text: string): string {
+	return (
+		text
+			// Collapse control characters (newlines, tabs, carriage returns) to a
+			// single space so the value can never inject extra lines or blocks.
+			// eslint-disable-next-line no-control-regex
+			.replace(/[\u0000-\u001f\u007f]+/g, " ")
+			// Neutralize raw HTML and the link/image/inline-code metacharacters so a
+			// crafted value cannot embed a tracking pixel, phishing link, or markup.
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/([`[\]])/g, "\\$1")
+			.trim()
+	);
+}
+
+/**
+ * Render inert any executable Dataview code fence (```dataviewjs / ```dataview,
+ * including ~~~ fences) that a feed smuggled through `htmlToMarkdown`, in ANY
+ * Markdown container - top level, blockquote, callout, or list item - so the
+ * blockquote/list-indent nesting `htmlToMarkdown` produces cannot hide it.
+ *
+ * A run of three or more fence characters immediately followed by one of these
+ * language tokens only ever occurs as a code-fence info string, so rewriting that
+ * token to a non-executable one is always safe regardless of container or whether
+ * the fence is technically the opener or closer; ordinary code blocks and the rest
+ * of the show-note formatting are left intact. Feed content is never a legitimate
+ * source of executable Dataview (a feed cannot author a query against the reader's
+ * vault), so this has no false positives on genuine show notes.
+ */
+function neutralizeExecutableCodeBlocks(markdown: string): string {
+	return markdown.replace(
+		/(`{3,}|~{3,})[ \t]*(?:dataviewjs|dataview)\b/gi,
+		"$1text",
+	);
+}
+
+/**
+ * Convert feed-controlled HTML to Markdown and render any executable Dataview code
+ * fence inert. `htmlToMarkdown` strips active HTML (scripts, `javascript:`), and
+ * this additionally closes the `<pre><code class="language-dataviewjs">` ->
+ * ```dataviewjs code-execution path.
+ *
+ * Legitimate rich-text formatting in show notes (links, images, ordinary code
+ * blocks) is intentionally preserved: rendering the feed's own show notes is the
+ * purpose of {{description}}/{{content}}. That means a feed can still place an
+ * external image (a reader can disable external image loading in Obsidian) or a
+ * literal [[wikilink]] in this free-text body; unlike the structured tags
+ * ({{title}}, {{podcastlink}}, the URL tags) these are accepted as show-note
+ * content. Inline Dataview queries (`= ...`/`$= ...`) are a known residual of the
+ * same speculative, Dataview-must-be-installed class and are not rewritten here to
+ * avoid mangling legitimate inline code in programming show notes.
+ */
+function feedHtmlToMarkdown(html: string): string {
+	return neutralizeExecutableCodeBlocks(htmlToMarkdown(html));
+}
+
 function formatTemplateChapters(
 	chapters: Chapter[] | undefined,
 	prependToLines?: string,
@@ -191,10 +261,18 @@ export function NoteTemplateEngine(
 ) {
 	const [replacer, addTag] = useTemplateEngine();
 
-	addTag("title", episode.title);
+	// For a local file episode.url is a vault-generated wikilink (trusted, and
+	// mutating it would break the link); for a feed episode it is attacker-
+	// controlled, so it is sanitized so it cannot inject Markdown/wikilinks on the
+	// bare `{{url}}` line. See note-injection findings.
+	const episodeUrl = isLocalFile(episode)
+		? episode.url
+		: sanitizeUrlForTemplate(episode.url);
+
+	addTag("title", sanitizeInlineText(episode.title));
 	addTag("description", (prependToLines?: string) => {
 		// reduce multiple new lines
-		const sanitizeDescription = htmlToMarkdown(episode.description).replace(
+		const sanitizeDescription = feedHtmlToMarkdown(episode.description).replace(
 			/\n{3,}/g,
 			"\n\n",
 		);
@@ -209,17 +287,17 @@ export function NoteTemplateEngine(
 	});
 	addTag("content", (prependToLines?: string) => {
 		if (prependToLines) {
-			return htmlToMarkdown(episode.content)
+			return feedHtmlToMarkdown(episode.content)
 				.split("\n")
 				.map((str) => `${prependToLines}${str}`)
 				.join("\n");
 		}
 
-		return htmlToMarkdown(episode.content);
+		return feedHtmlToMarkdown(episode.content);
 	});
 	addTag("safetitle", replaceIllegalFileNameCharactersInString(episode.title));
-	addTag("stream", episode.streamUrl);
-	addTag("url", episode.url);
+	addTag("stream", sanitizeUrlForTemplate(episode.streamUrl));
+	addTag("url", episodeUrl);
 	addTag("date", (format?: string) =>
 		episode.episodeDate
 			? formatDate(episode.episodeDate, format ?? "YYYY-MM-DD")
@@ -249,17 +327,22 @@ export function NoteTemplateEngine(
 		"podcast",
 		replaceIllegalFileNameCharactersInString(episode.podcastName),
 	);
-	addTag("artwork", episode.artworkUrl ?? "");
+	addTag("artwork", sanitizeUrlForTemplate(episode.artworkUrl ?? ""));
 
 	// Feed-scoped tags so an episode note can reference its parent podcast feed
 	// without changing the meaning of the existing {{url}}/{{artwork}} tags
 	// (which always describe the episode itself). See issue #163.
-	addTag("episodeurl", episode.url);
-	addTag("episodeartwork", episode.artworkUrl ?? "");
-	addTag("feedurl", episode.feedUrl ?? "");
+	addTag("episodeurl", episodeUrl);
+	addTag("episodeartwork", sanitizeUrlForTemplate(episode.artworkUrl ?? ""));
+	addTag("feedurl", sanitizeUrlForTemplate(episode.feedUrl ?? ""));
 	const parentFeed =
 		get(plugin)?.settings?.savedFeeds?.[episode.podcastName];
-	addTag("feedartwork", parentFeed?.artworkUrl ?? episode.artworkUrl ?? "");
+	addTag(
+		"feedartwork",
+		sanitizeUrlForTemplate(
+			parentFeed?.artworkUrl ?? episode.artworkUrl ?? "",
+		),
+	);
 	// A ready-made wikilink to the parent feed's note, pointing at the same file
 	// createFeedNote writes (derived from the feed-note path setting).
 	addTag("podcastlink", getFeedNoteWikilink(episode.podcastName));
@@ -371,16 +454,19 @@ export function TranscriptTemplateEngine(
 	addTag("transcript", transcription);
 	addTag("description", (prependToLines?: string) => {
 		if (prependToLines) {
-			return htmlToMarkdown(episode.description)
+			return feedHtmlToMarkdown(episode.description)
 				.split("\n")
 				.map((str) => `${prependToLines}${str}`)
 				.join("\n");
 		}
 
-		return htmlToMarkdown(episode.description);
+		return feedHtmlToMarkdown(episode.description);
 	});
-	addTag("url", episode.url);
-	addTag("artwork", episode.artworkUrl ?? "");
+	addTag(
+		"url",
+		isLocalFile(episode) ? episode.url : sanitizeUrlForTemplate(episode.url),
+	);
+	addTag("artwork", sanitizeUrlForTemplate(episode.artworkUrl ?? ""));
 
 	return replacer(template);
 }
@@ -391,20 +477,22 @@ export function FeedNoteTemplateEngine(template: string, feed: PodcastFeed) {
 	const safeTitle = replaceIllegalFileNameCharactersInString(feed.title);
 
 	// In a feed note the subject is the feed, so {{url}}/{{artwork}} describe the
-	// feed (mirroring how they describe the episode in NoteTemplateEngine).
-	addTag("title", feed.title);
+	// feed (mirroring how they describe the episode in NoteTemplateEngine). The raw
+	// {{title}}/{{author}} are feed-controlled, so they are neutralized so a crafted
+	// feed cannot inject Markdown/HTML into the note body.
+	addTag("title", sanitizeInlineText(feed.title));
 	addTag("safetitle", safeTitle);
 	addTag("podcast", safeTitle);
-	// URL tags are sanitized so they stay valid inside quoted YAML frontmatter
-	// scalars (the default feed template quotes them). A well-formed URL never
-	// contains a raw double-quote, backslash, or control character.
+	// URL tags are sanitized so they stay safe as Markdown link/image targets and
+	// inside quoted YAML frontmatter scalars (the default feed template uses both).
+	// A well-formed URL never contains the characters this neutralizes.
 	addTag("url", sanitizeUrlForTemplate(feed.link ?? ""));
 	addTag("feedurl", sanitizeUrlForTemplate(feed.url));
 	addTag("artwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
 	addTag("feedartwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
-	addTag("author", feed.author ?? "");
+	addTag("author", sanitizeInlineText(feed.author ?? ""));
 	addTag("description", (prependToLines?: string) => {
-		const sanitizeDescription = htmlToMarkdown(feed.description ?? "").replace(
+		const sanitizeDescription = feedHtmlToMarkdown(feed.description ?? "").replace(
 			/\n{3,}/g,
 			"\n\n",
 		);
@@ -470,23 +558,33 @@ export function getFeedNoteWikilink(feedTitle: string): string {
 }
 
 /**
- * Strip the two characters that would break a double-quoted YAML scalar
- * (and never appear in a well-formed URL): the double-quote that ends the
- * scalar and the backslash that YAML reads as an escape. Lossless for valid
- * URLs; only sanitizes malformed feeds so quoted frontmatter stays valid.
+ * Make a feed-controlled URL safe to embed as a Markdown link/image target, a
+ * bare-line autolink, and a double-quoted YAML scalar. A well-formed URL never
+ * contains whitespace, control characters, quotes, backslashes, backticks,
+ * angle brackets, or parentheses/square brackets - all of which would let a
+ * crafted value break out of `![](...)` / `[](...)`, inject extra lines, or
+ * terminate a quoted YAML scalar. They are percent-encoded (not stripped) so
+ * legitimate URLs keep working while malicious feed values are neutralized; the
+ * scheme/path separators (`:` `/` `?` `&` `=` `#` `%`) are preserved so real
+ * URLs are unchanged.
  */
 function sanitizeUrlForTemplate(url: string): string {
-	return url.replace(/["\\]/g, "");
+	// eslint-disable-next-line no-control-regex
+	return url.replace(/[\u0000-\u0020"'`()[\]<>\\]/g, (char) => {
+		return `%${char.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`;
+	});
 }
 
 export function replaceIllegalFileNameCharactersInString(string: string) {
 	return (
 		string
 			// Strip characters that are illegal in file names on major platforms,
-			// plus a few the plugin removes for clean paths/wikilinks. Dots are
-			// intentionally preserved so titles like "Episode 1.5" are not mangled
-			// into "Episode 15".
-			.replace(/[\\,#%&{}/*<>$'":@\u2023|?]/g, "")
+			// plus a few the plugin removes for clean paths/wikilinks. The square
+			// brackets are included so a feed-controlled title cannot inject an
+			// Obsidian [[wikilink]] when used as a link name (e.g. {{podcastlink}}
+			// built from a feed <title>). Dots are intentionally preserved so titles
+			// like "Episode 1.5" are not mangled into "Episode 15".
+			.replace(/[\\,#%&{}/*<>$'":@\u2023|?[\]]/g, "")
 			// Replace any control characters (newlines, tabs, carriage returns)
 			// with spaces so they can never end up in a file name.
 			// eslint-disable-next-line no-control-regex

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -254,6 +254,22 @@ function formatTemplateChapters(
 	return lines.map((line) => `${prependToLines}${line}`).join("\n");
 }
 
+/**
+ * Resolve {{url}}/{{episodeurl}}. A genuine local-file episode stores a
+ * vault-generated wikilink in `url` that must pass through verbatim (sanitizing it
+ * would break the link). That trust is gated on the plugin-set `filePath` - a feed
+ * cannot forge it (only `getContextMenuHandler` sets it; `feedParser` never does) -
+ * NOT on `podcastName === "local file"` alone, which an attacker controls via the
+ * feed <title> and could otherwise use to skip sanitization (P1, PR #228 review).
+ * Every other (feed) episode's url is attacker-controlled and is sanitized so it
+ * cannot inject Markdown/wikilinks on the bare `{{url}}` line.
+ */
+function resolveEpisodeUrl(episode: Episode): string {
+	return isLocalFile(episode) && episode.filePath
+		? episode.url
+		: sanitizeUrlForTemplate(episode.url);
+}
+
 export function NoteTemplateEngine(
 	template: string,
 	episode: Episode,
@@ -261,13 +277,7 @@ export function NoteTemplateEngine(
 ) {
 	const [replacer, addTag] = useTemplateEngine();
 
-	// For a local file episode.url is a vault-generated wikilink (trusted, and
-	// mutating it would break the link); for a feed episode it is attacker-
-	// controlled, so it is sanitized so it cannot inject Markdown/wikilinks on the
-	// bare `{{url}}` line. See note-injection findings.
-	const episodeUrl = isLocalFile(episode)
-		? episode.url
-		: sanitizeUrlForTemplate(episode.url);
+	const episodeUrl = resolveEpisodeUrl(episode);
 
 	addTag("title", sanitizeInlineText(episode.title));
 	addTag("description", (prependToLines?: string) => {
@@ -462,10 +472,7 @@ export function TranscriptTemplateEngine(
 
 		return feedHtmlToMarkdown(episode.description);
 	});
-	addTag(
-		"url",
-		isLocalFile(episode) ? episode.url : sanitizeUrlForTemplate(episode.url),
-	);
+	addTag("url", resolveEpisodeUrl(episode));
 	addTag("artwork", sanitizeUrlForTemplate(episode.artworkUrl ?? ""));
 
 	return replacer(template);


### PR DESCRIPTION
## Summary

Feed-controlled fields are written into generated notes by the template engines in `src/TemplateEngine.ts` without escaping. A malicious RSS feed can therefore inject Markdown, external/tracking images, phishing links, Obsidian `[[wikilinks]]`, and (speculatively) executable Dataview code blocks into a reader's vault.

This fixes two deepsec-confirmed findings, both scoped to `src/TemplateEngine.ts`:

- `other-markdown-injection` (`adb1a853c0`) - raw `{{title}}`/URL tags (`artwork`/`stream`/`url`/`feedurl`/`feed*`/`episode*`) and `htmlToMarkdown`'d `{{description}}`/`{{content}}` injected verbatim. The headline attack: a crafted `artworkUrl` like `x)![pwn](http://attacker/leak.png) [click](http://phish)` breaks out of the default template's `![]({{artwork}})` to inject external tracking images / phishing links.
- `other-wikilink-injection` (`7a7cf39683`) - `replaceIllegalFileNameCharactersInString` did not strip `[`/`]`, so a feed `<title>` such as `Real]] [[Victims Private Note` injects an extra wikilink into every episode note's `podcast:` frontmatter via `{{podcastlink}}`.

## What changed (`src/TemplateEngine.ts`)

- **Raw inline text** (`{{title}}`, feed `{{title}}`/`{{author}}`) - new `sanitizeInlineText`: collapses control characters to spaces (no line/block breakout from `# {{title}}`) and neutralizes link/image/inline-code/raw-HTML metacharacters (`[ ] < > \``), while keeping ordinary punctuation readable (deliberately lighter than `escapeMarkdownText`).
- **URL tags** - broadened `sanitizeUrlForTemplate` percent-encodes the characters that would break a Markdown link/image target, a bare-line autolink, or a quoted YAML scalar (control/space/`"'\`()[]<>\\`), losslessly for real URLs. `{{url}}`/`{{episodeurl}}` still pass a trusted **local-file** vault wikilink through verbatim (`isLocalFile` gate); feed URLs are sanitized.
- **Wikilink sanitizer** - `replaceIllegalFileNameCharactersInString` now also strips `[`/`]`, closing the wikilink injection through `{{podcast}}`/`{{safetitle}}`/`{{podcastlink}}`.
- **Executable code blocks** - `feedHtmlToMarkdown` renders injected Dataview fences (` ```dataviewjs ` / ` ```dataview `, `~~~`, in **any** container: top-level, blockquote, callout, or list item) inert. A 3+ fence run followed by the language token only ever occurs as a code-fence info string, so the container-agnostic rewrite is always safe.

Applied consistently across `NoteTemplateEngine`, `FeedNoteTemplateEngine`, and `TranscriptTemplateEngine`.

### Deliberately preserved (not bugs)
- Legitimate show-note rich text in `{{description}}`/`{{content}}` (links, images, ordinary code blocks) is the feature, so it is kept. A feed can still place an external image (readers can disable external-image loading in Obsidian) or a literal `[[wikilink]]` in this free-text body; unlike the structured tags these are accepted as show-note content.
- Inline Dataview queries (`` `= ` ``/`` `$= ` ``) are a documented residual of the same speculative, Dataview-must-be-installed class - not rewritten to avoid mangling legitimate inline code in programming show notes.

### Behavior-change note
Adding `[`/`]` to the file-name sanitizer also affects derived download/note paths: a title like `Episode [Bonus]` now yields `Episode Bonus`. Acceptable for the wikilink-injection fix.

## Tests
New/updated unit tests in `src/TemplateEngine.test.ts` prove each malicious input is neutralized and legitimate input is preserved: artwork `![]()` breakout, feed `{{url}}`/`{{stream}}` injection, raw `{{title}}` newline/Markdown injection, `dataviewjs` fences (incl. blockquote/callout, 4-space list indent, and long-fence-desync regressions from adversarial review), wikilink injection via `podcastName`, a feed-forged `[[...]]` url, and local-file wikilink passthrough.

## Validation
- Gates (Node 22): `npm run lint`, `typecheck`, `build`, `test` - all green (872 tests).
- Adversarially self-reviewed with two subagents (one actively trying to bypass the guards). The fence-container bypasses they found (blockquote/callout, list-indent, fence-length desync) were fixed by switching to the container-agnostic regex; regression tests added.
- Isolated worktree Obsidian vault: confirmed the plugin loads with the change (v2.17.2). Full end-to-end note creation for a *synthetically injected* current episode is not scriptable in this harness (a benign control episode fails identically - it is a harness limitation in injecting a store-backed episode, independent of this change); the real `htmlToMarkdown` output shape was validated against Obsidian's Turndown-based converter during review.

Do not merge yet - opening as draft for maintainer review.