### PR TITLE
fix(security): harden template string escaping

### DIFF
--- a/src/TemplateEngine.test.ts
+++ b/src/TemplateEngine.test.ts
@@ -336,6 +336,23 @@ describe("default note template renders valid frontmatter (#160)", () => {
 		// Empty publish date renders as a null property, never a broken value.
 		expect(dateLine?.replace(/\s+$/, "")).toBe("date:");
 	});
+
+	it("keeps quote- and backslash-heavy titles in Markdown body context", () => {
+		const episode: Episode = {
+			...demoEpisode,
+			title: 'A ""quoted"" \\[title\\]\nwith controls\u0000\u007f',
+		};
+		const rendered = NoteTemplateEngine(DEFAULT_SETTINGS.note.template, episode);
+		const frontmatter = frontmatterOf(rendered);
+		const body = rendered.slice(rendered.indexOf("\n---\n") + 5);
+
+		// The default contract keeps raw metadata out of YAML, where Markdown
+		// escaping would not protect a quoted scalar. Its body encoding preserves
+		// the visible characters while collapsing the injected line break.
+		expect(frontmatter).not.toContain("quoted");
+		expect(frontmatter).not.toContain("title");
+		expect(body).toContain(String.raw`# A ""quoted"" \\\[title\\\] with controls`);
+	});
 });
 
 describe("FeedNoteTemplateEngine (#163)", () => {
@@ -362,6 +379,25 @@ describe("FeedNoteTemplateEngine (#163)", () => {
 		expect(FeedNoteTemplateEngine("{{title}}", feed)).toBe("My Show: A Podcast");
 		expect(FeedNoteTemplateEngine("{{podcast}}", feed)).toBe("My Show A Podcast");
 		expect(FeedNoteTemplateEngine("{{safetitle}}", feed)).toBe("My Show A Podcast");
+	});
+
+	it("keeps the default line-leading author in plain Markdown text context", () => {
+		const attacks = [
+			["# forged heading", String.raw`\# forged heading`],
+			["> forged quote", "&gt; forged quote"],
+			["---", String.raw`\-\-\-`],
+			["~~~dataviewjs", String.raw`\~\~\~dataviewjs`],
+			["```dataviewjs", "\\`\\`\\`dataviewjs"],
+		] as const;
+
+		for (const [author, encodedAuthor] of attacks) {
+			const rendered = FeedNoteTemplateEngine(DEFAULT_SETTINGS.feedNote.template, {
+				...feed,
+				author,
+			});
+
+			expect(rendered).toContain(`\n${encodedAuthor}\n\n`);
+		}
 	});
 
 	it("leaves {{url}} empty when the feed has no website link", () => {
@@ -695,6 +731,125 @@ describe("feed content injection is neutralized (deepsec other-markdown-injectio
 		expect(rendered).toContain("\\[pixel\\]");
 	});
 
+	it("does not let input backslashes reactivate escaped Markdown links", () => {
+		const malicious: Episode = {
+			...demoEpisode,
+			// Each bracket arrives already preceded by a backslash. If the sanitizer
+			// only prefixes the bracket, the resulting even-length backslash run
+			// leaves that bracket active in CommonMark and recreates a live link.
+			title: String.raw`\[click\](//attacker.example/phish)`,
+		};
+
+		expect(NoteTemplateEngine("{{title}}", malicious)).toBe(
+			String.raw`\\\[click\\\]\(//attacker\.example/phish\)`,
+		);
+	});
+
+	it("keeps every Markdown metacharacter escaped after any input backslash run", () => {
+		const punctuation = [
+			"`",
+			"*",
+			"_",
+			"{",
+			"}",
+			"[",
+			"]",
+			"(",
+			")",
+			"#",
+			"+",
+			"-",
+			".",
+			"!",
+			"|",
+			"=",
+			"~",
+			"$",
+			"%",
+			"^",
+		];
+
+		for (const metacharacter of punctuation) {
+			for (let inputBackslashes = 0; inputBackslashes <= 6; inputBackslashes += 1) {
+				const inputPrefix = "\\".repeat(inputBackslashes);
+				const expectedPrefix = "\\".repeat(inputBackslashes * 2 + 1);
+				const episode: Episode = {
+					...demoEpisode,
+					title: `${inputPrefix}${metacharacter}text`,
+				};
+
+				expect(NoteTemplateEngine("{{title}}", episode)).toBe(
+					`${expectedPrefix}${metacharacter}text`,
+				);
+			}
+		}
+	});
+
+	it("neutralizes line-leading CommonMark and Obsidian block markers", () => {
+		const attacks = [
+			["# forged heading", String.raw`\# forged heading`],
+			["> forged quote", "&gt; forged quote"],
+			["- forged list", String.raw`\- forged list`],
+			["+ forged list", String.raw`\+ forged list`],
+			["1. forged list", String.raw`1\. forged list`],
+			["1) forged list", String.raw`1\) forged list`],
+			["---", String.raw`\-\-\-`],
+			["***", String.raw`\*\*\*`],
+			["___", String.raw`\_\_\_`],
+			["===", String.raw`\=\=\=`],
+			["~~~dataviewjs", String.raw`\~\~\~dataviewjs`],
+			["```dataviewjs", "\\`\\`\\`dataviewjs"],
+			["<script>alert(1)</script>", "&lt;script&gt;alert\\(1\\)&lt;/script&gt;"],
+		] as const;
+
+		for (const [title, encodedTitle] of attacks) {
+			expect(NoteTemplateEngine("{{title}}\n", { ...demoEpisode, title })).toBe(
+				`${encodedTitle}\n`,
+			);
+		}
+	});
+
+	it("encodes ampersands before angle entities so entity-looking input stays literal", () => {
+		const episode: Episode = {
+			...demoEpisode,
+			title: "Fish & chips <b>bold</b> &lt; &#35;",
+		};
+
+		expect(NoteTemplateEngine("{{title}}", episode)).toBe(
+			String.raw`Fish &amp; chips &lt;b&gt;bold&lt;/b&gt; &amp;lt; &amp;\#35;`,
+		);
+	});
+
+	it("preserves repeated input backslashes before ampersands and angle brackets", () => {
+		for (const [character, entity] of [
+			["&", "&amp;"],
+			["<", "&lt;"],
+			[">", "&gt;"],
+		] as const) {
+			for (let inputBackslashes = 0; inputBackslashes <= 6; inputBackslashes += 1) {
+				const episode: Episode = {
+					...demoEpisode,
+					title: `${"\\".repeat(inputBackslashes)}${character}text`,
+				};
+
+				expect(NoteTemplateEngine("{{title}}", episode)).toBe(
+					`${"\\".repeat(inputBackslashes * 2)}${entity}text`,
+				);
+			}
+		}
+	});
+
+	it("preserves quotes and visible backslashes while collapsing control sequences", () => {
+		const episode: Episode = {
+			...demoEpisode,
+			title: 'She said ""listen""\n\tthen\u0000\u001f\u007fopened C:\\Podcasts\\Episode',
+		};
+
+		expect(NoteTemplateEngine("{{title}}", episode)).toBe(
+			'She said ""listen"" then opened C:\\\\Podcasts\\\\Episode',
+		);
+	});
+
 	it("renders an injected ```dataviewjs code block inert while keeping normal formatting", () => {
 		const malicious: Episode = {
 			...demoEpisode,
@@ -759,18 +914,21 @@ describe("feed content injection is neutralized (deepsec other-markdown-injectio
 		expect(rendered).not.toContain("```dataviewjs");
 	});
 
-	it("preserves legitimate episode metadata verbatim", () => {
-		// A normal episode must be unaffected by the sanitizers.
+	it("preserves legitimate episode metadata when Markdown renders the encoded source", () => {
+		// Plain text stays readable in source when it has no structural punctuation.
 		expect(NoteTemplateEngine("# {{title}}", demoEpisode)).toBe("# Episode 1");
 		expect(NoteTemplateEngine("{{url}}|{{artwork}}", demoEpisode)).toBe(
 			"https://example.com/ep1|https://example.com/ep1.png",
 		);
-		// A title with ordinary punctuation (dots, colons, quotes, parens) is kept.
+		// Context-sensitive punctuation is escaped in source; quotes and colons remain
+		// readable, and Markdown renders the visible title exactly as supplied.
 		const punctuated: Episode = {
 			...demoEpisode,
 			title: "Ep. 5: A.I. & You (Part 1)",
 		};
-		expect(NoteTemplateEngine("# {{title}}", punctuated)).toBe("# Ep. 5: A.I. & You (Part 1)");
+		expect(NoteTemplateEngine("# {{title}}", punctuated)).toBe(
+			String.raw`# Ep\. 5: A\.I\. &amp; You \(Part 1\)`,
+		);
 	});
 });
 

--- a/src/TemplateEngine.ts
+++ b/src/TemplateEngine.ts
@@ -145,40 +145,40 @@ function formatChapterTitle(title: string): string {
 	return title.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Encode plain text for an arbitrary Markdown body position. The template engine
+ * cannot know whether a tag is placed at the start of a line, after text that can
+ * become a Setext heading, or inside another Markdown construct, so every
+ * CommonMark/Obsidian punctuation character that can change structure is escaped
+ * everywhere. Quotes, colons, commas, and other inert prose punctuation remain
+ * readable in source; all escapes render as the original visible characters.
+ *
+ * Ampersands must be encoded before producing the angle-bracket entities. This
+ * preserves a literal input such as `&lt;` instead of letting it decode into `<`.
+ * Input backslashes and slash-escaped punctuation are handled in one replacement,
+ * so a punctuation character after n input backslashes always has 2n + 1 slashes.
+ */
 function escapeMarkdownText(text: string): string {
 	return text
-		.replace(/\\/g, "\\\\")
+		.replace(/&/g, "&amp;")
 		.replace(/</g, "&lt;")
 		.replace(/>/g, "&gt;")
-		.replace(/([`*_{}[\]()#+.!|-])/g, "\\$1");
+		.replace(/[\\`*_{}[\]()#+.!|=~$%^-]/g, "\\$&");
 }
 
 /**
- * Neutralize Markdown/HTML injection in a raw, feed-controlled single-line value
- * (an episode/feed title or author) while keeping it human-readable. Newlines and
- * other control characters are collapsed to spaces so the value can never break
- * out of its line (e.g. the `# {{title}}` heading) and inject extra blocks, and
- * the characters that introduce links, images, inline code, or raw HTML are
- * escaped so a crafted title cannot embed a tracking pixel, phishing link, or
- * markup. Ordinary punctuation (dots, dashes, parentheses, colons, quotes) is
- * preserved so legitimate titles render verbatim - this is deliberately lighter
- * than `escapeMarkdownText` (which backslash-escapes `.`/`-`/`(`/`)` etc.), which
- * would make a normal title like "Ep. 5 - A.I. (Part 1)" unreadable in source.
+ * Collapse a feed-controlled title/author to one line, then encode it as plain
+ * Markdown body text. This blocks both inline constructs and line-leading block
+ * constructs regardless of where a user places the tag in a body template.
+ *
+ * This is not a YAML or JavaScript string encoder. The built-in templates keep
+ * these metadata tags out of frontmatter and executable code, and custom templates
+ * must maintain that context boundary.
  */
-function sanitizeInlineText(text: string): string {
-	return (
-		text
-			// Collapse control characters (newlines, tabs, carriage returns) to a
-			// single space so the value can never inject extra lines or blocks.
-			// eslint-disable-next-line no-control-regex
-			.replace(/[\u0000-\u001f\u007f]+/g, " ")
-			// Neutralize raw HTML and the link/image/inline-code metacharacters so a
-			// crafted value cannot embed a tracking pixel, phishing link, or markup.
-			.replace(/</g, "&lt;")
-			.replace(/>/g, "&gt;")
-			.replace(/([`[\]])/g, "\\$1")
-			.trim()
-	);
+function escapeMarkdownBodyText(text: string): string {
+	// eslint-disable-next-line no-control-regex
+	const singleLine = text.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+	return escapeMarkdownText(singleLine);
 }
 
 /**
@@ -259,7 +259,7 @@ export function NoteTemplateEngine(
 
 	const episodeUrl = resolveEpisodeUrl(episode);
 
-	addTag("title", sanitizeInlineText(episode.title));
+	addTag("title", escapeMarkdownBodyText(episode.title));
 	addTag("description", (prependToLines?: string) => {
 		// reduce multiple new lines
 		const sanitizeDescription = feedHtmlToMarkdown(episode.description).replace(
@@ -442,7 +442,7 @@ export function FeedNoteTemplateEngine(template: string, feed: PodcastFeed) {
 	// feed (mirroring how they describe the episode in NoteTemplateEngine). The raw
 	// {{title}}/{{author}} are feed-controlled, so they are neutralized so a crafted
 	// feed cannot inject Markdown/HTML into the note body.
-	addTag("title", sanitizeInlineText(feed.title));
+	addTag("title", escapeMarkdownBodyText(feed.title));
 	addTag("safetitle", safeTitle);
 	addTag("podcast", safeTitle);
 	// URL tags are sanitized so they stay safe as Markdown link/image targets and
@@ -452,7 +452,7 @@ export function FeedNoteTemplateEngine(template: string, feed: PodcastFeed) {
 	addTag("feedurl", sanitizeUrlForTemplate(feed.url));
 	addTag("artwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
 	addTag("feedartwork", sanitizeUrlForTemplate(feed.artworkUrl ?? ""));
-	addTag("author", sanitizeInlineText(feed.author ?? ""));
+	addTag("author", escapeMarkdownBodyText(feed.author ?? ""));
 	addTag("description", (prependToLines?: string) => {
 		const sanitizeDescription = feedHtmlToMarkdown(feed.description ?? "").replace(
 			/\n{3,}/g,

--- a/tests/e2e/podnotes-runtime.test.ts
+++ b/tests/e2e/podnotes-runtime.test.ts
@@ -469,6 +469,117 @@ describe("PodNotes runtime", () => {
 		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
 	});
 
+	test("renders feed-controlled Markdown punctuation only as visible text", async () => {
+		const { obsidian, plugin, sandbox } = getContext();
+		const audioPath = await seedAudio(sandbox, "template-escaping-episode.mp3");
+		const attacks = [
+			{
+				id: "link",
+				title: String.raw`\[click\](//attacker.example/phish)`,
+				encoded: String.raw`\\\[click\\\]\(//attacker\.example/phish\)`,
+				visible: String.raw`\[click\](//attacker.example/phish)`,
+			},
+			{ id: "heading", title: "# forged heading", encoded: String.raw`\# forged heading` },
+			{ id: "quote", title: "> forged quote", encoded: "&gt; forged quote" },
+			{ id: "thematic", title: "---", encoded: String.raw`\-\-\-` },
+			{ id: "list", title: "- forged list", encoded: String.raw`\- forged list` },
+			{ id: "ordered", title: "1. forged list", encoded: String.raw`1\. forged list` },
+			{
+				id: "setext",
+				title: "===",
+				encoded: String.raw`\=\=\=`,
+				template: "safe\n{{title}}\n",
+			},
+			{ id: "tilde-fence", title: "~~~dataviewjs", encoded: String.raw`\~\~\~dataviewjs` },
+			{ id: "backtick-fence", title: "```dataviewjs", encoded: "\\`\\`\\`dataviewjs" },
+			{
+				id: "html",
+				title: '<img src="//attacker.example/pixel">',
+				encoded: '&lt;img src\\="//attacker\\.example/pixel"&gt;',
+			},
+			{
+				id: "entity",
+				title: "&lt;script&gt;",
+				encoded: "&amp;lt;script&amp;gt;",
+			},
+		] as const;
+
+		for (const attack of attacks) {
+			const notePath = sandbox.path(`template-escaping-${attack.id}.md`);
+			const episode = createLocalEpisode(attack.title, audioPath);
+			const template = "template" in attack ? attack.template : "{{title}}\n";
+
+			await seedRuntimeData(plugin, sandbox, episode, {
+				currentEpisode: episode,
+				note: { path: notePath, template },
+			});
+			await waitForPodNotesReady(obsidian);
+
+			await obsidian.command(`${PLUGIN_ID}:create-podcast-note`).run();
+			const content = await sandbox.waitForContent(
+				`template-escaping-${attack.id}.md`,
+				(value) => value.includes(attack.encoded),
+				WAIT_OPTS,
+			);
+			expect(content).toContain(attack.encoded);
+
+			await evalJsonAsync<boolean>(
+				obsidian,
+				`
+				(async () => {
+					const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+					if (!file) throw new Error("Template escaping note was not created.");
+					const leaf = app.workspace.getLeaf(true);
+					await leaf.setViewState({
+						type: "markdown",
+						state: { file: file.path, mode: "preview" },
+						active: true,
+					});
+					await app.workspace.revealLeaf(leaf);
+					return true;
+				})()
+			`,
+			);
+
+			const visible = "visible" in attack ? attack.visible : attack.title;
+			await obsidian.waitFor(
+				async () =>
+					await obsidian.dev.evalJson<boolean>(`
+						(() => {
+							const preview = document.querySelector(
+								".workspace-leaf.mod-active .markdown-preview-view",
+							);
+							return Boolean(preview?.textContent?.includes(${JSON.stringify(visible)}));
+						})()
+					`),
+				WAIT_OPTS,
+			);
+
+			const preview = await obsidian.dev.evalJson<{
+				forbiddenElements: string[];
+				text: string;
+			}>(`
+				(() => {
+					const preview = document.querySelector(
+						".workspace-leaf.mod-active .markdown-preview-view",
+					);
+					const forbidden = "h1,h2,h3,h4,h5,h6,blockquote,hr,ul,ol,pre,code,a,img,script,iframe,video,audio,table";
+					return {
+						forbiddenElements: Array.from(preview?.querySelectorAll(forbidden) ?? []).map(
+							(element) => element.tagName.toLowerCase(),
+						),
+						text: preview?.textContent ?? "",
+					};
+				})()
+			`);
+
+			expect(preview.text).toContain(visible);
+			expect(preview.forbiddenElements).toEqual([]);
+		}
+
+		expect(await obsidian.dev.runtimeErrors()).toEqual([]);
+	}, 60_000);
+
 	test("refuses a future schema without modifying its data", async () => {
 		const { obsidian, plugin } = getContext();
 		const original = await plugin.data<PodNotesData>().read();


### PR DESCRIPTION
## Summary

- Escape feed-controlled input backslashes in the same pass as Markdown brackets and backticks.
- Preserve readable quotes, punctuation, and visible backslashes while collapsing control characters.
- Add parity tests for repeated backslash runs and a real Obsidian preview assertion that no attacker link is created.

## Security impact

Closes CodeQL alert #1. A title such as \\[click\\](//attacker.example/phish) previously produced an even-length escape run, which reactivated the Markdown link in Obsidian preview. The encoder now guarantees an odd escaping slash before every bracket or backtick after any attacker-controlled slash run.

## Validation

- Focused TemplateEngine tests: 75 passed
- Full Vitest suite: 75 files, 994 tests passed
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm run check:a11y: 0 errors and 0 warnings
- MkDocs build via uv
- Real Obsidian focused reproduction failed before the fix and passed after it
- Full isolated real Obsidian E2E: 14/14 passed, zero runtime errors

The isolated Obsidian instance was stopped and cleaned up.