### PR TITLE
chore(format): cover Svelte components

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "./node_modules/oxfmt/configuration_schema.json",
+	"svelte": true,
 	"useTabs": true,
 	"ignorePatterns": [],
 	"overrides": [

--- a/src/ui/PodcastView/ChapterList.svelte
+++ b/src/ui/PodcastView/ChapterList.svelte
@@ -57,7 +57,9 @@
 							aria-label={`Jump to ${chapter.title}`}
 							on:click={() => handleChapterClick(chapter)}
 						>
-							<span class="chapter-time">{formatSeconds(chapter.startTime, "H:mm:ss")}</span>
+							<span class="chapter-time"
+								>{formatSeconds(chapter.startTime, "H:mm:ss")}</span
+							>
 							<span class="chapter-title">{chapter.title}</span>
 						</button>
 					</li>

--- a/src/ui/PodcastView/EpisodeList.svelte
+++ b/src/ui/PodcastView/EpisodeList.svelte
@@ -8,10 +8,7 @@
 	import Loading from "./Loading.svelte";
 	import { getEpisodeKey } from "src/utility/episodeKey";
 	import { isEpisodeFinished } from "src/utility/episodeStatus";
-	import {
-		createEpisodeListEntries,
-		type EpisodeListEntry,
-	} from "src/utility/episodeListEntry";
+	import { createEpisodeListEntries, type EpisodeListEntry } from "src/utility/episodeListEntry";
 
 	export let episodes: Episode[] = [];
 	export let episodeEntries: EpisodeListEntry[] | null = null;
@@ -24,9 +21,7 @@
 	$: listEntries = episodeEntries ?? createEpisodeListEntries(episodes);
 	$: shouldHidePlayedEpisodes = $hidePlayedEpisodes && !alwaysShowPlayedEpisodes;
 	$: visibleEntries = listEntries.filter(
-		(entry) =>
-			!shouldHidePlayedEpisodes ||
-			!isEpisodeFinished(entry.episode, $playedEpisodes),
+		(entry) => !shouldHidePlayedEpisodes || !isEpisodeFinished(entry.episode, $playedEpisodes),
 	);
 
 	const dispatch = createEventDispatcher();
@@ -43,7 +38,7 @@
 
 	function forwardContextMenuEpisode(
 		entry: EpisodeListEntry,
-		event: CustomEvent<{ episode: Episode; event: MouseEvent }>
+		event: CustomEvent<{ episode: Episode; event: MouseEvent }>,
 	) {
 		dispatch("contextMenuEpisode", {
 			episode: event.detail.episode,

--- a/src/ui/PodcastView/EpisodeListHeader.svelte
+++ b/src/ui/PodcastView/EpisodeListHeader.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    export let text: string = "";
-    export let artworkUrl: string = "";
+	export let text: string = "";
+	export let artworkUrl: string = "";
 </script>
 
 <div class="podcast-header">
-    {#if artworkUrl}
-        <img id="podcast-artwork" src={artworkUrl} alt={text} />
-    {/if}
-    <h2 class="podcast-heading">{text}</h2>
+	{#if artworkUrl}
+		<img id="podcast-artwork" src={artworkUrl} alt={text} />
+	{/if}
+	<h2 class="podcast-heading">{text}</h2>
 </div>
 
 <style>

--- a/src/ui/PodcastView/EpisodeListItem.svelte
+++ b/src/ui/PodcastView/EpisodeListItem.svelte
@@ -13,7 +13,7 @@
 	const dateFormatter = new Intl.DateTimeFormat("en-GB", {
 		day: "2-digit",
 		month: "long",
-		year: "numeric"
+		year: "numeric",
 	});
 	const formattedDateCache = new Map<string, string>();
 	let overflowEl: HTMLDivElement;
@@ -93,7 +93,9 @@
 		{/if}
 		<div class="podcast-episode-information">
 			<span class="episode-item-date">{date}</span>
-			<span class={`episode-item-title ${episodeFinished && "strikeout"}`}>{episode.title}</span>
+			<span class={`episode-item-title ${episodeFinished && "strikeout"}`}
+				>{episode.title}</span
+			>
 			{#if unavailableReason}
 				<span class="episode-item-status">{unavailableReason}</span>
 			{/if}
@@ -165,7 +167,9 @@
 		padding: 0.35rem;
 		border-radius: 0.375rem;
 		color: var(--text-muted);
-		transition: background-color 120ms ease, color 120ms ease;
+		transition:
+			background-color 120ms ease,
+			color 120ms ease;
 	}
 
 	.podcast-episode-overflow :global(.icon-button:hover) {

--- a/src/ui/PodcastView/EpisodePlayer.svelte
+++ b/src/ui/PodcastView/EpisodePlayer.svelte
@@ -50,8 +50,7 @@
 	// Hide the player's Queue list only when queue automation is off AND the queue
 	// is empty (issue #108) — otherwise show it (default-on state or a non-empty
 	// manual queue).
-	$: showQueue =
-		$plugin?.settings?.autoQueue !== false || $queue.episodes.length > 0;
+	$: showQueue = $plugin?.settings?.autoQueue !== false || $queue.episodes.length > 0;
 
 	// Title length feeds the CSS length-based downscaling on .podcast-title (issue #81).
 	$: titleCharCount = $currentEpisode?.title?.length ?? 0;
@@ -77,9 +76,9 @@
 		isPaused.update((value) => !value);
 	}
 
-	function onClickProgressbar(
-		{ detail: { event, percent } }: CustomEvent<{ event: MouseEvent | KeyboardEvent; percent?: number }>
-	) {
+	function onClickProgressbar({
+		detail: { event, percent },
+	}: CustomEvent<{ event: MouseEvent | KeyboardEvent; percent?: number }>) {
 		if (typeof percent === "number") {
 			seekPlaybackTo(percent * $duration);
 			return;
@@ -100,7 +99,7 @@
 		playlists.update((lists) => {
 			Object.values(lists).forEach((playlist) => {
 				playlist.episodes = playlist.episodes.filter(
-					(ep) => !isSameStoredEpisode(ep, $currentEpisode)
+					(ep) => !isSameStoredEpisode(ep, $currentEpisode),
 				);
 			});
 
@@ -154,9 +153,7 @@
 		// usable; fall back to the bare <video> element on iOS Safari/WKWebView,
 		// where requestFullscreen on a div is unsupported and only the media
 		// element itself can go fullscreen.
-		const container = mediaElement?.closest(
-			".episode-video-container",
-		) as HTMLElement | null;
+		const container = mediaElement?.closest(".episode-video-container") as HTMLElement | null;
 		if (container?.requestFullscreen) {
 			void container.requestFullscreen();
 			return;
@@ -223,10 +220,7 @@
 		restoreSavedPlaybackTime(currentEp, playedEps);
 	}
 
-	function restoreSavedPlaybackTime(
-		currentEp: Episode,
-		playedEps: typeof $playedEpisodes,
-	) {
+	function restoreSavedPlaybackTime(currentEp: Episode, playedEps: typeof $playedEpisodes) {
 		const key = getEpisodeKey(currentEp);
 
 		// Check composite key first, then fall back to the title-only key for
@@ -422,7 +416,7 @@
 	function handleContextMenuEpisodeImage(event: MouseEvent) {
 		spawnEpisodeContextMenu($currentEpisode, event, {
 			play: true,
-			markPlayed: true
+			markPlayed: true,
 		});
 	}
 
@@ -471,10 +465,7 @@
 	): downloadedEpisode is DownloadedEpisode {
 		if (!downloadedEpisode?.filePath) return false;
 
-		const downloadedMediaType = getDownloadedEpisodeMediaType(
-			episode,
-			downloadedEpisode,
-		);
+		const downloadedMediaType = getDownloadedEpisodeMediaType(episode, downloadedEpisode);
 		if (episode.mediaType && downloadedMediaType !== episode.mediaType) {
 			return false;
 		}
@@ -491,10 +482,7 @@
 		episode: Episode,
 		downloadedEpisode: DownloadedEpisode,
 	): EpisodeMediaType {
-		return getEpisodeMediaTypeWithContainerHint(
-			downloadedEpisode,
-			episode.mediaType,
-		);
+		return getEpisodeMediaTypeWithContainerHint(downloadedEpisode, episode.mediaType);
 	}
 
 	$: if (mediaElement && mediaElement.playbackRate !== $playbackRate) {
@@ -568,7 +556,10 @@
 					opacity={isHoveringArtwork || $isPaused ? 0.5 : 1}
 				>
 					<svelte:fragment slot="fallback">
-						<div class={"podcast-artwork-placeholder" + (isHoveringArtwork || $isPaused ? " opacity-50" : "")}>
+						<div
+							class={"podcast-artwork-placeholder" +
+								(isHoveringArtwork || $isPaused ? " opacity-50" : "")}
+						>
 							<Icon icon="image" size={150} clickable={false} />
 						</div>
 					</svelte:fragment>
@@ -590,7 +581,9 @@
 		</div>
 	{/if}
 
-	<h2 class="podcast-title" style="--title-char-count: {titleCharCount}">{$currentEpisode.title}</h2>
+	<h2 class="podcast-title" style="--title-char-count: {titleCharCount}">
+		{$currentEpisode.title}
+	</h2>
 
 	{#if !isVideoEpisode}
 		<audio
@@ -639,11 +632,7 @@
 	<div class="slider-stack">
 		<div class="volume-container">
 			<span>Volume: {Math.round(playerVolume * 100)}%</span>
-			<Slider
-				on:change={onVolumeChange}
-				value={playerVolume}
-				limits={[0, 1, 0.05]}
-			/>
+			<Slider on:change={onVolumeChange} value={playerVolume} limits={[0, 1, 0.05]} />
 		</div>
 
 		<div class="playbackrate-container">
@@ -657,11 +646,7 @@
 	</div>
 
 	<div class="lists-container">
-		<ChapterList
-			{chapters}
-			currentTime={$currentTime}
-			on:seek={onChapterSeek}
-		/>
+		<ChapterList {chapters} currentTime={$currentTime} on:seek={onChapterSeek} />
 
 		{#if showQueue}
 			<EpisodeList
@@ -729,7 +714,9 @@
 		border-radius: 0.75rem;
 		overflow: hidden;
 		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
-		transition: box-shadow 200ms ease, transform 200ms ease;
+		transition:
+			box-shadow 200ms ease,
+			transform 200ms ease;
 	}
 
 	.hover-container:hover {
@@ -814,7 +801,9 @@
 		color: var(--text-on-accent);
 		cursor: pointer;
 		opacity: 0;
-		transition: opacity 200ms ease, background-color 120ms ease;
+		transition:
+			opacity 200ms ease,
+			background-color 120ms ease;
 	}
 
 	.episode-video-container:hover .podcast-video-fullscreen,

--- a/src/ui/PodcastView/Loading.svelte
+++ b/src/ui/PodcastView/Loading.svelte
@@ -10,79 +10,79 @@
 </div>
 
 <style>
-/*!
+	/*!
  * Load Awesome v1.1.0 (http://github.danielcardoso.net/load-awesome/)
  * Copyright 2015 Daniel Cardoso <@DanielCardoso>
  * Licensed under MIT
  */
-.la-line-scale,
-.la-line-scale > div {
-    position: relative;
-    -webkit-box-sizing: border-box;
-       -moz-box-sizing: border-box;
-            box-sizing: border-box;
-}
-.la-line-scale {
-    display: block;
-    font-size: 0;
-    color: #fff;
-}
-/* .la-line-scale.la-dark {
+	.la-line-scale,
+	.la-line-scale > div {
+		position: relative;
+		-webkit-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		box-sizing: border-box;
+	}
+	.la-line-scale {
+		display: block;
+		font-size: 0;
+		color: #fff;
+	}
+	/* .la-line-scale.la-dark {
     color: #333;
 } */
-.la-line-scale > div {
-    display: inline-block;
-    float: none;
-    background-color: currentColor;
-    border: 0 solid currentColor;
-}
-.la-line-scale {
-    width: 40px;
-    height: 32px;
-}
-.la-line-scale > div {
-    width: 4px;
-    height: 32px;
-    margin: 2px;
-    margin-top: 0;
-    margin-bottom: 0;
-    border-radius: 0;
-    -webkit-animation: line-scale 1.2s infinite ease;
-       -moz-animation: line-scale 1.2s infinite ease;
-         -o-animation: line-scale 1.2s infinite ease;
-            animation: line-scale 1.2s infinite ease;
-}
-.la-line-scale > div:nth-child(1) {
-    -webkit-animation-delay: -1.2s;
-       -moz-animation-delay: -1.2s;
-         -o-animation-delay: -1.2s;
-            animation-delay: -1.2s;
-}
-.la-line-scale > div:nth-child(2) {
-    -webkit-animation-delay: -1.1s;
-       -moz-animation-delay: -1.1s;
-         -o-animation-delay: -1.1s;
-            animation-delay: -1.1s;
-}
-.la-line-scale > div:nth-child(3) {
-    -webkit-animation-delay: -1s;
-       -moz-animation-delay: -1s;
-         -o-animation-delay: -1s;
-            animation-delay: -1s;
-}
-.la-line-scale > div:nth-child(4) {
-    -webkit-animation-delay: -.9s;
-       -moz-animation-delay: -.9s;
-         -o-animation-delay: -.9s;
-            animation-delay: -.9s;
-}
-.la-line-scale > div:nth-child(5) {
-    -webkit-animation-delay: -.8s;
-       -moz-animation-delay: -.8s;
-         -o-animation-delay: -.8s;
-            animation-delay: -.8s;
-}
-/* .la-line-scale.la-sm {
+	.la-line-scale > div {
+		display: inline-block;
+		float: none;
+		background-color: currentColor;
+		border: 0 solid currentColor;
+	}
+	.la-line-scale {
+		width: 40px;
+		height: 32px;
+	}
+	.la-line-scale > div {
+		width: 4px;
+		height: 32px;
+		margin: 2px;
+		margin-top: 0;
+		margin-bottom: 0;
+		border-radius: 0;
+		-webkit-animation: line-scale 1.2s infinite ease;
+		-moz-animation: line-scale 1.2s infinite ease;
+		-o-animation: line-scale 1.2s infinite ease;
+		animation: line-scale 1.2s infinite ease;
+	}
+	.la-line-scale > div:nth-child(1) {
+		-webkit-animation-delay: -1.2s;
+		-moz-animation-delay: -1.2s;
+		-o-animation-delay: -1.2s;
+		animation-delay: -1.2s;
+	}
+	.la-line-scale > div:nth-child(2) {
+		-webkit-animation-delay: -1.1s;
+		-moz-animation-delay: -1.1s;
+		-o-animation-delay: -1.1s;
+		animation-delay: -1.1s;
+	}
+	.la-line-scale > div:nth-child(3) {
+		-webkit-animation-delay: -1s;
+		-moz-animation-delay: -1s;
+		-o-animation-delay: -1s;
+		animation-delay: -1s;
+	}
+	.la-line-scale > div:nth-child(4) {
+		-webkit-animation-delay: -0.9s;
+		-moz-animation-delay: -0.9s;
+		-o-animation-delay: -0.9s;
+		animation-delay: -0.9s;
+	}
+	.la-line-scale > div:nth-child(5) {
+		-webkit-animation-delay: -0.8s;
+		-moz-animation-delay: -0.8s;
+		-o-animation-delay: -0.8s;
+		animation-delay: -0.8s;
+	}
+	/* .la-line-scale.la-sm {
     width: 20px;
     height: 16px;
 }
@@ -115,63 +115,63 @@
     margin-top: 0;
     margin-bottom: 0;
 }*/
-/*
+	/*
  * Animation
  */
-@-webkit-keyframes line-scale {
-    0%,
-    40%,
-    100% {
-        -webkit-transform: scaleY(.4);
-                transform: scaleY(.4);
-    }
-    20% {
-        -webkit-transform: scaleY(1);
-                transform: scaleY(1);
-    }
-}
-@-moz-keyframes line-scale {
-    0%,
-    40%,
-    100% {
-        -webkit-transform: scaleY(.4);
-           -moz-transform: scaleY(.4);
-                transform: scaleY(.4);
-    }
-    20% {
-        -webkit-transform: scaleY(1);
-           -moz-transform: scaleY(1);
-                transform: scaleY(1);
-    }
-}
-@-o-keyframes line-scale {
-    0%,
-    40%,
-    100% {
-        -webkit-transform: scaleY(.4);
-             -o-transform: scaleY(.4);
-                transform: scaleY(.4);
-    }
-    20% {
-        -webkit-transform: scaleY(1);
-             -o-transform: scaleY(1);
-                transform: scaleY(1);
-    }
-}
-@keyframes line-scale {
-    0%,
-    40%,
-    100% {
-        -webkit-transform: scaleY(.4);
-           -moz-transform: scaleY(.4);
-             -o-transform: scaleY(.4);
-                transform: scaleY(.4);
-    }
-    20% {
-        -webkit-transform: scaleY(1);
-           -moz-transform: scaleY(1);
-             -o-transform: scaleY(1);
-                transform: scaleY(1);
-    }
-}
+	@-webkit-keyframes line-scale {
+		0%,
+		40%,
+		100% {
+			-webkit-transform: scaleY(0.4);
+			transform: scaleY(0.4);
+		}
+		20% {
+			-webkit-transform: scaleY(1);
+			transform: scaleY(1);
+		}
+	}
+	@-moz-keyframes line-scale {
+		0%,
+		40%,
+		100% {
+			-webkit-transform: scaleY(0.4);
+			-moz-transform: scaleY(0.4);
+			transform: scaleY(0.4);
+		}
+		20% {
+			-webkit-transform: scaleY(1);
+			-moz-transform: scaleY(1);
+			transform: scaleY(1);
+		}
+	}
+	@-o-keyframes line-scale {
+		0%,
+		40%,
+		100% {
+			-webkit-transform: scaleY(0.4);
+			-o-transform: scaleY(0.4);
+			transform: scaleY(0.4);
+		}
+		20% {
+			-webkit-transform: scaleY(1);
+			-o-transform: scaleY(1);
+			transform: scaleY(1);
+		}
+	}
+	@keyframes line-scale {
+		0%,
+		40%,
+		100% {
+			-webkit-transform: scaleY(0.4);
+			-moz-transform: scaleY(0.4);
+			-o-transform: scaleY(0.4);
+			transform: scaleY(0.4);
+		}
+		20% {
+			-webkit-transform: scaleY(1);
+			-moz-transform: scaleY(1);
+			-o-transform: scaleY(1);
+			transform: scaleY(1);
+		}
+	}
 </style>

--- a/src/ui/PodcastView/PlaylistCard.svelte
+++ b/src/ui/PodcastView/PlaylistCard.svelte
@@ -10,7 +10,6 @@
 	function onClickPlaylist(event: MouseEvent) {
 		dispatch("clickPlaylist", { playlist, event });
 	}
-
 </script>
 
 <button
@@ -20,7 +19,7 @@
 	title={playlist.name}
 	on:click={onClickPlaylist}
 >
-	<Icon icon={playlist.icon} size={32} clickable={false}/>
+	<Icon icon={playlist.icon} size={32} clickable={false} />
 	<span class="playlist-card-name">{playlist.name}</span>
 	<span class="playlist-card-count">
 		({playlist.episodes.length})
@@ -45,7 +44,11 @@
 		text-align: center;
 		background: var(--background-secondary);
 		cursor: pointer;
-		transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease, background-color 150ms ease;
+		transition:
+			transform 150ms ease,
+			box-shadow 150ms ease,
+			border-color 150ms ease,
+			background-color 150ms ease;
 	}
 
 	.playlist-card:hover {

--- a/src/ui/PodcastView/PodcastGrid.svelte
+++ b/src/ui/PodcastView/PodcastGrid.svelte
@@ -10,7 +10,9 @@
 
 	const dispatch = createEventDispatcher();
 
-	function forwardClickPlaylist({detail: {playlist, event}}: CustomEvent<{event: MouseEvent, playlist: Playlist}>) {
+	function forwardClickPlaylist({
+		detail: { playlist, event },
+	}: CustomEvent<{ event: MouseEvent; playlist: Playlist }>) {
 		dispatch("clickPlaylist", { playlist, event });
 	}
 </script>
@@ -18,16 +20,13 @@
 <div class="podcast-grid">
 	{#if playlists.length > 0}
 		{#each playlists as playlist (playlist.name)}
-			<PlaylistCard playlist={playlist} on:clickPlaylist={forwardClickPlaylist} />
+			<PlaylistCard {playlist} on:clickPlaylist={forwardClickPlaylist} />
 		{/each}
 	{/if}
 
 	{#if feeds.length > 0}
 		{#each feeds as feed (feed.url)}
-			<PodcastGridCard
-				feed={feed}
-				on:clickPodcast
-			/>
+			<PodcastGridCard {feed} on:clickPodcast />
 		{/each}
 	{:else}
 		<div>

--- a/src/ui/PodcastView/PodcastGridCard.svelte
+++ b/src/ui/PodcastView/PodcastGridCard.svelte
@@ -12,12 +12,12 @@
 	}
 </script>
 
-<Image 
-	src={feed.artworkUrl} 
-	alt={feed.title} 
+<Image
+	src={feed.artworkUrl}
+	alt={feed.title}
 	interactive={true}
-    on:click={onclickPodcast.bind(null, feed)}
-    class="podcast-image"
+	on:click={onclickPodcast.bind(null, feed)}
+	class="podcast-image"
 />
 
 <style>
@@ -32,7 +32,10 @@
 		background-repeat: no-repeat;
 		border: 1px solid var(--background-modifier-border);
 		border-radius: 0.5rem;
-		transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+		transition:
+			transform 150ms ease,
+			box-shadow 150ms ease,
+			border-color 150ms ease;
 	}
 
 	:global(.podcast-image:hover) {

--- a/src/ui/PodcastView/PodcastView.svelte
+++ b/src/ui/PodcastView/PodcastView.svelte
@@ -29,10 +29,7 @@
 	import searchEpisodes from "src/utility/searchEpisodes";
 	import type { Playlist } from "src/types/Playlist";
 	import spawnEpisodeContextMenu from "./spawnEpisodeContextMenu";
-	import {
-		getCachedEpisodes,
-		setCachedEpisodes,
-	} from "src/services/FeedCacheService";
+	import { getCachedEpisodes, setCachedEpisodes } from "src/services/FeedCacheService";
 	import { get } from "svelte/store";
 	import { PLAYED_SETTINGS } from "src/constants";
 	import { getFinishedPlayedEpisodeRecords } from "src/utility/episodeStatus";
@@ -65,9 +62,7 @@
 	$: loadingFeedNames = Array.from(loadingFeeds);
 	// Exclude the selected feed from the banner: its loading state is already
 	// shown by the inline EpisodeList spinner, so the banner would duplicate it.
-	$: bannerFeedNames = loadingFeedNames.filter(
-		(name) => name !== selectedFeed?.title,
-	);
+	$: bannerFeedNames = loadingFeedNames.filter((name) => name !== selectedFeed?.title);
 	$: loadingFeedSummary =
 		bannerFeedNames.length > 3
 			? `${bannerFeedNames.slice(0, 3).join(", ")} +${bannerFeedNames.length - 3} more`
@@ -83,8 +78,7 @@
 			// empty "Queue" tile. The default-on state and a non-empty manual queue
 			// both keep it visible.
 			const showQueue =
-				get(plugin)?.settings?.autoQueue !== false ||
-				queueValue.episodes.length > 0;
+				get(plugin)?.settings?.autoQueue !== false || queueValue.episodes.length > 0;
 			displayedPlaylists = [
 				...(showQueue ? [queueValue] : []),
 				get(favorites),
@@ -124,9 +118,7 @@
 
 			feeds = updatedFeeds;
 
-			const newFeeds = updatedFeeds.filter(
-				(feed) => !previousFeedTitles.has(feed.title),
-			);
+			const newFeeds = updatedFeeds.filter((feed) => !previousFeedTitles.has(feed.title));
 
 			if (newFeeds.length > 0) {
 				void fetchEpisodesInAllFeeds(newFeeds);
@@ -138,22 +130,20 @@
 			currentViewState = vs;
 		});
 
-		const unsubscribeLatestEpisodes = latestEpisodesStore.subscribe(
-			(episodes) => {
-				latestEpisodes = episodes;
+		const unsubscribeLatestEpisodes = latestEpisodesStore.subscribe((episodes) => {
+			latestEpisodes = episodes;
 
-				if (
-					currentViewState === ViewState.EpisodeList &&
-					!selectedFeed &&
-					!selectedPlaylist &&
-					!isShowingPlayedEpisodes
-				) {
-					displayedEpisodes = currentSearchQuery
-						? searchEpisodes(currentSearchQuery, episodes)
-						: episodes;
-				}
-			},
-		);
+			if (
+				currentViewState === ViewState.EpisodeList &&
+				!selectedFeed &&
+				!selectedPlaylist &&
+				!isShowingPlayedEpisodes
+			) {
+				displayedEpisodes = currentSearchQuery
+					? searchEpisodes(currentSearchQuery, episodes)
+					: episodes;
+			}
+		});
 
 		return () => {
 			unsubscribeLatestEpisodes();
@@ -200,11 +190,7 @@
 		const currentCache = get(episodeCache);
 		const cachedEpisodesInFeed = currentCache[feed.title];
 
-		if (
-			useCache &&
-			cachedEpisodesInFeed &&
-			cachedEpisodesInFeed.length > 0
-		) {
+		if (useCache && cachedEpisodesInFeed && cachedEpisodesInFeed.length > 0) {
 			return cachedEpisodesInFeed;
 		}
 
@@ -232,10 +218,7 @@
 
 			return episodes;
 		} catch (error) {
-			console.error(
-				`Failed to fetch episodes for ${feed.title}:`,
-				error,
-			);
+			console.error(`Failed to fetch episodes for ${feed.title}:`, error);
 			const downloaded = get(downloadedEpisodes);
 			if (downloaded[feed.title]?.length) {
 				return downloaded[feed.title];
@@ -247,10 +230,7 @@
 				}
 
 				if (cacheEnabled) {
-					const persistedEpisodes = getCachedEpisodes(
-						feed,
-						cacheTtlMs,
-					);
+					const persistedEpisodes = getCachedEpisodes(feed, cacheTtlMs);
 					if (persistedEpisodes?.length) {
 						episodeCache.update((cache) => ({
 							...cache,
@@ -320,8 +300,8 @@
 	function getPlayedPlaylist(): Playlist {
 		return {
 			...PLAYED_SETTINGS,
-			episodes: getFinishedPlayedEpisodeRecords(get(playedEpisodes)).map(
-				({ episode }) => createPlayedEpisodePlaceholder(episode),
+			episodes: getFinishedPlayedEpisodeRecords(get(playedEpisodes)).map(({ episode }) =>
+				createPlayedEpisodePlaceholder(episode),
 			),
 			isVirtual: true,
 		};
@@ -330,9 +310,7 @@
 	function getEpisodeSources(): Episode[][] {
 		const cachedEpisodes = Object.values(get(episodeCache));
 		const downloaded = Object.values(get(downloadedEpisodes));
-		const userPlaylists = Object.values(get(playlists)).map(
-			(playlist) => playlist.episodes,
-		);
+		const userPlaylists = Object.values(get(playlists)).map((playlist) => playlist.episodes);
 
 		return [
 			...cachedEpisodes,
@@ -350,9 +328,7 @@
 	): PlayedEpisodeListEntry[] {
 		if (!query) return entries;
 
-		const entriesByEpisode = new Map(
-			entries.map((entry) => [entry.episode, entry]),
-		);
+		const entriesByEpisode = new Map(entries.map((entry) => [entry.episode, entry]));
 
 		return searchEpisodes(
 			query,
@@ -363,14 +339,8 @@
 	}
 
 	function updateDisplayedPlayedEpisodes() {
-		const entries = buildPlayedEpisodeListEntries(
-			get(playedEpisodes),
-			getEpisodeSources(),
-		);
-		displayedEpisodeEntries = filterPlayedEntries(
-			entries,
-			currentSearchQuery,
-		);
+		const entries = buildPlayedEpisodeListEntries(get(playedEpisodes), getEpisodeSources());
+		displayedEpisodeEntries = filterPlayedEntries(entries, currentSearchQuery);
 		displayedEpisodes = displayedEpisodeEntries.map((entry) => entry.episode);
 	}
 
@@ -433,9 +403,7 @@
 	function getPlayedEpisodeKey(entry: EpisodeListEntry): string | undefined {
 		if (!("playedEpisodeKey" in entry)) return undefined;
 
-		return typeof entry.playedEpisodeKey === "string"
-			? entry.playedEpisodeKey
-			: undefined;
+		return typeof entry.playedEpisodeKey === "string" ? entry.playedEpisodeKey : undefined;
 	}
 
 	function setFeedLoading(feedTitle: string, isLoading: boolean) {
@@ -468,13 +436,11 @@
 				} finally {
 					setFeedLoading(feed.title, false);
 				}
-			})
+			}),
 		).then(() => undefined);
 	}
 
-	async function handleClickPodcast(
-		event: CustomEvent<{ feed: PodcastFeed }>
-	) {
+	async function handleClickPodcast(event: CustomEvent<{ feed: PodcastFeed }>) {
 		const { feed } = event.detail;
 
 		selectedFeed = feed;
@@ -495,9 +461,7 @@
 		}
 	}
 
-	function handleClickEpisode(
-		event: CustomEvent<{ episode: Episode; entry: EpisodeListEntry }>,
-	) {
+	function handleClickEpisode(event: CustomEvent<{ episode: Episode; entry: EpisodeListEntry }>) {
 		const { episode, entry } = event.detail;
 		if (!entry.isAvailable) {
 			new Notice("This played episode is no longer available in current feeds.");
@@ -531,10 +495,7 @@
 
 	async function handleClickRefresh() {
 		if (isShowingPlayedEpisodes) {
-			await fetchEpisodesInAllFeeds(
-				getFeedsWithPlayedEpisodes(),
-				"network",
-			);
+			await fetchEpisodesInAllFeeds(getFeedsWithPlayedEpisodes(), "network");
 			updateDisplayedPlayedEpisodesIfSelected();
 			return;
 		}
@@ -553,11 +514,7 @@
 		setFeedLoading(selectedFeed.title, true);
 
 		try {
-			const episodes = await fetchEpisodesByStrategy(
-				selectedFeed,
-				"network",
-				true,
-			);
+			const episodes = await fetchEpisodesByStrategy(selectedFeed, "network", true);
 			displayedEpisodeEntries = null;
 			displayedEpisodes = currentSearchQuery
 				? searchEpisodes(currentSearchQuery, episodes)
@@ -594,9 +551,7 @@
 		displayedEpisodes = searchEpisodes(query, latestEpisodes);
 	}, 250);
 
-	function handleClickPlaylist(
-		event: CustomEvent<{ event: MouseEvent; playlist: Playlist }>
-	) {
+	function handleClickPlaylist(event: CustomEvent<{ event: MouseEvent; playlist: Playlist }>) {
 		const { playlist } = event.detail;
 
 		if (playlist.isVirtual && playlist.name === PLAYED_SETTINGS.name) {
@@ -607,10 +562,7 @@
 			displayedEpisodeEntries = [];
 			viewState.set(ViewState.EpisodeList);
 
-			void fetchEpisodesInAllFeeds(
-				getFeedsWithPlayedEpisodes(),
-				"full",
-			).then(() => {
+			void fetchEpisodesInAllFeeds(getFeedsWithPlayedEpisodes(), "full").then(() => {
 				updateDisplayedPlayedEpisodesIfSelected();
 			});
 			return;
@@ -657,7 +609,9 @@
 				</div>
 				<div class="feed-loading-text">
 					<span>
-						Updating {bannerFeedNames.length} feed{bannerFeedNames.length === 1 ? "" : "s"}
+						Updating {bannerFeedNames.length} feed{bannerFeedNames.length === 1
+							? ""
+							: "s"}
 					</span>
 					{#if loadingFeedSummary}
 						<span class="feed-loading-names">{loadingFeedSummary}</span>
@@ -679,39 +633,19 @@
 		>
 			<svelte:fragment slot="header">
 				{#if selectedFeed}
-					<button
-						type="button"
-						class="go-back"
-						on:click={showLatestEpisodes}
-					>
-						<Icon
-							icon={"arrow-left"}
-							size={20}
-							clickable={false}
-						/> Latest Episodes
+					<button type="button" class="go-back" on:click={showLatestEpisodes}>
+						<Icon icon={"arrow-left"} size={20} clickable={false} /> Latest Episodes
 					</button>
 					<EpisodeListHeader
 						text={selectedFeed.title}
 						artworkUrl={selectedFeed.artworkUrl}
 					/>
 				{:else if selectedPlaylist}
-					<button
-						type="button"
-						class="go-back"
-						on:click={showLatestEpisodes}
-					>
-						<Icon
-							icon={"arrow-left"}
-							size={20}
-							clickable={false}
-						/> Latest Episodes
+					<button type="button" class="go-back" on:click={showLatestEpisodes}>
+						<Icon icon={"arrow-left"} size={20} clickable={false} /> Latest Episodes
 					</button>
 					<div class="playlist-header-icon">
-						<Icon
-							icon={selectedPlaylist.icon}
-							size={40}
-							clickable={false}
-						/>
+						<Icon icon={selectedPlaylist.icon} size={40} clickable={false} />
 					</div>
 					<EpisodeListHeader text={selectedPlaylist.name} />
 				{:else}
@@ -789,7 +723,9 @@
 		background: none;
 		border: none;
 		border-radius: 0.25rem;
-		transition: color 120ms ease, background-color 120ms ease;
+		transition:
+			color 120ms ease,
+			background-color 120ms ease;
 	}
 
 	.go-back:hover {

--- a/src/ui/PodcastView/TopBar.svelte
+++ b/src/ui/PodcastView/TopBar.svelte
@@ -7,17 +7,11 @@
 	export let canShowPlayer: boolean = false;
 
 	const gridTooltip = "Browse podcast grid";
-	const disabledEpisodeTooltip =
-		"Select a podcast or playlist to view its episodes.";
-	const disabledPlayerTooltip =
-		"Start playing an episode to open the player.";
+	const disabledEpisodeTooltip = "Select a podcast or playlist to view its episodes.";
+	const disabledPlayerTooltip = "Start playing an episode to open the player.";
 
-	$: episodeTooltip = canShowEpisodeList
-		? "View episode list"
-		: disabledEpisodeTooltip;
-	$: playerTooltip = canShowPlayer
-		? "Open player"
-		: disabledPlayerTooltip;
+	$: episodeTooltip = canShowEpisodeList ? "View episode list" : disabledEpisodeTooltip;
+	$: playerTooltip = canShowPlayer ? "Open player" : disabledPlayerTooltip;
 
 	function handleClickMenuItem(newState: ViewState) {
 		if (viewState === newState) return;
@@ -28,7 +22,6 @@
 
 		viewState = newState;
 	}
-
 </script>
 
 <div class="topbar-container">
@@ -54,11 +47,9 @@
             ${viewState === ViewState.EpisodeList ? "topbar-selected" : ""}
             ${canShowEpisodeList ? "topbar-selectable" : "topbar-disabled"}
         `}
-		aria-label={
-			canShowEpisodeList
-				? "Episode list"
-				: "Episode list (select a podcast or playlist first)"
-		}
+		aria-label={canShowEpisodeList
+			? "Episode list"
+			: "Episode list (select a podcast or playlist first)"}
 		aria-pressed={viewState === ViewState.EpisodeList}
 		disabled={!canShowEpisodeList}
 		title={episodeTooltip}
@@ -73,11 +64,9 @@
             ${viewState === ViewState.Player ? "topbar-selected" : ""}
             ${canShowPlayer ? "topbar-selectable" : "topbar-disabled"}
         `}
-		aria-label={
-			canShowPlayer
-				? "Player"
-				: "Player (start playing an episode to open the player)"
-		}
+		aria-label={canShowPlayer
+			? "Player"
+			: "Player (start playing an episode to open the player)"}
 		aria-pressed={viewState === ViewState.Player}
 		disabled={!canShowPlayer}
 		title={playerTooltip}

--- a/src/ui/common/Image.svelte
+++ b/src/ui/common/Image.svelte
@@ -7,7 +7,7 @@
 	export let opacity: number = 0; // Falsey value so condition isn't triggered if not set.
 	export let interactive: boolean = false;
 	export let loading: "lazy" | "eager" | null | undefined = "lazy";
-	export {_class as class};
+	export { _class as class };
 	let _class = "";
 
 	let loaded = false;
@@ -23,35 +23,43 @@
 
 {#if isLoading || loaded}
 	{#if interactive}
-		<button
-			type="button"
-			class="pn_image_container"
-			on:click={onClick}
-		>
-			<img 
+		<button type="button" class="pn_image_container" on:click={onClick}>
+			<img
 				draggable="false"
-				{src} 
-				{alt} 
+				{src}
+				{alt}
 				{loading}
 				class={_class}
 				style:opacity={opacity ? opacity : !fadeIn ? 1 : loaded ? 1 : 0}
 				style:transition={fadeIn ? "opacity 0.5s ease-out" : ""}
-				on:load={() => {loaded = true; isLoading = false;}}
-				on:error={() => {failed = true; isLoading = false;}}
+				on:load={() => {
+					loaded = true;
+					isLoading = false;
+				}}
+				on:error={() => {
+					failed = true;
+					isLoading = false;
+				}}
 			/>
 		</button>
 	{:else}
 		<div class="pn_image_container pn_image_container--static">
-			<img 
+			<img
 				draggable="false"
-				{src} 
-				{alt} 
+				{src}
+				{alt}
 				{loading}
 				class={_class}
 				style:opacity={opacity ? opacity : !fadeIn ? 1 : loaded ? 1 : 0}
 				style:transition={fadeIn ? "opacity 0.5s ease-out" : ""}
-				on:load={() => {loaded = true; isLoading = false;}}
-				on:error={() => {failed = true; isLoading = false;}}
+				on:load={() => {
+					loaded = true;
+					isLoading = false;
+				}}
+				on:error={() => {
+					failed = true;
+					isLoading = false;
+				}}
 			/>
 		</div>
 	{/if}

--- a/src/ui/common/ImageLoader.svelte
+++ b/src/ui/common/ImageLoader.svelte
@@ -31,12 +31,12 @@
 	style:aspect-ratio={resolvedAspectRatio}
 >
 	<Image
-		{alt} 
-		{src} 
+		{alt}
+		{src}
 		{fadeIn}
 		{interactive}
 		{loading}
-		on:click={event => dispatcher('click', { event })} 
+		on:click={(event) => dispatcher("click", { event })}
 		class={_class}
 	/>
 </div>

--- a/src/ui/common/Progressbar.svelte
+++ b/src/ui/common/Progressbar.svelte
@@ -1,77 +1,77 @@
 <script lang="ts">
-import type { CSSObject } from "src/types/CSSObject";
-import extractStylesFromObj from "src/utility/extractStylesFromObj";
-import { createEventDispatcher } from "svelte";
+	import type { CSSObject } from "src/types/CSSObject";
+	import extractStylesFromObj from "src/utility/extractStylesFromObj";
+	import { createEventDispatcher } from "svelte";
 
-export let max: number;
-export let value: number;
-export let ariaLabel = "Seek";
-export let valueText: string | undefined = undefined;
-export { _styled as style };
+	export let max: number;
+	export let value: number;
+	export let ariaLabel = "Seek";
+	export let valueText: string | undefined = undefined;
+	export { _styled as style };
 
-let isDragging: boolean = false;
-let _styled: CSSObject = {};
-let progressRef: HTMLDivElement;
+	let isDragging: boolean = false;
+	let _styled: CSSObject = {};
+	let progressRef: HTMLDivElement;
 
-let styles: string;
+	let styles: string;
 
-$: {
-	styles = extractStylesFromObj(_styled);
-}
-
-const dispatch = createEventDispatcher();
-
-function forwardClick(e: MouseEvent | KeyboardEvent, percent?: number) {
-	dispatch("click", { event: e, percent });
-}
-
-function onDragStart() {
-	isDragging = true;
-}
-
-function onDragEnd() {
-	isDragging = false;
-}
-
-function handleDragging(e: MouseEvent) {
-	if (!isDragging) return;
-
-	forwardClick(e);
-}
-
-function handleKeyDown(event: KeyboardEvent) {
-	if (!progressRef || !max) return;
-	const step = max * 0.05;
-	let nextValue = value;
-
-	switch (event.key) {
-		case "ArrowRight":
-		case "ArrowUp":
-			nextValue = Math.min(max, value + step);
-			break;
-		case "ArrowLeft":
-		case "ArrowDown":
-			nextValue = Math.max(0, value - step);
-			break;
-		case "Home":
-			nextValue = 0;
-			break;
-		case "End":
-			nextValue = max;
-			break;
-		case "Enter":
-		case " ":
-			// Keep current value; allow parent to handle if needed.
-			nextValue = value;
-			break;
-		default:
-			return;
+	$: {
+		styles = extractStylesFromObj(_styled);
 	}
 
-	event.preventDefault();
-	const percent = max ? nextValue / max : 0;
-	forwardClick(event, percent);
-}
+	const dispatch = createEventDispatcher();
+
+	function forwardClick(e: MouseEvent | KeyboardEvent, percent?: number) {
+		dispatch("click", { event: e, percent });
+	}
+
+	function onDragStart() {
+		isDragging = true;
+	}
+
+	function onDragEnd() {
+		isDragging = false;
+	}
+
+	function handleDragging(e: MouseEvent) {
+		if (!isDragging) return;
+
+		forwardClick(e);
+	}
+
+	function handleKeyDown(event: KeyboardEvent) {
+		if (!progressRef || !max) return;
+		const step = max * 0.05;
+		let nextValue = value;
+
+		switch (event.key) {
+			case "ArrowRight":
+			case "ArrowUp":
+				nextValue = Math.min(max, value + step);
+				break;
+			case "ArrowLeft":
+			case "ArrowDown":
+				nextValue = Math.max(0, value - step);
+				break;
+			case "Home":
+				nextValue = 0;
+				break;
+			case "End":
+				nextValue = max;
+				break;
+			case "Enter":
+			case " ":
+				// Keep current value; allow parent to handle if needed.
+				nextValue = value;
+				break;
+			default:
+				return;
+		}
+
+		event.preventDefault();
+		const percent = max ? nextValue / max : 0;
+		forwardClick(event, percent);
+	}
 </script>
 
 <div

--- a/src/ui/obsidian/Button.svelte
+++ b/src/ui/obsidian/Button.svelte
@@ -1,63 +1,62 @@
 <script lang="ts">
-    import { ButtonComponent } from "obsidian";
-    import type { CSSObject } from "src/types/CSSObject";
-    import type { IconType } from "src/types/IconType";
-    import extractStylesFromObj from "src/utility/extractStylesFromObj";
-    import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+	import { ButtonComponent } from "obsidian";
+	import type { CSSObject } from "src/types/CSSObject";
+	import type { IconType } from "src/types/IconType";
+	import extractStylesFromObj from "src/utility/extractStylesFromObj";
+	import { afterUpdate, createEventDispatcher, onMount } from "svelte";
 
-    export let text: string = "";
-    export let tooltip: string = "";
-    export let ariaLabel: string = "";
-    export let icon: IconType | undefined = undefined;
-    export let disabled: boolean = false;
-    export let warning: boolean = false;
-    export let cta: boolean = false;
-    export { className as class };
-    export { styles as style };
+	export let text: string = "";
+	export let tooltip: string = "";
+	export let ariaLabel: string = "";
+	export let icon: IconType | undefined = undefined;
+	export let disabled: boolean = false;
+	export let warning: boolean = false;
+	export let cta: boolean = false;
+	export { className as class };
+	export { styles as style };
 
-    let buttonRef: HTMLSpanElement;
-    let className: string;
-    let styles: CSSObject;
+	let buttonRef: HTMLSpanElement;
+	let className: string;
+	let styles: CSSObject;
 
-    let button: ButtonComponent;
+	let button: ButtonComponent;
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-    onMount(() => createButton(buttonRef));
-    afterUpdate(() => updateButtonAttributes(button));
+	onMount(() => createButton(buttonRef));
+	afterUpdate(() => updateButtonAttributes(button));
 
-    function createButton(container: HTMLElement) {
-        button = new ButtonComponent(container);
-        
-        updateButtonAttributes(button);
-    }
+	function createButton(container: HTMLElement) {
+		button = new ButtonComponent(container);
 
-    function updateButtonAttributes(btn: ButtonComponent) {
-        if (text) btn.setButtonText(text);
-        if (tooltip) btn.setTooltip(tooltip);
-        if (icon) btn.setIcon(icon);
-        if (disabled) btn.setDisabled(disabled);
-        if (warning) btn.setWarning(); else btn.buttonEl.classList.remove('mod-warning');
-        if (className) btn.setClass(className);
-        if (cta) btn.setCta(); else btn.removeCta();
+		updateButtonAttributes(button);
+	}
 
-        btn.onClick((event: MouseEvent) => {
-            dispatch("click", { event });
-        });
+	function updateButtonAttributes(btn: ButtonComponent) {
+		if (text) btn.setButtonText(text);
+		if (tooltip) btn.setTooltip(tooltip);
+		if (icon) btn.setIcon(icon);
+		if (disabled) btn.setDisabled(disabled);
+		if (warning) btn.setWarning();
+		else btn.buttonEl.classList.remove("mod-warning");
+		if (className) btn.setClass(className);
+		if (cta) btn.setCta();
+		else btn.removeCta();
 
-        if (styles) {
-            btn.buttonEl.setAttr('style', extractStylesFromObj(styles));
-        }
+		btn.onClick((event: MouseEvent) => {
+			dispatch("click", { event });
+		});
 
-        if (ariaLabel) {
-            btn.buttonEl.setAttr("aria-label", ariaLabel);
-        } else {
-            btn.buttonEl.removeAttribute("aria-label");
-        }
-    }
+		if (styles) {
+			btn.buttonEl.setAttr("style", extractStylesFromObj(styles));
+		}
 
+		if (ariaLabel) {
+			btn.buttonEl.setAttr("aria-label", ariaLabel);
+		} else {
+			btn.buttonEl.removeAttribute("aria-label");
+		}
+	}
 </script>
 
-<span 
-    bind:this={buttonRef} 
-></span>
+<span bind:this={buttonRef}></span>

--- a/src/ui/obsidian/Dropdown.svelte
+++ b/src/ui/obsidian/Dropdown.svelte
@@ -6,14 +6,14 @@
 
 	export let value: string = "";
 	export let options: Record<string, string> = {};
-    export let disabled: boolean = false;
-    export { styles as style };
-	
+	export let disabled: boolean = false;
+	export { styles as style };
+
 	let dropdownRef: HTMLSpanElement;
 	let dropdown: DropdownComponent;
 	let styles: CSSObject;
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
 	onMount(() => {
 		dropdown = new DropdownComponent(dropdownRef);
@@ -38,17 +38,15 @@
 		if (options) dropdown.addOptions(options);
 		if (value) dropdown.setValue(value);
 		if (disabled) dropdown.setDisabled(disabled);
-		
-		
+
 		dropdown.onChange((value: string) => {
 			dispatch("change", { value });
 		});
 
-        if (styles) {
-            dropdown.selectEl.setAttr('style', extractStylesFromObj(styles));
-        }
+		if (styles) {
+			dropdown.selectEl.setAttr("style", extractStylesFromObj(styles));
+		}
 	}
-
 </script>
 
 <span bind:this={dropdownRef}></span>

--- a/src/ui/obsidian/Icon.svelte
+++ b/src/ui/obsidian/Icon.svelte
@@ -1,38 +1,37 @@
 <script lang="ts">
-    import { setIcon } from "obsidian";
-    import type { CSSObject } from "src/types/CSSObject";
-    import type { IconType } from "src/types/IconType";
-    import extractStylesFromObj from "src/utility/extractStylesFromObj";
-    import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+	import { setIcon } from "obsidian";
+	import type { CSSObject } from "src/types/CSSObject";
+	import type { IconType } from "src/types/IconType";
+	import extractStylesFromObj from "src/utility/extractStylesFromObj";
+	import { afterUpdate, createEventDispatcher, onMount } from "svelte";
 
-    export let size: number = 16;
-    export let icon: IconType;
+	export let size: number = 16;
+	export let icon: IconType;
 	export let clickable: boolean = true;
 	export let label: string = "";
 	export let pressed: boolean | undefined = undefined;
 	export let disabled: boolean = false;
-    export {styles as style};
+	export { styles as style };
 
-    let ref: HTMLSpanElement;
-    let styles: CSSObject = {};
-    let stylesStr: string;
-    let pressedAttr: "true" | "false" | undefined;
+	let ref: HTMLSpanElement;
+	let styles: CSSObject = {};
+	let stylesStr: string;
+	let pressedAttr: "true" | "false" | undefined;
 
-    $: stylesStr = extractStylesFromObj(styles);
-    $: pressedAttr =
-        pressed === undefined ? undefined : (pressed ? "true" : "false");
+	$: stylesStr = extractStylesFromObj(styles);
+	$: pressedAttr = pressed === undefined ? undefined : pressed ? "true" : "false";
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-    onMount(() => {
-        setIcon(ref, icon);
-        applyIconStyles();
-    });
+	onMount(() => {
+		setIcon(ref, icon);
+		applyIconStyles();
+	});
 
-    afterUpdate(() => {
-        setIcon(ref, icon);
-        applyIconStyles();
-    });
+	afterUpdate(() => {
+		setIcon(ref, icon);
+		applyIconStyles();
+	});
 
 	function applyIconStyles() {
 		if (!ref) return;
@@ -44,51 +43,51 @@
 		}
 	}
 
-    function forwardClick(event: MouseEvent) {
-        if (!clickable || disabled) return;
-        dispatch("click", { event });
-    }
+	function forwardClick(event: MouseEvent) {
+		if (!clickable || disabled) return;
+		dispatch("click", { event });
+	}
 </script>
 
 {#if clickable}
-    <button
-        type="button"
-        class="icon-button"
-        on:click={forwardClick}
-        aria-label={label}
-        aria-pressed={pressedAttr}
-        disabled={disabled}
-    >
-        <span bind:this={ref}></span>
-    </button>
+	<button
+		type="button"
+		class="icon-button"
+		on:click={forwardClick}
+		aria-label={label}
+		aria-pressed={pressedAttr}
+		{disabled}
+	>
+		<span bind:this={ref}></span>
+	</button>
 {:else}
-    <span
-        class="icon-static"
-        aria-label={label || undefined}
-        aria-hidden={label ? undefined : "true"}
-        bind:this={ref}
-    ></span>
+	<span
+		class="icon-static"
+		aria-label={label || undefined}
+		aria-hidden={label ? undefined : "true"}
+		bind:this={ref}
+	></span>
 {/if}
 
 <style>
-    .icon-button {
-        border: none;
-        background: none;
-        padding: 0;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-    }
+	.icon-button {
+		border: none;
+		background: none;
+		padding: 0;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
 
-    .icon-button:disabled {
-        cursor: not-allowed;
-        opacity: 0.4;
-    }
+	.icon-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.4;
+	}
 
-    .icon-static {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-    }
+	.icon-static {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
 </style>

--- a/src/ui/obsidian/Slider.svelte
+++ b/src/ui/obsidian/Slider.svelte
@@ -1,74 +1,72 @@
 <script lang="ts">
-    import { SliderComponent } from "obsidian";
-    import type { CSSObject } from "src/types/CSSObject";
-    import extractStylesFromObj from "src/utility/extractStylesFromObj";
-    import { createEventDispatcher, onDestroy, onMount } from "svelte";
+	import { SliderComponent } from "obsidian";
+	import type { CSSObject } from "src/types/CSSObject";
+	import extractStylesFromObj from "src/utility/extractStylesFromObj";
+	import { createEventDispatcher, onDestroy, onMount } from "svelte";
 
-    export let value: number;
-    export let limits: [min: number, max: number] | [min: number, max: number, step: number];
-    export { styles as style };
+	export let value: number;
+	export let limits: [min: number, max: number] | [min: number, max: number, step: number];
+	export { styles as style };
 
-    let sliderRef: HTMLSpanElement;
+	let sliderRef: HTMLSpanElement;
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-    let slider: SliderComponent;
-    let styles: CSSObject = {};
-    let changeHandler: ((event: Event) => void) | null = null;
-    let isProgrammaticUpdate = false;
+	let slider: SliderComponent;
+	let styles: CSSObject = {};
+	let changeHandler: ((event: Event) => void) | null = null;
+	let isProgrammaticUpdate = false;
 
-    // This is not a complete implementation. I implemented what I needed.
+	// This is not a complete implementation. I implemented what I needed.
 
-    onMount(() => {
-        slider = new SliderComponent(sliderRef);
+	onMount(() => {
+		slider = new SliderComponent(sliderRef);
 
-        changeHandler = (event: Event) => {
-            if (isProgrammaticUpdate) return;
+		changeHandler = (event: Event) => {
+			if (isProgrammaticUpdate) return;
 
-            const newValue = Number((event.target as HTMLInputElement).value);
-            dispatch("change", { value: newValue });
-        };
+			const newValue = Number((event.target as HTMLInputElement).value);
+			dispatch("change", { value: newValue });
+		};
 
-        slider.sliderEl.addEventListener("input", changeHandler);
-    });
+		slider.sliderEl.addEventListener("input", changeHandler);
+	});
 
-    onDestroy(() => {
-        if (slider?.sliderEl && changeHandler) {
-            slider.sliderEl.removeEventListener("input", changeHandler);
-        }
-    });
+	onDestroy(() => {
+		if (slider?.sliderEl && changeHandler) {
+			slider.sliderEl.removeEventListener("input", changeHandler);
+		}
+	});
 
-    $: if (slider) {
-        updateSliderAttributes(slider, value, limits, styles);
-    }
+	$: if (slider) {
+		updateSliderAttributes(slider, value, limits, styles);
+	}
 
-    function updateSliderAttributes(
-        sldr: SliderComponent,
-        currentValue: number,
-        currentLimits: [min: number, max: number] | [min: number, max: number, step: number],
-        currentStyles: CSSObject
-    ) {
-        const sliderValue =
-            typeof sldr.getValue === "function"
-                ? sldr.getValue()
-                : Number(sldr.sliderEl?.value);
+	function updateSliderAttributes(
+		sldr: SliderComponent,
+		currentValue: number,
+		currentLimits: [min: number, max: number] | [min: number, max: number, step: number],
+		currentStyles: CSSObject,
+	) {
+		const sliderValue =
+			typeof sldr.getValue === "function" ? sldr.getValue() : Number(sldr.sliderEl?.value);
 
-        if (currentValue !== undefined && sliderValue !== currentValue) {
-            isProgrammaticUpdate = true;
-            sldr.setValue(currentValue);
-            isProgrammaticUpdate = false;
-        }
-        if (currentLimits) {
-            if (currentLimits.length === 2) {
-                sldr.setLimits(currentLimits[0], currentLimits[1], 1);
-            } else {
-                sldr.setLimits(currentLimits[0], currentLimits[1], currentLimits[2]);
-            }
-        }
-        if (currentStyles) {
-            sldr.sliderEl.setAttr("style", extractStylesFromObj(currentStyles));
-        }
-    }
+		if (currentValue !== undefined && sliderValue !== currentValue) {
+			isProgrammaticUpdate = true;
+			sldr.setValue(currentValue);
+			isProgrammaticUpdate = false;
+		}
+		if (currentLimits) {
+			if (currentLimits.length === 2) {
+				sldr.setLimits(currentLimits[0], currentLimits[1], 1);
+			} else {
+				sldr.setLimits(currentLimits[0], currentLimits[1], currentLimits[2]);
+			}
+		}
+		if (currentStyles) {
+			sldr.sliderEl.setAttr("style", extractStylesFromObj(currentStyles));
+		}
+	}
 </script>
 
 <span bind:this={sliderRef}></span>

--- a/src/ui/obsidian/Text.svelte
+++ b/src/ui/obsidian/Text.svelte
@@ -1,113 +1,107 @@
 <script lang="ts">
-    import { TextComponent } from "obsidian";
-    import type { CSSObject } from "src/types/CSSObject";
-    import extractStylesFromObj from "src/utility/extractStylesFromObj";
-    import { createEventDispatcher, onDestroy, onMount } from "svelte";
+	import { TextComponent } from "obsidian";
+	import type { CSSObject } from "src/types/CSSObject";
+	import extractStylesFromObj from "src/utility/extractStylesFromObj";
+	import { createEventDispatcher, onDestroy, onMount } from "svelte";
 
-    export let value: string = "";
-    export let disabled: boolean = false;
-    export let placeholder: string = "";
-    export let type: "text" | "password" | "email" | "number" | "tel" | "url" = "text";
-    export let el: HTMLInputElement | null = null;
-    export { styles as style };
+	export let value: string = "";
+	export let disabled: boolean = false;
+	export let placeholder: string = "";
+	export let type: "text" | "password" | "email" | "number" | "tel" | "url" = "text";
+	export let el: HTMLInputElement | null = null;
+	export { styles as style };
 
-    let textRef: HTMLSpanElement;
+	let textRef: HTMLSpanElement;
 
-    const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-    let text: TextComponent;
-    let styles: CSSObject = {};
-    let inputHandler: ((event: Event) => void) | null = null;
-    let changeHandler: ((value: string) => void) | null = null;
-    let isProgrammaticUpdate = false;
+	let text: TextComponent;
+	let styles: CSSObject = {};
+	let inputHandler: ((event: Event) => void) | null = null;
+	let changeHandler: ((value: string) => void) | null = null;
+	let isProgrammaticUpdate = false;
 
-    onMount(() => {
-        text = new TextComponent(textRef);
-    });
+	onMount(() => {
+		text = new TextComponent(textRef);
+	});
 
-    onDestroy(() => {
-        if (text?.inputEl && inputHandler) {
-            text.inputEl.removeEventListener("input", inputHandler);
-        }
-    });
+	onDestroy(() => {
+		if (text?.inputEl && inputHandler) {
+			text.inputEl.removeEventListener("input", inputHandler);
+		}
+	});
 
-    $: if (text) {
-        attachEventListeners(text);
-        updateTextComponentAttributes(text, value, disabled, placeholder, type, styles);
-    }
+	$: if (text) {
+		attachEventListeners(text);
+		updateTextComponentAttributes(text, value, disabled, placeholder, type, styles);
+	}
 
-    function handleInput(event: Event) {
-        if (isProgrammaticUpdate) return;
+	function handleInput(event: Event) {
+		if (isProgrammaticUpdate) return;
 
-        const input = event.target as HTMLInputElement | null;
-        const newValue = input?.value ?? "";
+		const input = event.target as HTMLInputElement | null;
+		const newValue = input?.value ?? "";
 
-        value = newValue;
-        dispatch("input", { value: newValue });
-    }
+		value = newValue;
+		dispatch("input", { value: newValue });
+	}
 
-    function handleChange(newValue: string) {
-        if (isProgrammaticUpdate) return;
+	function handleChange(newValue: string) {
+		if (isProgrammaticUpdate) return;
 
-        value = newValue;
-        dispatch("change", { value: newValue });
-    }
+		value = newValue;
+		dispatch("change", { value: newValue });
+	}
 
-    function attachEventListeners(component: TextComponent) {
-        if (!component?.inputEl || inputHandler) return;
+	function attachEventListeners(component: TextComponent) {
+		if (!component?.inputEl || inputHandler) return;
 
-        changeHandler = handleChange;
-        component.onChange(changeHandler);
+		changeHandler = handleChange;
+		component.onChange(changeHandler);
 
-        inputHandler = handleInput;
-        component.inputEl.addEventListener("input", inputHandler);
-    }
+		inputHandler = handleInput;
+		component.inputEl.addEventListener("input", inputHandler);
+	}
 
-    function updateTextComponentAttributes(
-        component: TextComponent,
-        currentValue: string,
-        isDisabled: boolean,
-        currentPlaceholder: string,
-        currentType: "text" | "password" | "email" | "number" | "tel" | "url",
-        currentStyles: CSSObject
-    ) {
-        const componentValue =
-            typeof component.getValue === "function"
-                ? component.getValue()
-                : component.inputEl?.value;
+	function updateTextComponentAttributes(
+		component: TextComponent,
+		currentValue: string,
+		isDisabled: boolean,
+		currentPlaceholder: string,
+		currentType: "text" | "password" | "email" | "number" | "tel" | "url",
+		currentStyles: CSSObject,
+	) {
+		const componentValue =
+			typeof component.getValue === "function"
+				? component.getValue()
+				: component.inputEl?.value;
 
-        if (currentValue !== undefined && componentValue !== currentValue) {
-            isProgrammaticUpdate = true;
-            component.setValue(currentValue);
-            isProgrammaticUpdate = false;
-        }
+		if (currentValue !== undefined && componentValue !== currentValue) {
+			isProgrammaticUpdate = true;
+			component.setValue(currentValue);
+			isProgrammaticUpdate = false;
+		}
 
-        if (component?.inputEl) {
-            if (component.inputEl.disabled !== isDisabled) {
-                component.setDisabled(isDisabled);
-            }
+		if (component?.inputEl) {
+			if (component.inputEl.disabled !== isDisabled) {
+				component.setDisabled(isDisabled);
+			}
 
-            if (
-                currentPlaceholder &&
-                component.inputEl.placeholder !== currentPlaceholder
-            ) {
-                component.setPlaceholder(currentPlaceholder);
-            }
+			if (currentPlaceholder && component.inputEl.placeholder !== currentPlaceholder) {
+				component.setPlaceholder(currentPlaceholder);
+			}
 
-            if (component.inputEl.type !== currentType) {
-                component.inputEl.type = currentType;
-            }
+			if (component.inputEl.type !== currentType) {
+				component.inputEl.type = currentType;
+			}
 
-            if (currentStyles) {
-                component.inputEl.setAttr(
-                    "style",
-                    extractStylesFromObj(currentStyles),
-                );
-            }
+			if (currentStyles) {
+				component.inputEl.setAttr("style", extractStylesFromObj(currentStyles));
+			}
 
-            el = component.inputEl;
-        }
-    }
+			el = component.inputEl;
+		}
+	}
 </script>
 
 <span bind:this={textRef}></span>

--- a/src/ui/settings/CaptureSettings.svelte
+++ b/src/ui/settings/CaptureSettings.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-	import {
-		MarkdownRenderer,
-	} from "obsidian";
+	import { MarkdownRenderer } from "obsidian";
 
 	import { episodeCache } from "src/store";
 
-import type { Episode } from "src/types/Episode";
+	import type { Episode } from "src/types/Episode";
 	import { onMount } from "svelte";
 	import { get } from "svelte/store";
 	import { NoteTemplateEngine } from "../../TemplateEngine";
@@ -44,12 +42,10 @@ PublishDate:: {{date: YYYY-MM-DD-HH-MM-SS}}
 		const feedEpisodes = Object.values(get(episodeCache));
 		if (!feedEpisodes.length) return fallbackDemoObj;
 
-		const randomFeed =
-			feedEpisodes[Math.floor(Math.random() * feedEpisodes.length)];
+		const randomFeed = feedEpisodes[Math.floor(Math.random() * feedEpisodes.length)];
 		if (!randomFeed.length) return fallbackDemoObj;
-		
-		const randomEpisode =
-			randomFeed[Math.floor(Math.random() * randomFeed.length)];
+
+		const randomEpisode = randomFeed[Math.floor(Math.random() * randomFeed.length)];
 
 		return randomEpisode;
 	}
@@ -64,7 +60,7 @@ PublishDate:: {{date: YYYY-MM-DD-HH-MM-SS}}
 			el,
 			"",
 			// @ts-ignore
-			null
+			null,
 		);
 
 		// CSS selectors didn't seem to work for me, so I'm using this hacky way to get the rendered element

--- a/src/ui/settings/PlaylistItem.svelte
+++ b/src/ui/settings/PlaylistItem.svelte
@@ -32,11 +32,7 @@
 
 <div class="playlist-item">
 	<div class="playlist-item-left">
-		<Icon
-			icon={playlist.icon}
-			clickable={false}
-			size={18}
-		/>
+		<Icon icon={playlist.icon} clickable={false} size={18} />
 		<span class="playlist-name">{playlist.name}</span>
 		<span class="playlist-count">({playlist.episodes.length})</span>
 	</div>
@@ -50,11 +46,7 @@
 				on:click={onClickedDelete}
 				aria-label={clickedDelete ? "Confirm deletion" : "Delete playlist"}
 			>
-				<Icon
-					icon={clickedDelete ? "check" : "trash"}
-					clickable={false}
-					size={16}
-				/>
+				<Icon icon={clickedDelete ? "check" : "trash"} clickable={false} size={16} />
 			</button>
 		{/if}
 	</div>
@@ -114,7 +106,9 @@
 		background: transparent;
 		color: var(--text-muted);
 		cursor: pointer;
-		transition: background-color 120ms ease, color 120ms ease;
+		transition:
+			background-color 120ms ease,
+			color 120ms ease;
 	}
 
 	.delete-button:hover {

--- a/src/ui/settings/PlaylistManager.svelte
+++ b/src/ui/settings/PlaylistManager.svelte
@@ -90,31 +90,17 @@
 
 <div class="playlist-manager-container">
 	<div class="playlist-list">
-		<PlaylistItem
-			playlist={$queue}
-			showDeleteButton={false}
-		/>
-		<PlaylistItem
-			playlist={$favorites}
-			showDeleteButton={false}
-		/>
+		<PlaylistItem playlist={$queue} showDeleteButton={false} />
+		<PlaylistItem playlist={$favorites} showDeleteButton={false} />
 		{#each playlistArr as playlist (playlist.name)}
-			<PlaylistItem
-				{playlist}
-				on:delete={onDeletePlaylist}
-			/>
+			<PlaylistItem {playlist} on:delete={onDeletePlaylist} />
 		{/each}
 	</div>
 
 	<div class="add-playlist-container">
 		<Dropdown {options} bind:value={icon} on:change={onChangeIcon} />
 		<Text placeholder="Playlist name" bind:value={playlistInput} />
-		<Button
-			text="Add"
-			cta={true}
-			ariaLabel="Add playlist"
-			on:click={onAddPlaylist}
-		/>
+		<Button text="Add" cta={true} ariaLabel="Add playlist" on:click={onAddPlaylist} />
 	</div>
 </div>
 

--- a/src/ui/settings/PodcastQueryGrid.svelte
+++ b/src/ui/settings/PodcastQueryGrid.svelte
@@ -8,7 +8,7 @@
 	import Text from "../obsidian/Text.svelte";
 	import PodcastResultCard from "./PodcastResultCard.svelte";
 	import { onMount } from "svelte";
-	import { fade } from 'svelte/transition';
+	import { fade } from "svelte/transition";
 
 	let searchResults: PodcastFeed[] = [];
 	let gridSizeClass: string = "grid-3";
@@ -52,7 +52,7 @@
 	}
 
 	const debouncedUpdate = debounce(
-		async ({detail: { value }}: CustomEvent<{ value: string }>) => {
+		async ({ detail: { value } }: CustomEvent<{ value: string }>) => {
 			searchQuery = value;
 			searchError = "";
 			const customFeedUrl = checkStringIsUrl(value);
@@ -60,8 +60,7 @@
 			// Only treat the input as a feed URL when it is an http(s) URL, so
 			// things like "podcast:name" don't get parsed as feeds.
 			const isFeedUrl =
-				customFeedUrl?.protocol === "http:" ||
-				customFeedUrl?.protocol === "https:";
+				customFeedUrl?.protocol === "http:" || customFeedUrl?.protocol === "https:";
 
 			if (isFeedUrl && customFeedUrl) {
 				isSearching = true;
@@ -91,7 +90,7 @@
 			}
 		},
 		300,
-		true
+		true,
 	);
 
 	function addPodcast(event: CustomEvent<{ podcast: PodcastFeed }>) {
@@ -123,17 +122,13 @@
 	/>
 
 	{#if isSearching}
-		<div class="podcast-query-status" role="status" aria-live="polite">
-			Searching...
-		</div>
+		<div class="podcast-query-status" role="status" aria-live="polite">Searching...</div>
 	{:else if searchError}
 		<div class="podcast-query-status podcast-query-error" role="alert">
 			{searchError}
 		</div>
 	{:else if searchQuery.trim() !== "" && searchResults.length === 0}
-		<div class="podcast-query-status" role="status" aria-live="polite">
-			No results.
-		</div>
+		<div class="podcast-query-status" role="status" aria-live="polite">No results.</div>
 	{/if}
 
 	<div class="podcast-query-results" role="list" aria-label="Podcast search results">
@@ -141,7 +136,8 @@
 			<div role="listitem">
 				<PodcastResultCard
 					{podcast}
-					isSaved={typeof podcast.url === "string" && $savedFeeds[podcast.title]?.url === podcast.url}
+					isSaved={typeof podcast.url === "string" &&
+						$savedFeeds[podcast.title]?.url === podcast.url}
 					on:addPodcast={addPodcast}
 					on:removePodcast={removePodcast}
 				/>

--- a/src/ui/settings/PodcastResultCard.svelte
+++ b/src/ui/settings/PodcastResultCard.svelte
@@ -50,7 +50,10 @@
 		border-radius: 0.5rem;
 		background-color: var(--background-secondary);
 		max-width: 100%;
-		transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+		transition:
+			transform 150ms ease,
+			box-shadow 150ms ease,
+			border-color 150ms ease;
 	}
 
 	.podcast-result-card:hover {


### PR DESCRIPTION
## Summary

- enable Oxfmt's native Svelte formatter support
- format all 24 tracked Svelte components that were previously skipped
- keep this mechanical cleanup separate from later Svelte 5 migration and behavior fixes

## Semantic verification

- normalized compiled JavaScript ASTs are identical before and after for all 24 components
- independently verified template structure and non-whitespace text content are identical
- independently verified minified compiled CSS is identical
- reviewed ARIA attributes, event handlers, bindings, prop shorthand, and visible text for semantic changes

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run test` - 69 files, 876 tests
- `npm run check:a11y` - 0 errors and 0 warnings
- `git diff --check`

## Runtime impact

None expected. This is a formatter-only change and compiled output was compared structurally. Real Obsidian runtime verification is not needed for this mechanical slice.
