### PR TITLE
fix(e2e): harden Obsidian runner lifecycle

### DIFF
--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -14,6 +14,9 @@ import {
 	waitForInstanceReady,
 } from "./start-obsidian-e2e-instance.mjs";
 
+/** @typedef {import("./obsidian-e2e-types").InstanceOptions} InstanceOptions */
+/** @typedef {import("./obsidian-e2e-types").WrapperArgs} WrapperArgs */
+
 const VALUE_OPTIONS = new Set([
 	"--vault",
 	"--root",
@@ -47,8 +50,14 @@ Instance options:
 `);
 }
 
+/**
+ * @param {readonly string[]} argv
+ * @returns {WrapperArgs}
+ */
 export function parseArgs(argv) {
+	/** @type {string[]} */
 	const instanceArgs = [];
+	/** @type {string[]} */
 	const commandArgs = [];
 
 	for (let index = 0; index < argv.length; index += 1) {
@@ -92,6 +101,10 @@ export function parseArgs(argv) {
 	};
 }
 
+/**
+ * @param {Pick<InstanceOptions, "obsidianHome">} options
+ * @returns {NodeJS.ProcessEnv}
+ */
 export function obsidianEnv(options) {
 	return {
 		...process.env,
@@ -99,14 +112,18 @@ export function obsidianEnv(options) {
 	};
 }
 
+/**
+ * @param {Pick<InstanceOptions, "vaultName">} options
+ * @param {readonly string[]} commandArgs
+ */
 export function obsidianCommandArgs(options, commandArgs) {
 	return [`vault=${options.vaultName}`, ...commandArgs];
 }
 
+/** @param {InstanceOptions} options */
 export async function ensureObsidianInstance(options) {
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
-	options.userDataPath = profileResult.userDataPath;
 
 	const reused = await isInstanceReady(options);
 	if (reused) {
@@ -130,6 +147,11 @@ export async function ensureObsidianInstance(options) {
 	};
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @param {readonly string[]} commandArgs
+ * @returns {Promise<number>}
+ */
 function spawnObsidian(options, commandArgs) {
 	return new Promise((resolve) => {
 		const child = spawn(options.obsidianBin, obsidianCommandArgs(options, commandArgs), {

--- a/scripts/obsidian-e2e-errors.mjs
+++ b/scripts/obsidian-e2e-errors.mjs
@@ -1,0 +1,40 @@
+/**
+ * @param {unknown} error
+ * @returns {error is { code: unknown }}
+ */
+function hasErrorCode(error) {
+	return typeof error === "object" && error !== null && "code" in error;
+}
+
+/**
+ * @param {unknown} error
+ * @param {string} code
+ */
+export function errorHasCode(error, code) {
+	return hasErrorCode(error) && error.code === code;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+export function isRecord(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Extract the useful output attached to a rejected child-process command.
+ *
+ * @param {unknown} error
+ */
+export function commandErrorMessage(error) {
+	if (typeof error === "object" && error !== null) {
+		if ("stderr" in error && typeof error.stderr === "string" && error.stderr.trim()) {
+			return error.stderr.trim();
+		}
+		if ("stdout" in error && typeof error.stdout === "string" && error.stdout.trim()) {
+			return error.stdout.trim();
+		}
+	}
+	return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/obsidian-e2e-types.d.ts
+++ b/scripts/obsidian-e2e-types.d.ts
@@ -1,0 +1,130 @@
+import type { Dirent } from "node:fs";
+
+export interface ProvisionRawOptions {
+	data?: string;
+	force?: boolean;
+	help?: boolean;
+	json?: boolean;
+	printEnv?: boolean;
+	root?: string;
+	vault?: string;
+	worktree?: string;
+}
+
+export interface ProvisionOptions {
+	dataPath: string | undefined;
+	force: boolean;
+	json: boolean;
+	printEnv: boolean;
+	rootPath: string;
+	vaultName: string;
+	vaultPath: string;
+	worktreePath: string;
+}
+
+export interface ProvisionResult {
+	pluginPath: string;
+	vaultName: string;
+	vaultPath: string;
+	worktreePath: string;
+}
+
+export interface InstanceRawOptions extends ProvisionRawOptions {
+	launch?: boolean;
+	obsidianApp?: string;
+	obsidianBin?: string;
+	profileRoot?: string;
+}
+
+export interface InstanceOptions extends ProvisionOptions {
+	instanceId: string;
+	instancePath: string;
+	launch: boolean;
+	obsidianApp: string;
+	obsidianBin: string;
+	obsidianHome: string;
+	profileRoot: string;
+	userDataPath: string;
+}
+
+export interface ProfileResult {
+	obsidianJsonPath: string;
+	userDataPath: string;
+	vaultId: string;
+}
+
+export interface LaunchResult {
+	pid: null;
+	pidPath: null;
+}
+
+export interface InstanceShellResult {
+	obsidianBin?: string;
+	obsidianHome: string;
+	vaultName: string;
+	vaultPath: string;
+}
+
+export interface WrapperArgs {
+	commandArgs: string[];
+	help: boolean;
+	instanceArgs: string[];
+}
+
+export interface ProcessInfo {
+	command: string;
+	pid: number;
+	ppid: number;
+}
+
+export interface CollectInstanceOptions {
+	selfPid?: number;
+}
+
+export type KillFunction = (pid: number, signal: NodeJS.Signals | 0) => void;
+export type RunPsFunction = () => Promise<string>;
+export type RemoveDirFunction = (dir: string) => Promise<void>;
+export type ReadFileFunction = (file: string) => Promise<string>;
+export type ExistsFunction = (target: string) => Promise<boolean>;
+
+export interface StopOptions {
+	dryRun?: boolean;
+	graceMs?: number;
+	kill?: KillFunction;
+	pollMs?: number;
+	profileRoot?: string;
+	removeDir?: RemoveDirFunction;
+	runPs?: RunPsFunction;
+	selfPid?: number;
+}
+
+export interface StopResult {
+	instancePath: string;
+	killed: number[];
+	pids: number[];
+	removed: boolean;
+	terminated: number[];
+}
+
+export interface InstanceReadDependencies {
+	exists?: ExistsFunction;
+	readFile?: ReadFileFunction;
+}
+
+export interface ReapOptions extends StopOptions, InstanceReadDependencies {
+	exceptInstancePath?: string;
+	log?: (message: string) => void;
+	profileRoot?: string;
+	readdir?: (dir: string) => Promise<Dirent[]>;
+}
+
+export interface ReapResult {
+	reaped: string[];
+	scanned: number;
+}
+
+export interface StopRawOptions extends InstanceRawOptions {
+	dryRun: boolean;
+	json: boolean;
+	prune: boolean;
+}

--- a/scripts/provision-obsidian-e2e-vault.mjs
+++ b/scripts/provision-obsidian-e2e-vault.mjs
@@ -2,6 +2,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { errorHasCode } from "./obsidian-e2e-errors.mjs";
+
+/** @typedef {import("./obsidian-e2e-types").ProvisionOptions} ProvisionOptions */
+/** @typedef {import("./obsidian-e2e-types").ProvisionRawOptions} ProvisionRawOptions */
+/** @typedef {import("./obsidian-e2e-types").ProvisionResult} ProvisionResult */
 
 // PodNotes bundles its CSS into main.js (svelte compilerOptions css: "injected"),
 // so there is no styles.css artifact to symlink — only the manifest and bundle.
@@ -115,6 +120,7 @@ export const DEFAULT_PODNOTES_DATA = {
 	},
 };
 
+/** @param {string} value */
 function slugify(value) {
 	return (
 		value
@@ -140,7 +146,12 @@ Options:
 `);
 }
 
