### PR TITLE
fix(release): verify recovery attestation source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       release-sha: ${{ steps.resolve.outputs.release-sha }}
       pr-number: ${{ steps.resolve.outputs.pr-number }}
       source-ref: ${{ steps.resolve.outputs.source-ref }}
+      source-sha: ${{ steps.resolve.outputs.source-sha }}
       version: ${{ steps.resolve.outputs.version }}
     steps:
       - name: Validate merged release PR provenance
@@ -138,6 +139,7 @@ jobs:
             core.setOutput('release-sha', releaseSha);
             core.setOutput('pr-number', String(pullNumber));
             core.setOutput('source-ref', sourceRef);
+            core.setOutput('source-sha', process.env.EVENT_SHA);
             core.setOutput('version', version);
             core.notice(`Validated release PR #${pullNumber} for ${version} at ${releaseSha}.`);
 
@@ -470,7 +472,7 @@ jobs:
 
       - name: Verify GitHub attestations
         env:
-          EXPECTED_SHA: ${{ needs.resolve.outputs.release-sha }}
+          EXPECTED_SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
           GH_TOKEN: ${{ github.token }}
           SOURCE_REF: ${{ needs.resolve.outputs.source-ref }}
         run: |
@@ -480,7 +482,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --signer-workflow "$SIGNER_WORKFLOW" \
               --source-ref "$SOURCE_REF" \
-              --source-digest "$EXPECTED_SHA" \
+              --source-digest "$EXPECTED_SOURCE_SHA" \
               --deny-self-hosted-runners
           done
 


### PR DESCRIPTION
## Summary
- expose the exact workflow source SHA from release provenance validation
- verify GitHub attestations against that workflow source SHA and ref
- keep the built release commit independently pinned by the validated release context, version-file contract, checkout, tag, and payload metadata

## Failure reproduced
Recovery run 29079826974 correctly used the reviewed workflow from `refs/heads/master` while rebuilding release commit `79c6421334caae9c9ec3fa97620e49ae2dad95c9`. The attestation verifier still required the release commit as its source digest, so it selected the earlier `release-run/2.17.4` attestation and rejected the master source ref before publication.

## Validation
- `git diff --check`
- `npm run format:check`
- Ruby YAML parse of `.github/workflows/release.yml`
- `npm run test -- scripts/release-contract.test.ts scripts/release-plan.test.ts` (28 tests)

## Recovery
After merge, rerun `release.yml` from protected master for release PR #259. The verifier will bind attestations to the exact reviewed master workflow commit while the release payload and tag remain bound to the original 2.17.4 merge commit.