### PR TITLE
chore(types): isolate production environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"scripts": {
 		"dev": "vite build --watch --mode development",
 		"build": "npm run typecheck && vite build",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsc --project tsconfig.json --noEmit && tsc --project tsconfig.test.json --noEmit",
 		"lint": "oxlint --deny-warnings src tests/e2e scripts",
 		"format:check": "npm run format -- --check",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
@@ -24,10 +24,10 @@
 		"provision:e2e-vault": "node scripts/provision-obsidian-e2e-vault.mjs",
 		"start:e2e-obsidian": "node scripts/start-obsidian-e2e-instance.mjs",
 		"stop:e2e-obsidian": "node scripts/stop-obsidian-e2e-instance.mjs",
-		"check:a11y": "svelte-check --fail-on-warnings",
+		"check:a11y": "svelte-check --tsconfig ./tsconfig.json --fail-on-warnings && svelte-check --tsconfig ./tsconfig.test.json --fail-on-warnings",
 		"docs:build": "mkdocs build -f docs/mkdocs.yml -d site",
 		"docs:deploy": "npm run docs:build && wrangler pages deploy docs/site --project-name podnotes --branch master",
-		"format": "oxfmt src tests scripts .github package.json manifest.json versions.json tsconfig.json .oxlintrc.json .oxfmtrc.json svelte.config.mjs vite.config.ts vitest.config.ts vitest.e2e.config.ts vitest.setup.ts version-bump.mjs wrangler.jsonc orca.yaml docs/mkdocs.yml"
+		"format": "oxfmt src tests scripts .github package.json manifest.json versions.json tsconfig.base.json tsconfig.json tsconfig.test.json .oxlintrc.json .oxfmtrc.json svelte.config.mjs vite.config.ts vitest.config.ts vitest.e2e.config.ts vitest.setup.ts version-bump.mjs wrangler.jsonc orca.yaml docs/mkdocs.yml"
 	},
 	"dependencies": {
 		"fuse.js": "^7.4.2",

--- a/scripts/version-bump.test.ts
+++ b/scripts/version-bump.test.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = resolve(process.cwd(), "version-bump.mjs");
+
+describe("version-bump", () => {
+	it("fails clearly before reading project files when npm_package_version is missing", () => {
+		const result = spawnSync(process.execPath, [scriptPath], {
+			cwd: tmpdir(),
+			encoding: "utf8",
+			env: {
+				...process.env,
+				npm_package_version: "",
+			},
+		});
+
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain(
+			"npm_package_version is required; run this script through `npm version`.",
+		);
+	});
+});

--- a/svelte.config.mjs
+++ b/svelte.config.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import sveltePreprocess from "svelte-preprocess";
 
 export default {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"paths": {
+			"src/*": ["./src/*"]
+		},
+		"module": "ESNext",
+		"target": "ES2020",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noImplicitOverride": true,
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true,
+		"importHelpers": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"skipLibCheck": true,
+		"lib": ["DOM", "ES2020"]
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,8 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"paths": {
-			"src/*": ["./src/*"]
-		},
-		"module": "ESNext",
-		"target": "ES2020",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"allowJs": true,
-		"noImplicitOverride": true,
-		"noEmit": true,
-		"forceConsistentCasingInFileNames": true,
-		"importHelpers": true,
-		"isolatedModules": true,
-		"verbatimModuleSyntax": true,
-		"types": ["svelte", "node", "obsidian", "vitest/globals", "@testing-library/jest-dom"],
-		"skipLibCheck": true,
-		"lib": ["DOM", "ES2020"]
+		"types": ["svelte", "obsidian"]
 	},
-	"include": [
-		"src/**/*.ts",
-		"src/**/*.d.ts",
-		"vite.config.ts",
-		"vitest.config.ts",
-		"vitest.e2e.config.ts",
-		"tests/e2e/**/*.ts",
-		"scripts/**/*.ts"
-	]
+	"include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
+	"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": true,
+		// JavaScript tools opt in with `@ts-check` until the E2E runner scripts are typed.
+		"checkJs": false,
+		"types": ["svelte", "node", "obsidian", "vitest/globals", "@testing-library/jest-dom"]
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.d.ts",
+		"src/**/*.svelte",
+		"tests/**/*.ts",
+		"tests/**/*.svelte",
+		"scripts/**/*.ts",
+		"*.ts",
+		"*.mjs"
+	]
+}

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,6 +1,12 @@
+// @ts-check
+
 import { readFileSync, writeFileSync } from "fs";
 
 const targetVersion = process.env.npm_package_version;
+
+if (!targetVersion) {
+	throw new Error("npm_package_version is required; run this script through `npm version`.");
+}
 
 // read minAppVersion from manifest.json and bump version to target version
 let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -138,6 +138,7 @@ if (typeof IntersectionObserver === "undefined") {
 
 		readonly root: Element | Document | null = null;
 		readonly rootMargin: string = this._options?.rootMargin ?? "0px";
+		readonly scrollMargin: string = this._options?.scrollMargin ?? "0px";
 		readonly thresholds: ReadonlyArray<number> = [0];
 
 		disconnect(): void {}


### PR DESCRIPTION
Separate PodNotes' production compiler environment from its tests and developer tooling.

Production TypeScript and Svelte code now compile with only the `svelte` and `obsidian` ambient type sets. A separate superset project checks tests, mocks, setup code, configs, TypeScript scripts, and selected root JavaScript tools with the Node, Vitest, and Testing Library environments they actually use.

Both Svelte environments run explicitly. The production pass prevents Node or test globals from masking mistakes in shipped components, while the superset pass retains test-harness coverage.

This also fixes two pieces of type drift exposed by the wider tool project:

- the IntersectionObserver mock now implements the required `scrollMargin`
- `version-bump.mjs` fails clearly when it is not invoked through `npm version`, with a regression test

Resolved-program evidence:

- production project: no tests or tooling, and zero Node, Vitest, or jest-dom ambient files
- production Svelte pass: all 24 shipped components
- test/tool project: all TypeScript tests, mocks, configs, setup files, scripts, and both root MJS tools

The four large Obsidian E2E runner MJS files remain an explicit follow-up boundary. Enabling global `checkJs` exposed 121 existing diagnostics concentrated there, so this PR does not suppress strictness or mix a broad JSDoc rewrite into the environment split. Small root MJS tools opt in with `@ts-check` now.

Validation:

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- dual production and test-superset Svelte checks - 0 errors and 0 warnings
- `npm run build` - 410.80 kB / 122.49 kB gzip
- `npm run test` - 70 files, 877 tests
- MkDocs build through `docs/requirements.txt`
- two independent read-only reviews; final review finding for `.spec.ts` exclusion was fixed
- `git diff --check`

No runtime, storage, public API, or release artifact behavior changes.
