### PR TITLE
ci(deps): update artifact actions

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload version-file plan
         if: steps.plan.outputs.release == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.plan.outputs.artifact-name }}
           path: ${{ runner.temp }}/release-version-files
@@ -174,7 +174,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download version-file plan
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.plan.outputs.artifact-name }}
           path: release-version-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
           NODE
 
       - name: Upload verified build payload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ needs.resolve.outputs.artifact-name }}
           path: ${{ runner.temp }}/release-payload
@@ -380,7 +380,7 @@ jobs:
       id-token: write
     steps:
       - name: Download verified build payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.resolve.outputs.artifact-name }}
           path: release-payload
@@ -465,7 +465,7 @@ jobs:
       contents: write
     steps:
       - name: Download verified release payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.resolve.outputs.artifact-name }}
           path: release-payload


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` from v4.6.2 to v7.0.1
- update `actions/download-artifact` from v4.3.0 to v8.0.1
- keep every action pinned to the immutable official tag commit

Both current majors declare the Node 24 action runtime. This removes the Node 20 deprecation warnings emitted by the verified 2.17.4 release and keeps the release payload round trip on supported GitHub-hosted runner behavior.

## Validation
- resolved both official release tags through the GitHub Git ref API
- inspected both official `action.yml` files and confirmed `runs.using: node24`
- `git diff --check`
- `npm run format:check`
- parsed every workflow YAML file with Ruby Psych
- release 2.17.4 already proved the surrounding upload, download, attestation, digest, and publication contract before this dependency-only update

## Release impact
None. This changes CI dependencies only and does not modify plugin assets or version files.