### PR TITLE
chore(deps): drop no-op node-gyp undici override

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,6 @@
 	"overrides": {
 		"@actions/http-client": {
 			"undici": "^6.27.0"
-		},
-		"node-gyp": {
-			"undici": "^6.27.0"
 		}
 	},
 	"config": {


### PR DESCRIPTION
Follow-up to #229. Devin's review correctly noted the node-gyp override is inert: node-gyp only exists bundled inside the npm package, where npm overrides cannot reach. The vendored-undici advisory was actually fixed by re-resolving npm to 11.18.0, so the override never did anything.

Removing it changes nothing in the lockfile (verified: `npm install` reports up to date, `npm audit` still 0 vulnerabilities). The @actions/http-client override stays - that one is live and pins undici 6.27.0 under a real unbundled dep.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/podnotes/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->