+/**
+ * @param {string[]} argv
+ * @returns {ProvisionRawOptions}
+ */
 export function parseArgs(argv) {
+	/** @type {ProvisionRawOptions} */
 	const options = {
 		force: false,
 		json: false,
@@ -184,10 +195,28 @@ export function parseArgs(argv) {
 	return options;
 }
 
+/**
+ * @param {"--vault" | "--root" | "--worktree" | "--data"} arg
+ * @returns {"vault" | "root" | "worktree" | "data"}
+ */
 function toOptionKey(arg) {
-	return arg.slice(2);
+	switch (arg) {
+		case "--vault":
+			return "vault";
+		case "--root":
+			return "root";
+		case "--worktree":
+			return "worktree";
+		case "--data":
+			return "data";
+	}
 }
 
+/**
+ * @param {ProvisionRawOptions} rawOptions
+ * @param {string} [cwd]
+ * @returns {ProvisionOptions}
+ */
 export function resolveProvisionOptions(rawOptions, cwd = process.cwd()) {
 	const worktreePath = path.resolve(cwd, rawOptions.worktree ?? ".");
 	const vaultName =
@@ -215,16 +244,18 @@ export function resolveProvisionOptions(rawOptions, cwd = process.cwd()) {
 	};
 }
 
+/** @param {string} filePath */
 async function pathExists(filePath) {
 	try {
 		await fs.lstat(filePath);
 		return true;
 	} catch (error) {
-		if (error?.code === "ENOENT") return false;
+		if (errorHasCode(error, "ENOENT")) return false;
 		throw error;
 	}
 }
 
+/** @param {string} worktreePath */
 async function assertRequiredPluginFiles(worktreePath) {
 	const missing = [];
 	for (const fileName of REQUIRED_PLUGIN_FILES) {
@@ -242,17 +273,30 @@ async function assertRequiredPluginFiles(worktreePath) {
 	}
 }
 
+/**
+ * @param {string} filePath
+ * @param {unknown} value
+ */
 async function writeJson(filePath, value) {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 	await fs.writeFile(`${filePath}.tmp`, `${JSON.stringify(value, null, "\t")}\n`);
 	await fs.rename(`${filePath}.tmp`, filePath);
 }
 
+/**
+ * @param {string} filePath
+ * @param {unknown} value
+ */
 async function writeJsonIfMissing(filePath, value) {
 	if (await pathExists(filePath)) return;
 	await writeJson(filePath, value);
 }
 
+/**
+ * @param {string} sourcePath
+ * @param {string} destinationPath
+ * @param {boolean} force
+ */
 async function linkPluginFile(sourcePath, destinationPath, force) {
 	const existing = await pathExists(destinationPath);
 	if (existing && force) {
@@ -276,6 +320,10 @@ async function linkPluginFile(sourcePath, destinationPath, force) {
 	await fs.symlink(sourcePath, destinationPath);
 }
 
+/**
+ * @param {ProvisionOptions} options
+ * @returns {Promise<ProvisionResult>}
+ */
 export async function provisionVault(options) {
 	await assertRequiredPluginFiles(options.worktreePath);
 
@@ -316,6 +364,7 @@ export async function provisionVault(options) {
 	};
 }
 
+/** @param {Pick<ProvisionResult, "vaultName" | "vaultPath">} result */
 export function toShellExports(result) {
 	return [
 		`export PODNOTES_E2E_VAULT=${shellQuote(result.vaultName)}`,
@@ -323,6 +372,7 @@ export function toShellExports(result) {
 	].join("\n");
 }
 
+/** @param {unknown} value */
 function shellQuote(value) {
 	return `'${String(value).replaceAll("'", "'\\''")}'`;
 }

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -5,12 +5,19 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
+import { commandErrorMessage, errorHasCode } from "./obsidian-e2e-errors.mjs";
 import {
 	PODNOTES_READY_EVAL,
 	provisionVault,
 	resolveProvisionOptions,
 	toShellExports,
 } from "./provision-obsidian-e2e-vault.mjs";
+
+/** @typedef {import("./obsidian-e2e-types").InstanceOptions} InstanceOptions */
+/** @typedef {import("./obsidian-e2e-types").InstanceRawOptions} InstanceRawOptions */
+/** @typedef {import("./obsidian-e2e-types").InstanceShellResult} InstanceShellResult */
+/** @typedef {import("./obsidian-e2e-types").LaunchResult} LaunchResult */
+/** @typedef {import("./obsidian-e2e-types").ProfileResult} ProfileResult */
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_PROFILE_ROOT = "/tmp/podnotes-obsidian-e2e";
@@ -43,7 +50,12 @@ Options:
 `);
 }
 
+/**
+ * @param {readonly string[]} argv
+ * @returns {InstanceRawOptions}
+ */
 export function parseArgs(argv) {
+	/** @type {InstanceRawOptions} */
 	const options = {
 		force: false,
 		json: false,
@@ -94,19 +106,41 @@ export function parseArgs(argv) {
 	return options;
 }
 
+/**
+ * @param {"--vault" | "--root" | "--worktree" | "--data" | "--profile-root" | "--obsidian-app" | "--obsidian-bin"} arg
+ * @returns {"vault" | "root" | "worktree" | "data" | "profileRoot" | "obsidianApp" | "obsidianBin"}
+ */
 function toOptionKey(arg) {
-	if (arg === "--profile-root") return "profileRoot";
-	if (arg === "--obsidian-app") return "obsidianApp";
-	if (arg === "--obsidian-bin") return "obsidianBin";
-	return arg.slice(2);
+	switch (arg) {
+		case "--vault":
+			return "vault";
+		case "--root":
+			return "root";
+		case "--worktree":
+			return "worktree";
+		case "--data":
+			return "data";
+		case "--profile-root":
+			return "profileRoot";
+		case "--obsidian-app":
+			return "obsidianApp";
+		case "--obsidian-bin":
+			return "obsidianBin";
+	}
 }
 
+/**
+ * @param {InstanceRawOptions} rawOptions
+ * @param {string} [cwd]
+ * @returns {InstanceOptions}
+ */
 export function resolveInstanceOptions(rawOptions, cwd = process.cwd()) {
 	const provisionOptions = resolveProvisionOptions(rawOptions, cwd);
 	const profileRoot = path.resolve(cwd, rawOptions.profileRoot ?? DEFAULT_PROFILE_ROOT);
 	const instanceId = stableInstanceId(provisionOptions.worktreePath, provisionOptions.vaultName);
 	const instancePath = path.join(profileRoot, instanceId);
 	const obsidianHome = path.join(instancePath, "home");
+	const userDataPath = path.join(obsidianHome, "Library", "Application Support", "obsidian");
 
 	return {
 		...provisionOptions,
@@ -117,9 +151,14 @@ export function resolveInstanceOptions(rawOptions, cwd = process.cwd()) {
 		obsidianBin: rawOptions.obsidianBin ?? DEFAULT_OBSIDIAN_BIN,
 		obsidianHome,
 		profileRoot,
+		userDataPath,
 	};
 }
 
+/**
+ * @param {string} worktreePath
+ * @param {string} vaultName
+ */
 function stableInstanceId(worktreePath, vaultName) {
 	const hash = crypto
 		.createHash("sha256")
@@ -129,6 +168,7 @@ function stableInstanceId(worktreePath, vaultName) {
 	return `${safeName(vaultName).slice(0, 32)}-${hash}`;
 }
 
+/** @param {string} value */
 function safeName(value) {
 	return (
 		value
@@ -138,13 +178,12 @@ function safeName(value) {
 	);
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @returns {Promise<ProfileResult>}
+ */
 export async function prepareObsidianProfile(options) {
-	const userDataPath = path.join(
-		options.obsidianHome,
-		"Library",
-		"Application Support",
-		"obsidian",
-	);
+	const { userDataPath } = options;
 	await fs.mkdir(userDataPath, { recursive: true, mode: 0o700 });
 	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), {
 		recursive: true,
@@ -181,6 +220,7 @@ export async function prepareObsidianProfile(options) {
 	};
 }
 
+/** @param {InstanceOptions} options */
 async function linkHostKeychains(options) {
 	const realHome = process.env.HOME;
 	if (!realHome) return;
@@ -195,7 +235,7 @@ async function linkHostKeychains(options) {
 	try {
 		await fs.lstat(source);
 	} catch (error) {
-		if (error?.code === "ENOENT") return;
+		if (errorHasCode(error, "ENOENT")) return;
 		throw error;
 	}
 
@@ -206,17 +246,22 @@ async function linkHostKeychains(options) {
 		if (path.resolve(path.dirname(destination), target) === source) return;
 		await fs.unlink(destination);
 	} catch (error) {
-		if (error?.code !== "ENOENT") throw error;
+		if (!errorHasCode(error, "ENOENT")) throw error;
 	}
 
 	await fs.mkdir(path.dirname(destination), { recursive: true });
 	await fs.symlink(source, destination);
 }
 
+/** @param {string} vaultPath */
 function stableVaultId(vaultPath) {
 	return crypto.createHash("sha256").update(path.resolve(vaultPath)).digest("hex").slice(0, 16);
 }
 
+/**
+ * @param {string} filePath
+ * @param {unknown} value
+ */
 async function writeJson(filePath, value) {
 	await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
 	try {
@@ -225,13 +270,17 @@ async function writeJson(filePath, value) {
 			throw new Error(`${filePath} exists but is not a regular file.`);
 		}
 	} catch (error) {
-		if (error?.code !== "ENOENT") throw error;
+		if (!errorHasCode(error, "ENOENT")) throw error;
 	}
 	await fs.writeFile(filePath, `${JSON.stringify(value, null, "\t")}\n`, {
 		mode: 0o600,
 	});
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @returns {Promise<LaunchResult>}
+ */
 export async function launchObsidianInstance(options) {
 	await fs.mkdir(options.instancePath, { recursive: true });
 	await execFileAsync(
@@ -258,6 +307,10 @@ export async function launchObsidianInstance(options) {
 	};
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @returns {NodeJS.ProcessEnv}
+ */
 function obsidianEnv(options) {
 	return {
 		...process.env,
@@ -265,19 +318,27 @@ function obsidianEnv(options) {
 	};
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @param {readonly string[]} args
+ * @param {Omit<import("node:child_process").ExecFileOptionsWithStringEncoding, "encoding">} [execOptions]
+ */
 async function execObsidian(options, args, execOptions = {}) {
 	return execFileAsync(options.obsidianBin, args, {
+		encoding: "utf8",
 		env: obsidianEnv(options),
 		...execOptions,
 	});
 }
 
+/** @param {InstanceOptions} options */
 function cliSocketPath(options) {
 	// The obsidian CLI talks to this unix socket; its presence means an instance
 	// for this private HOME is up (or starting to listen).
 	return path.join(options.obsidianHome, ".obsidian-cli.sock");
 }
 
+/** @param {InstanceOptions} options */
 async function cliSocketExists(options) {
 	try {
 		await fs.lstat(cliSocketPath(options));
@@ -287,6 +348,7 @@ async function cliSocketExists(options) {
 	}
 }
 
+/** @param {InstanceOptions} options */
 export async function isInstanceReady(options) {
 	// Non-launching readiness probe: the obsidian CLI auto-launches Obsidian on
 	// the first command when nothing is running, so probing a cold HOME would
@@ -306,6 +368,10 @@ export async function isInstanceReady(options) {
 	}
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @returns {Promise<string>}
+ */
 export async function waitForInstanceReady(options) {
 	const expectedPath = path.resolve(options.vaultPath);
 	const deadline = Date.now() + READY_TIMEOUT_MS;
@@ -330,8 +396,7 @@ export async function waitForInstanceReady(options) {
 			if (actualPath === expectedPath) return actualPath;
 			lastError = `resolved ${actualPath}, expected ${expectedPath}`;
 		} catch (error) {
-			lastError =
-				error?.stderr?.trim() || error?.stdout?.trim() || error?.message || String(error);
+			lastError = commandErrorMessage(error);
 		}
 		await sleep(READY_INTERVAL_MS);
 	}
@@ -341,6 +406,10 @@ export async function waitForInstanceReady(options) {
 	);
 }
 
+/**
+ * @param {InstanceOptions} options
+ * @returns {Promise<boolean>}
+ */
 export async function trustVaultAndVerifyPodNotes(options) {
 	await execObsidian(options, [`vault=${options.vaultName}`, "plugins:restrict", "off"]);
 
@@ -356,8 +425,7 @@ export async function trustVaultAndVerifyPodNotes(options) {
 			if (stdout.includes(PODNOTES_READY_MARKER)) return true;
 			lastError = stdout.trim();
 		} catch (error) {
-			lastError =
-				error?.stderr?.trim() || error?.stdout?.trim() || error?.message || String(error);
+			lastError = commandErrorMessage(error);
 		}
 		await sleep(READY_INTERVAL_MS);
 	}
@@ -367,16 +435,19 @@ export async function trustVaultAndVerifyPodNotes(options) {
 	);
 }
 
+/** @param {InstanceOptions} options */
 export async function reloadPodNotes(options) {
 	// Reload the plugin so a reused instance picks up a rebuilt main.js (the
 	// symlink target) instead of running the bundle it loaded earlier.
 	await execObsidian(options, [`vault=${options.vaultName}`, "plugin:reload", "id=podnotes"]);
 }
 
+/** @param {number} ms */
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** @param {InstanceShellResult} result */
 export function toInstanceShellExports(result) {
 	const lines = [
 		toShellExports(result),
@@ -390,6 +461,7 @@ export function toInstanceShellExports(result) {
 	return lines.join("\n");
 }
 
+/** @param {unknown} value */
 function shellQuote(value) {
 	return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
@@ -400,6 +472,7 @@ function shellQuote(value) {
 // start. The reaper is imported lazily so the static module graph stays acyclic
 // (the stop module imports our option resolver; we only need its reaper at
 // runtime). Logs go to stderr so `--print-env` keeps stdout to `export …` lines.
+/** @param {InstanceOptions} options */
 export async function reapStaleInstances(options) {
 	try {
 		const { reapOrphanedInstances } = await import("./stop-obsidian-e2e-instance.mjs");
@@ -426,7 +499,6 @@ async function main() {
 	await reapStaleInstances(options);
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
-	options.userDataPath = profileResult.userDataPath;
 
 	let launchResult = { pid: null, pidPath: null };
 	let resolvedVaultPath = null;

--- a/scripts/start-obsidian-e2e-instance.test.ts
+++ b/scripts/start-obsidian-e2e-instance.test.ts
@@ -44,6 +44,9 @@ describe("start-obsidian-e2e-instance", () => {
 			),
 		).toBe(true);
 		expect(options.obsidianHome.endsWith("/home")).toBe(true);
+		expect(options.userDataPath).toBe(
+			path.join(options.obsidianHome, "Library", "Application Support", "obsidian"),
+		);
 		expect(options.vaultPath).toBe(
 			path.join("/tmp/podnotes-instance", "vaults", "podnotes-worktree-a"),
 		);
@@ -65,6 +68,7 @@ describe("start-obsidian-e2e-instance", () => {
 		);
 
 		const profile = await prepareObsidianProfile(options);
+		expect(profile.userDataPath).toBe(options.userDataPath);
 		const registry = JSON.parse(await fs.readFile(profile.obsidianJsonPath, "utf8"));
 		const vaults = Object.values(registry.vaults) as Array<{
 			path: string;

--- a/scripts/stop-obsidian-e2e-instance.mjs
+++ b/scripts/stop-obsidian-e2e-instance.mjs
@@ -4,7 +4,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
+import { errorHasCode, isRecord } from "./obsidian-e2e-errors.mjs";
 import { INSTANCE_MARKER_FILE, resolveInstanceOptions } from "./start-obsidian-e2e-instance.mjs";
+
+/** @typedef {import("./obsidian-e2e-types").CollectInstanceOptions} CollectInstanceOptions */
+/** @typedef {import("./obsidian-e2e-types").InstanceReadDependencies} InstanceReadDependencies */
+/** @typedef {import("./obsidian-e2e-types").KillFunction} KillFunction */
+/** @typedef {import("./obsidian-e2e-types").ProcessInfo} ProcessInfo */
+/** @typedef {import("./obsidian-e2e-types").ReapOptions} ReapOptions */
+/** @typedef {import("./obsidian-e2e-types").ReapResult} ReapResult */
+/** @typedef {import("./obsidian-e2e-types").StopOptions} StopOptions */
+/** @typedef {import("./obsidian-e2e-types").StopRawOptions} StopRawOptions */
+/** @typedef {import("./obsidian-e2e-types").StopResult} StopResult */
 
 const execFileAsync = promisify(execFile);
 
@@ -29,6 +40,14 @@ const VALUE_OPTIONS = new Set([
 	"--obsidian-bin",
 ]);
 
+/**
+ * @param {string} arg
+ * @returns {arg is "--vault" | "--root" | "--worktree" | "--data" | "--profile-root" | "--obsidian-app" | "--obsidian-bin"}
+ */
+function isValueOption(arg) {
+	return VALUE_OPTIONS.has(arg);
+}
+
 function printUsage() {
 	console.log(`Usage: node scripts/stop-obsidian-e2e-instance.mjs [options]
 
@@ -49,7 +68,12 @@ Options:
 `);
 }
 
+/**
+ * @param {readonly string[]} argv
+ * @returns {StopRawOptions}
+ */
 export function parseArgs(argv) {
+	/** @type {StopRawOptions} */
 	const options = { dryRun: false, json: false, prune: false };
 
 	for (let index = 0; index < argv.length; index += 1) {
@@ -70,7 +94,7 @@ export function parseArgs(argv) {
 				options.help = true;
 				break;
 			default: {
-				if (!VALUE_OPTIONS.has(arg)) {
+				if (!isValueOption(arg)) {
 					throw new Error(`Unknown option: ${arg}`);
 				}
 				const value = argv[index + 1];
@@ -86,21 +110,42 @@ export function parseArgs(argv) {
 	return options;
 }
 
+/**
+ * @param {"--vault" | "--root" | "--worktree" | "--data" | "--profile-root" | "--obsidian-app" | "--obsidian-bin"} arg
+ * @returns {"vault" | "root" | "worktree" | "data" | "profileRoot" | "obsidianApp" | "obsidianBin"}
+ */
 function toOptionKey(arg) {
-	if (arg === "--profile-root") return "profileRoot";
-	if (arg === "--obsidian-app") return "obsidianApp";
-	if (arg === "--obsidian-bin") return "obsidianBin";
-	return arg.slice(2);
+	switch (arg) {
+		case "--vault":
+			return "vault";
+		case "--root":
+			return "root";
+		case "--worktree":
+			return "worktree";
+		case "--data":
+			return "data";
+		case "--profile-root":
+			return "profileRoot";
+		case "--obsidian-app":
+			return "obsidianApp";
+		case "--obsidian-bin":
+			return "obsidianBin";
+	}
 }
 
 // macOS firmlinks /tmp, /var, and /etc under /private. Obsidian's main process
 // keeps the literal `--user-data-dir` we pass (e.g. /tmp/...), while Electron
 // canonicalizes the same flag to /private/tmp/... for its helper processes.
 // Strip a leading /private so one instance path matches the whole process tree.
+/** @param {string} value */
 function stripPrivatePrefix(value) {
 	return value.replace(/^\/private(?=\/)/, "");
 }
 
+/**
+ * @param {string} command
+ * @param {string} instancePath
+ */
 export function commandMatchesInstance(command, instancePath) {
 	const stripped = stripPrivatePrefix(instancePath);
 	const variants = new Set([instancePath, stripped, stripped.replace(/^\//, "/private/")]);
@@ -112,7 +157,12 @@ export function commandMatchesInstance(command, instancePath) {
 	return [...variants].some((variant) => command.includes(`--user-data-dir=${variant}/`));
 }
 
+/**
+ * @param {string} stdout
+ * @returns {ProcessInfo[]}
+ */
 export function parsePsOutput(stdout) {
+	/** @type {ProcessInfo[]} */
 	const processes = [];
 	for (const line of stdout.split("\n")) {
 		const match = line.match(/^\s*(\d+)\s+(\d+)\s+(.*\S)\s*$/);
@@ -131,8 +181,15 @@ export function parsePsOutput(stdout) {
 // descendant. The descendant walk is belt-and-suspenders — Electron helpers
 // already carry --user-data-dir, but this also reaps any grandchild a helper
 // spawned that does not echo the flag.
+/**
+ * @param {readonly ProcessInfo[]} processes
+ * @param {string} instancePath
+ * @param {CollectInstanceOptions} [options]
+ * @returns {number[]}
+ */
 export function collectInstancePids(processes, instancePath, options = {}) {
 	const selfPid = options.selfPid ?? process.pid;
+	/** @type {Map<number, ProcessInfo[]>} */
 	const childrenByParent = new Map();
 	for (const proc of processes) {
 		const siblings = childrenByParent.get(proc.ppid) ?? [];
@@ -140,12 +197,14 @@ export function collectInstancePids(processes, instancePath, options = {}) {
 		childrenByParent.set(proc.ppid, siblings);
 	}
 
+	/** @type {Set<number>} */
 	const collected = new Set();
 	const stack = processes
 		.filter((proc) => commandMatchesInstance(proc.command, instancePath))
 		.map((proc) => proc.pid);
 	while (stack.length > 0) {
 		const pid = stack.pop();
+		if (pid === undefined) continue;
 		if (collected.has(pid)) continue;
 		collected.add(pid);
 		for (const child of childrenByParent.get(pid) ?? []) {
@@ -159,6 +218,10 @@ export function collectInstancePids(processes, instancePath, options = {}) {
 	return [...collected].sort((a, b) => a - b);
 }
 
+/**
+ * @param {string} instancePath
+ * @param {string | undefined} profileRoot
+ */
 function assertSafeInstancePath(instancePath, profileRoot) {
 	if (!instancePath || !path.isAbsolute(instancePath)) {
 		throw new Error(`Refusing to remove non-absolute instance path: ${instancePath}`);
@@ -184,6 +247,7 @@ function assertSafeInstancePath(instancePath, profileRoot) {
 	}
 }
 
+/** @returns {Promise<string>} */
 async function defaultRunPs() {
 	const { stdout } = await execFileAsync("ps", ["-axww", "-o", "pid=,ppid=,command="], {
 		maxBuffer: 16 * 1024 * 1024,
@@ -191,6 +255,10 @@ async function defaultRunPs() {
 	return stdout;
 }
 
+/**
+ * @param {number} pid
+ * @param {KillFunction} kill
+ */
 function pidAlive(pid, kill) {
 	try {
 		kill(pid, 0);
@@ -198,10 +266,13 @@ function pidAlive(pid, kill) {
 	} catch (error) {
 		// EPERM means the process exists but is owned by someone else; for our own
 		// instances that should not happen, but treat it as alive to be safe.
-		return error?.code === "EPERM";
+		if (errorHasCode(error, "EPERM")) return true;
+		if (errorHasCode(error, "ESRCH")) return false;
+		throw error;
 	}
 }
 
+/** @param {number} ms */
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -212,6 +283,17 @@ function sleep(ms) {
 // recycled by a foreign process; skip rather than touch it), ENOENT (defensive).
 const IGNORABLE_KILL_CODES = new Set(["ESRCH", "EPERM", "ENOENT"]);
 
+/** @param {unknown} error */
+function isIgnorableKillError(error) {
+	return [...IGNORABLE_KILL_CODES].some((code) => errorHasCode(error, code));
+}
+
+/**
+ * @param {readonly number[]} pids
+ * @param {NodeJS.Signals} signal
+ * @param {KillFunction} kill
+ * @returns {number[]}
+ */
 function signalPids(pids, signal, kill) {
 	const signalled = [];
 	for (const pid of pids) {
@@ -219,7 +301,7 @@ function signalPids(pids, signal, kill) {
 			kill(pid, signal);
 			signalled.push(pid);
 		} catch (error) {
-			if (!IGNORABLE_KILL_CODES.has(error?.code)) throw error;
+			if (!isIgnorableKillError(error)) throw error;
 		}
 	}
 	return signalled;
@@ -229,6 +311,11 @@ function signalPids(pids, signal, kill) {
 // stragglers) and remove its profile directory. Safe to call when nothing is
 // running — it then just removes a leftover directory. All side effects are
 // injectable so the orchestration is unit-testable without real processes.
+/**
+ * @param {string} instancePath
+ * @param {StopOptions} [options]
+ * @returns {Promise<StopResult>}
+ */
 export async function stopInstance(instancePath, options = {}) {
 	const {
 		dryRun = false,
@@ -268,6 +355,11 @@ export async function stopInstance(instancePath, options = {}) {
 // Reads the vault paths an instance registered in its private obsidian.json.
 // Returns null when the registration is unreadable (so callers can stay
 // conservative and not reap an instance they cannot reason about).
+/**
+ * @param {string} instancePath
+ * @param {InstanceReadDependencies} [deps]
+ * @returns {Promise<string[] | null>}
+ */
 export async function readInstanceVaultPaths(instancePath, deps = {}) {
 	const readFile = deps.readFile ?? ((file) => fs.readFile(file, "utf8"));
 	const jsonPath = path.join(
@@ -279,31 +371,46 @@ export async function readInstanceVaultPaths(instancePath, deps = {}) {
 		"obsidian.json",
 	);
 	try {
-		const parsed = JSON.parse(await readFile(jsonPath));
-		return Object.values(parsed?.vaults ?? {})
-			.map((vault) => vault?.path)
-			.filter((vaultPath) => typeof vaultPath === "string");
+		const parsed = /** @type {unknown} */ (JSON.parse(await readFile(jsonPath)));
+		if (!isRecord(parsed) || !isRecord(parsed.vaults)) return null;
+
+		const vaultPaths = [];
+		for (const vault of Object.values(parsed.vaults)) {
+			if (isRecord(vault) && typeof vault.path === "string") {
+				vaultPaths.push(vault.path);
+			}
+		}
+		return vaultPaths;
 	} catch {
 		return null;
 	}
 }
 
+/** @param {string} target */
 async function pathExists(target) {
 	try {
 		await fs.lstat(target);
 		return true;
 	} catch (error) {
-		if (error?.code === "ENOENT") return false;
+		if (errorHasCode(error, "ENOENT")) return false;
 		throw error;
 	}
 }
 
 // Reads the instance marker that start writes (worktreePath/vaultName/vaultPath).
 // Returns null when it is missing/unreadable so callers can fall back.
+/**
+ * @param {string} instancePath
+ * @param {InstanceReadDependencies} [deps]
+ * @returns {Promise<Record<string, unknown> | null>}
+ */
 export async function readInstanceMarker(instancePath, deps = {}) {
 	const readFile = deps.readFile ?? ((file) => fs.readFile(file, "utf8"));
 	try {
-		return JSON.parse(await readFile(path.join(instancePath, INSTANCE_MARKER_FILE)));
+		const parsed = /** @type {unknown} */ (
+			JSON.parse(await readFile(path.join(instancePath, INSTANCE_MARKER_FILE)))
+		);
+		return isRecord(parsed) ? parsed : null;
 	} catch {
 		return null;
 	}
@@ -316,6 +423,10 @@ export async function readInstanceMarker(instancePath, deps = {}) {
 // as the signal — an idle-but-valid instance for a live worktree, or a vault on a
 // momentarily-unmounted volume, must survive. The worktree path is read from the
 // marker; pre-marker instances fall back to "every registered vault path is gone".
+/**
+ * @param {string} instancePath
+ * @param {InstanceReadDependencies} [deps]
+ */
 export async function isInstanceOrphaned(instancePath, deps = {}) {
 	const exists = deps.exists ?? pathExists;
 	const marker = await readInstanceMarker(instancePath, deps);
@@ -333,6 +444,10 @@ export async function isInstanceOrphaned(instancePath, deps = {}) {
 // Scans the profile root and tears down every orphaned instance. Used as a
 // self-healing safety net on the next `start:e2e-obsidian` so leaks survive even
 // when a worktree is removed without the orca archive hook (`--run-hooks`).
+/**
+ * @param {ReapOptions} [options]
+ * @returns {Promise<ReapResult>}
+ */
 export async function reapOrphanedInstances(options = {}) {
 	const {
 		profileRoot,
@@ -349,10 +464,11 @@ export async function reapOrphanedInstances(options = {}) {
 	try {
 		entries = await readdir(profileRoot);
 	} catch (error) {
-		if (error?.code === "ENOENT") return { scanned: 0, reaped: [] };
+		if (errorHasCode(error, "ENOENT")) return { scanned: 0, reaped: [] };
 		throw error;
 	}
 
+	/** @type {string[]} */
 	const reaped = [];
 	let scanned = 0;
 	const except = exceptInstancePath ? path.resolve(exceptInstancePath) : null;
@@ -399,6 +515,7 @@ async function main() {
 		profileRoot: options.profileRoot,
 	});
 
+	/** @type {ReapResult} */
 	let pruneResult = { scanned: 0, reaped: [] };
 	if (rawOptions.prune) {
 		pruneResult = await reapOrphanedInstances({

--- a/scripts/stop-obsidian-e2e-instance.test.ts
+++ b/scripts/stop-obsidian-e2e-instance.test.ts
@@ -8,6 +8,7 @@ import {
 	isInstanceOrphaned,
 	parseArgs,
 	parsePsOutput,
+	readInstanceMarker,
 	readInstanceVaultPaths,
 	reapOrphanedInstances,
 	stopInstance,
@@ -266,6 +267,29 @@ describe("stopInstance", () => {
 		expect(result.removed).toBe(true);
 	});
 
+	it("preserves the profile when a liveness probe fails unexpectedly", async () => {
+		let removeCalled = false;
+		const kill = (_pid: number, signal: string | number) => {
+			if (signal === 0) {
+				throw Object.assign(new Error("I/O failure"), { code: "EIO" });
+			}
+		};
+
+		await expect(
+			stopInstance(INSTANCE, {
+				runPs,
+				kill,
+				removeDir: async () => {
+					removeCalled = true;
+				},
+				selfPid: 999999,
+				pollMs: 1,
+				graceMs: 5,
+			}),
+		).rejects.toThrow("I/O failure");
+		expect(removeCalled).toBe(false);
+	});
+
 	it("refuses to remove a dir that is not a child of the given profile root", async () => {
 		await expect(
 			stopInstance(INSTANCE, {
@@ -300,6 +324,36 @@ describe("orphan detection", () => {
 		const root = await makeTempDir("podnotes-profiles");
 		const instance = await seedInstance(root, "podnotes-a-aaaaaaaaaaaa", "/x/y");
 		await expect(readInstanceVaultPaths(instance)).resolves.toEqual(["/x/y"]);
+	});
+
+	it("ignores malformed vault entries while keeping valid paths", async () => {
+		await expect(
+			readInstanceVaultPaths(INSTANCE, {
+				readFile: async () =>
+					JSON.stringify({
+						vaults: {
+							missing: {},
+							nonObject: null,
+							nonString: { path: 42 },
+							valid: { path: "/valid/vault" },
+						},
+					}),
+			}),
+		).resolves.toEqual(["/valid/vault"]);
+	});
+
+	it("rejects a registry whose JSON value is not an object", async () => {
+		await expect(
+			readInstanceVaultPaths(INSTANCE, { readFile: async () => '"not-a-registry"' }),
+		).resolves.toBeNull();
+	});
+
+	it("rejects an array-shaped vault registry", async () => {
+		await expect(
+			readInstanceVaultPaths(INSTANCE, {
+				readFile: async () => JSON.stringify({ vaults: [{ path: "/unexpected/vault" }] }),
+			}),
+		).resolves.toBeNull();
 	});
 
 	it("is orphaned only when every backing vault is gone", async () => {
@@ -339,6 +393,18 @@ describe("orphan detection", () => {
 		const bare = path.join(root, "podnotes-bare-dddddddddddd");
 		await fs.mkdir(bare, { recursive: true });
 		await expect(isInstanceOrphaned(bare)).resolves.toBe(false);
+	});
+
+	it("rejects a marker whose JSON value is not an object", async () => {
+		await expect(
+			readInstanceMarker(INSTANCE, { readFile: async () => '"not-a-marker"' }),
+		).resolves.toBeNull();
+	});
+
+	it("rejects an array-shaped marker", async () => {
+		await expect(
+			readInstanceMarker(INSTANCE, { readFile: async () => "[]" }),
+		).resolves.toBeNull();
 	});
 });
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,8 +2,8 @@
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"allowJs": true,
-		// JavaScript tools opt in with `@ts-check` until the E2E runner scripts are typed.
-		"checkJs": false,
+		"checkJs": true,
+		"lib": ["DOM", "ES2021"],
 		"types": ["svelte", "node", "obsidian", "vitest/globals", "@testing-library/jest-dom"]
 	},
 	"include": [
@@ -13,6 +13,7 @@
 		"tests/**/*.ts",
 		"tests/**/*.svelte",
 		"scripts/**/*.ts",
+		"scripts/**/*.mjs",
 		"*.ts",
 		"*.mjs"
 	]


### PR DESCRIPTION
Strictly type-check every JavaScript file in the Obsidian E2E runner subsystem and harden the lifecycle defects the new checks exposed.

This adds shared JSDoc declarations and structural unknown-error guards, enables `checkJs` for all script MJS files, and reduces the runner diagnostic baseline from 121 to zero without `any`, TypeScript suppressions, lint suppressions, or weakened strictness.

Three defects were reproduced with failing tests before correction:

- resolved instance options omitted the required Electron `userDataPath`, so exported resolver/launcher composition could emit `--user-data-dir=undefined`; the path is now derived once with `obsidianHome`
- unexpected process-liveness errors were treated as proof that a process had exited, allowing cleanup to remove a profile when process state was unknown; only `ESRCH` now means dead, `EPERM` means alive, and other errors abort cleanup
- array-shaped registry and marker JSON passed the old object guard and could become authoritative orphan-reaping data; only plain records are now accepted

Malformed registry entries are filtered structurally, parser option keys are exhaustive, child-process output is explicitly UTF-8, collections and injected dependencies have exact contracts, and the production ES2020 target remains unchanged. The test/tool library is raised only to ES2021 for the Node 22 runners.

Validation:

- strict JavaScript diagnostics: 121 -> 0
- focused runner suite: 4 files, 46 tests
- full suite: 70 files, 883 tests
- real Obsidian E2E: 1 file, 11 tests
- lint, formatting, both TypeScript projects, both Svelte environments, production build, Node syntax, docs, and diff check pass
- all four direct `node scripts/*.mjs --help` entry points pass
- production bundle remains byte-identical at 410,805 bytes, SHA-256 `6f593e89c049bc84a8a9b3da90a5f002ccc5b8e1066ae05aef671dbc12cd5ebc`

Real runtime proof:

- macOS 26.5.1, Obsidian 1.12.7, isolated vault `podnotes-podnotes`
- PodNotes 2.17.3 loaded and the committed E2E suite passed through the private HOME
- after clearing expected dummy-audio errors and reloading, `dev:errors` reported no errors
- teardown terminated the complete process tree without SIGKILL and removed the private profile

Two independent read-only reviews found and then cleared the array-guard issue. Final verdict: no actionable findings.
