### PR TITLE
fix(release): preserve published compatibility history

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -163,6 +163,49 @@ jobs:
               return isDeepStrictEqual(normalized, baseline);
             }
 
+            // BEGIN release-compatibility-contract
+            function compareStableCompatibilityVersions(left, right) {
+              const leftParts = left.split('.').map(Number);
+              const rightParts = right.split('.').map(Number);
+              for (let index = 0; index < 3; index += 1) {
+                if (leftParts[index] !== rightParts[index]) {
+                  return leftParts[index] - rightParts[index];
+                }
+              }
+              return 0;
+            }
+
+            function validateCompatibilityTransition(input) {
+              const stableVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+              if (typeof input.baseManifest.minAppVersion !== 'string' ||
+                  !stableVersion.test(input.baseManifest.minAppVersion) ||
+                  typeof input.nextManifest.minAppVersion !== 'string' ||
+                  !stableVersion.test(input.nextManifest.minAppVersion)) {
+                throw new Error('Manifest compatibility versions must be stable semantic versions.');
+              }
+              const releasedMinimum = input.baseVersions[input.baseVersion];
+              if (typeof releasedMinimum !== 'string' || !stableVersion.test(releasedMinimum)) {
+                throw new Error(`Released version ${input.baseVersion} has no compatibility record.`);
+              }
+              if (input.baseManifest.minAppVersion !== releasedMinimum &&
+                  compareStableCompatibilityVersions(
+                    input.baseManifest.minAppVersion,
+                    releasedMinimum,
+                  ) <= 0) {
+                throw new Error('Pending manifest compatibility must increase the released floor.');
+              }
+              if (input.nextVersions[input.nextVersion] !== input.nextManifest.minAppVersion) {
+                throw new Error('New release compatibility does not match its manifest.');
+              }
+            }
+
+            function assertReleasedHistoryUnchanged(baseVersions, tagVersions) {
+              if (!isDeepStrictEqual(baseVersions, tagVersions)) {
+                throw new Error('Released compatibility history changed after the previous tag.');
+              }
+            }
+            // END release-compatibility-contract
+
             async function readJsonAt(ref, file) {
               const response = await github.rest.repos.getContent({ owner, repo, path: file, ref });
               const data = response.data;
@@ -210,14 +253,14 @@ jobs:
                 nextVersion !== version || compareVersions(nextVersion, baseVersion) <= 0) {
               throw new Error('Release identity or version progression is invalid.');
             }
-            if (typeof baseManifest.minAppVersion !== 'string' || !baseManifest.minAppVersion ||
-                typeof nextManifest.minAppVersion !== 'string' || !nextManifest.minAppVersion) {
-              throw new Error('Manifest compatibility versions must be non-empty strings.');
-            }
-            if (baseVersions[baseVersion] !== baseManifest.minAppVersion ||
-                nextVersions[nextVersion] !== nextManifest.minAppVersion) {
-              throw new Error('Release version history does not match manifest compatibility.');
-            }
+            validateCompatibilityTransition({
+              baseManifest,
+              baseVersion,
+              baseVersions,
+              nextManifest,
+              nextVersion,
+              nextVersions,
+            });
             if (!equalExceptField(nextPackage, basePackage, 'version')) {
               throw new Error('package.json changed outside its version field.');
             }
@@ -286,6 +329,7 @@ jobs:
                 tagVersions[baseVersion] !== tagManifest.minAppVersion) {
               throw new Error(`Previous release tag ${baseVersion} has invalid version metadata.`);
             }
+            assertReleasedHistoryUnchanged(baseVersions, tagVersions);
             const previousComparison = await github.rest.repos.compareCommitsWithBasehead({
               owner,
               repo,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,13 @@ containing the four synchronized version files. Review that exact diff, wait
 for its explicitly dispatched `Test` run, mark the PR ready, and squash-merge
 it with the generated title unchanged.
 
+When a feature requires a newer Obsidian API, change `manifest.json`
+`minAppVersion` in the feature PR and leave every existing `versions.json`
+entry unchanged. Those entries describe already-published releases. The
+release planner verifies that released history still matches the latest tag,
+then the generated release PR records the new compatibility floor only under
+the new version.
+
 Keep the repository's default `GITHUB_TOKEN` permission read-only. Enable the
 repository setting that lets GitHub Actions create and approve pull requests so
 the narrowly scoped `Open release PR` job can create the machine-generated PR;

--- a/scripts/release-contract.mjs
+++ b/scripts/release-contract.mjs
@@ -133,20 +133,57 @@ function compareVersions(left, right) {
 	return 0;
 }
 
-/** @param {string} root */
-export function validateCurrentVersionFiles(root) {
+/** @param {unknown} value @param {string} label */
+function assertCompatibilityVersion(value, label) {
+	if (typeof value !== "string" || !SEMVER_PATTERN.test(value)) {
+		throw new Error(`${label} must be a stable semantic version.`);
+	}
+	return value;
+}
+
+/**
+ * @param {Record<string, unknown>} versions
+ * @param {string} version
+ * @param {string} label
+ */
+function recordedMinAppVersion(versions, version, label) {
+	const value = versions[version];
+	if (typeof value !== "string" || !value) {
+		throw new Error(`${label} versions.json does not record ${version}.`);
+	}
+	return assertCompatibilityVersion(value, `${label} compatibility record`);
+}
+
+/** @param {string} released @param {string} manifest @param {string} label */
+function assertPendingMinAppVersion(released, manifest, label) {
+	if (manifest !== released && compareVersions(manifest, released) <= 0) {
+		throw new Error(
+			`${label} minAppVersion must increase from the released compatibility floor.`,
+		);
+	}
+}
+
+/**
+ * @param {string} root
+ * @param {{ allowPendingMinAppVersion?: boolean }} [options]
+ */
+export function validateCurrentVersionFiles(root, options = {}) {
 	const packageJson = readJson(root, "package.json");
 	const packageLock = readJson(root, "package-lock.json");
 	const manifest = readJson(root, "manifest.json");
 	const versions = readJson(root, "versions.json");
 	const version = assertCurrentVersions(packageJson, packageLock, manifest, "current");
-	if (typeof manifest.minAppVersion !== "string" || !manifest.minAppVersion) {
-		throw new Error("manifest.json minAppVersion must be a non-empty string.");
-	}
-	if (versions[version] !== manifest.minAppVersion) {
+	const manifestMinAppVersion = assertCompatibilityVersion(
+		manifest.minAppVersion,
+		"manifest.json minAppVersion",
+	);
+	const releasedMinAppVersion = recordedMinAppVersion(versions, version, "Current");
+	if (options.allowPendingMinAppVersion) {
+		assertPendingMinAppVersion(releasedMinAppVersion, manifestMinAppVersion, "Pending");
+	} else if (releasedMinAppVersion !== manifestMinAppVersion) {
 		throw new Error("versions.json does not record the current manifest version.");
 	}
-	return { minAppVersion: manifest.minAppVersion, version };
+	return { minAppVersion: manifestMinAppVersion, version };
 }
 
 /**
@@ -176,17 +213,15 @@ export function materializeVersionFiles(options) {
 	if (compareVersions(version, currentVersion) <= 0) {
 		throw new Error(`Release version ${version} must be newer than ${currentVersion}.`);
 	}
-	if (versions[currentVersion] !== manifest.minAppVersion) {
-		throw new Error(
-			"versions.json version history is not synchronized with the current manifest.",
-		);
-	}
+	const releasedMinAppVersion = recordedMinAppVersion(versions, currentVersion, "Source");
 	if (Object.prototype.hasOwnProperty.call(versions, version)) {
 		throw new Error(`versions.json already contains ${version}.`);
 	}
-	if (typeof manifest.minAppVersion !== "string" || !manifest.minAppVersion) {
-		throw new Error("manifest.json minAppVersion must be a non-empty string.");
-	}
+	const manifestMinAppVersion = assertCompatibilityVersion(
+		manifest.minAppVersion,
+		"manifest.json minAppVersion",
+	);
+	assertPendingMinAppVersion(releasedMinAppVersion, manifestMinAppVersion, "Source");
 
 	packageJson.version = version;
 	packageLock.version = version;
@@ -250,9 +285,13 @@ export function validateVersionFiles(options) {
 	if (compareVersions(version, baseVersion) <= 0) {
 		throw new Error(`Release version ${version} must be newer than ${baseVersion}.`);
 	}
-	if (baseVersions[baseVersion] !== baseManifest.minAppVersion) {
-		throw new Error("Base versions.json is not synchronized with its manifest.");
-	}
+	const releasedMinAppVersion = recordedMinAppVersion(baseVersions, baseVersion, "Base");
+	const baseManifestMinAppVersion = assertCompatibilityVersion(
+		baseManifest.minAppVersion,
+		"Base manifest minAppVersion",
+	);
+	assertPendingMinAppVersion(releasedMinAppVersion, baseManifestMinAppVersion, "Base manifest");
+	assertCompatibilityVersion(nextManifest.minAppVersion, "Candidate manifest minAppVersion");
 	if (nextPackage.version !== version) {
 		throw new Error(
 			`Candidate version is ${String(nextPackage.version)}, expected ${version}.`,

--- a/scripts/release-contract.test.ts
+++ b/scripts/release-contract.test.ts
@@ -62,6 +62,10 @@ describe("release version contract", () => {
 
 		await writeJson(path.join(root, "versions.json"), { "2.17.3": "0.9.0" });
 		expect(() => validateCurrentVersionFiles(root)).toThrow("does not record");
+		expect(validateCurrentVersionFiles(root, { allowPendingMinAppVersion: true })).toEqual({
+			minAppVersion: "1.0.0",
+			version: "2.17.3",
+		});
 	});
 
 	it("accepts stable semantic versions only", () => {
@@ -69,6 +73,32 @@ describe("release version contract", () => {
 		for (const value of ["v2.17.4", "2.17", "02.17.4", "2.17.4-beta.1", "../2.17.4"]) {
 			expect(() => assertReleaseVersion(value)).toThrow("Invalid release version");
 		}
+	});
+
+	it("rejects invalid or lowered pending compatibility floors", async () => {
+		const root = await makeTempRoot("release-invalid-pending-min-app");
+		await writeVersionFixture(root);
+		const manifestPath = path.join(root, "manifest.json");
+		const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+
+		manifest.minAppVersion = "0.9.0";
+		await writeJson(manifestPath, manifest);
+		expect(() =>
+			validateCurrentVersionFiles(root, { allowPendingMinAppVersion: true }),
+		).toThrow("must increase from the released compatibility floor");
+
+		manifest.minAppVersion = "latest";
+		await writeJson(manifestPath, manifest);
+		expect(() =>
+			validateCurrentVersionFiles(root, { allowPendingMinAppVersion: true }),
+		).toThrow("must be a stable semantic version");
+
+		manifest.minAppVersion = "1.0.0";
+		await writeJson(manifestPath, manifest);
+		await writeJson(path.join(root, "versions.json"), { "2.17.3": "legacy" });
+		expect(() =>
+			validateCurrentVersionFiles(root, { allowPendingMinAppVersion: true }),
+		).toThrow("compatibility record must be a stable semantic version");
 	});
 
 	it("materializes and validates exactly synchronized version files", async () => {
@@ -106,6 +136,31 @@ describe("release version contract", () => {
 		expect(versions["2.17.4"]).toBe("1.0.0");
 	});
 
+	it("preserves released compatibility history while materializing a pending floor", async () => {
+		const root = await makeTempRoot("release-pending-min-app-source");
+		const out = await makeTempRoot("release-pending-min-app-output");
+		await writeVersionFixture(root);
+		const manifest = JSON.parse(await fs.readFile(path.join(root, "manifest.json"), "utf8"));
+		manifest.minAppVersion = "1.11.4";
+		await writeJson(path.join(root, "manifest.json"), manifest);
+
+		materializeVersionFiles({
+			baseSha: BASE_SHA,
+			out,
+			root,
+			version: "2.18.0",
+		});
+		expect(
+			validateVersionFiles({ baseRoot: root, candidateRoot: out, version: "2.18.0" }),
+		).toEqual({ version: "2.18.0" });
+
+		const versions = JSON.parse(await fs.readFile(path.join(out, "versions.json"), "utf8"));
+		expect(versions).toEqual({
+			"2.17.3": "1.0.0",
+			"2.18.0": "1.11.4",
+		});
+	});
+
 	it("rejects output reuse and an existing version entry", async () => {
 		const root = await makeTempRoot("release-existing");
 		const out = await makeTempRoot("release-nonempty");
@@ -141,7 +196,7 @@ describe("release version contract", () => {
 		).toThrow("real directory");
 	});
 
-	it("rejects downgrades and unsynchronized version history", async () => {
+	it("rejects downgrades and missing released version history", async () => {
 		const root = await makeTempRoot("release-history");
 		await writeVersionFixture(root);
 		const downgradeOut = await makeTempRoot("release-downgrade");
@@ -154,7 +209,7 @@ describe("release version contract", () => {
 			}),
 		).toThrow("must be newer");
 
-		await writeJson(path.join(root, "versions.json"), { "2.17.3": "0.9.0" });
+		await writeJson(path.join(root, "versions.json"), {});
 		const historyOut = await makeTempRoot("release-bad-history");
 		expect(() =>
 			materializeVersionFiles({
@@ -163,7 +218,21 @@ describe("release version contract", () => {
 				root,
 				version: "2.17.4",
 			}),
-		).toThrow("version history");
+		).toThrow("does not record 2.17.3");
+
+		await writeVersionFixture(root);
+		const manifest = JSON.parse(await fs.readFile(path.join(root, "manifest.json"), "utf8"));
+		manifest.minAppVersion = "0.9.0";
+		await writeJson(path.join(root, "manifest.json"), manifest);
+		const loweredOut = await makeTempRoot("release-lowered-min-app");
+		expect(() =>
+			materializeVersionFiles({
+				baseSha: BASE_SHA,
+				out: loweredOut,
+				root,
+				version: "2.17.4",
+			}),
+		).toThrow("must increase from the released compatibility floor");
 	});
 
 	it.each([

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 import { analyzeCommits } from "@semantic-release/commit-analyzer";
 import { generateNotes } from "@semantic-release/release-notes-generator";
 import { assertReleaseVersion, validateCurrentVersionFiles } from "./release-contract.mjs";
@@ -23,6 +24,16 @@ function git(cwd, args) {
 		encoding: "utf8",
 		maxBuffer: 10 * 1024 * 1024,
 	}).trim();
+}
+
+/** @param {string} cwd @param {string} lastTag @param {string | undefined} pendingVersion */
+function assertReleasedVersionHistoryUnchanged(cwd, lastTag, pendingVersion) {
+	const currentVersions = JSON.parse(fs.readFileSync(path.join(cwd, "versions.json"), "utf8"));
+	if (pendingVersion) delete currentVersions[pendingVersion];
+	const releasedVersions = JSON.parse(git(cwd, ["show", `${lastTag}:versions.json`]));
+	if (!isDeepStrictEqual(currentVersions, releasedVersions)) {
+		throw new Error(`versions.json changed after the latest stable tag ${lastTag}.`);
+	}
 }
 
 /** @param {string} version */
@@ -142,7 +153,9 @@ export async function calculateReleasePlan(options) {
 		? assertReleaseVersion(options.expectedVersion)
 		: undefined;
 	const lastTag = latestStableTag(cwd, expectedVersion);
-	const currentVersion = validateCurrentVersionFiles(cwd).version;
+	const currentVersion = validateCurrentVersionFiles(cwd, {
+		allowPendingMinAppVersion: !expectedVersion,
+	}).version;
 	if (expectedVersion) {
 		if (currentVersion !== expectedVersion) {
 			throw new Error(
@@ -153,6 +166,9 @@ export async function calculateReleasePlan(options) {
 		throw new Error(
 			`Synchronized version ${currentVersion} does not match latest stable tag ${lastTag ?? "none"}.`,
 		);
+	}
+	if (lastTag) {
+		assertReleasedVersionHistoryUnchanged(cwd, lastTag, expectedVersion);
 	}
 	const previousVersion = lastTag ?? "0.0.0";
 	const lastReleaseSha = lastTag ? git(cwd, ["rev-parse", `${lastTag}^{commit}`]) : "";

--- a/scripts/release-plan.test.ts
+++ b/scripts/release-plan.test.ts
@@ -118,6 +118,36 @@ describe("release plan", () => {
 		expect(plan.notes).toContain("(2024-03-04)");
 	});
 
+	it("plans a release with a pending minimum Obsidian version", async () => {
+		const root = await releaseRepository();
+		const manifestPath = path.join(root, "manifest.json");
+		const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+		manifest.minAppVersion = "1.11.4";
+		await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+		git(root, ["add", "manifest.json"]);
+		commit(root, "feat: require SecretStorage support");
+
+		await expect(calculateReleasePlan({ cwd: root })).resolves.toMatchObject({
+			nextVersion: "2.18.0",
+			previousVersion: "2.17.3",
+			release: true,
+		});
+	});
+
+	it("rejects changes to released compatibility history", async () => {
+		const root = await releaseRepository();
+		await fs.writeFile(
+			path.join(root, "versions.json"),
+			`${JSON.stringify({ "2.17.3": "0.9.0" }, null, 2)}\n`,
+		);
+		git(root, ["add", "versions.json"]);
+		commit(root, "fix: rewrite old compatibility history");
+
+		await expect(calculateReleasePlan({ cwd: root })).rejects.toThrow(
+			"versions.json changed after the latest stable tag 2.17.3",
+		);
+	});
+
 	it("ignores a release commit after the latest tag", async () => {
 		const root = await releaseRepository();
 		commit(root, "release(version): Release 2.17.3");
@@ -140,6 +170,22 @@ describe("release plan", () => {
 			previousVersion: "2.17.3",
 			release: true,
 		});
+	});
+
+	it("rejects recovery when released compatibility history was rewritten", async () => {
+		const root = await releaseRepository();
+		commit(root, "fix: correct playback");
+		await writeSynchronizedVersion(root, "2.17.4");
+		const versionsPath = path.join(root, "versions.json");
+		const versions = JSON.parse(await fs.readFile(versionsPath, "utf8"));
+		versions["2.17.3"] = "0.9.0";
+		await fs.writeFile(versionsPath, `${JSON.stringify(versions, null, 2)}\n`);
+		git(root, ["add", "package.json", "package-lock.json", "manifest.json", "versions.json"]);
+		commit(root, "release(version): Release 2.17.4");
+
+		await expect(
+			calculateReleasePlan({ cwd: root, expectedVersion: "2.17.4" }),
+		).rejects.toThrow("versions.json changed after the latest stable tag 2.17.3");
 	});
 
 	it("rejects an expected recovery tag that does not target HEAD", async () => {

--- a/scripts/release-workflow-contract.test.ts
+++ b/scripts/release-workflow-contract.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 
@@ -27,6 +28,21 @@ type ReleaseTagContract = {
 		tagSha: string | null,
 		expectedSha: string,
 		releaseVersion: string,
+	): void;
+};
+
+type ReleaseCompatibilityContract = {
+	validateCompatibilityTransition(input: {
+		baseManifest: { minAppVersion?: unknown };
+		baseVersion: string;
+		baseVersions: Record<string, unknown>;
+		nextManifest: { minAppVersion?: unknown };
+		nextVersion: string;
+		nextVersions: Record<string, unknown>;
+	}): void;
+	assertReleasedHistoryUnchanged(
+		baseVersions: Record<string, unknown>,
+		tagVersions: Record<string, unknown>,
 	): void;
 };
 
@@ -63,6 +79,30 @@ async function readReleaseTagContract() {
 		${source}
 		return { createOrResolveReleaseTag, assertExpectedReleaseTag };
 	})()`) as ReleaseTagContract;
+}
+
+async function readReleaseCompatibilityContract() {
+	const workflowPath = ".github/workflows/release-trigger.yml";
+	const workflow = await fs.readFile(path.resolve(workflowPath), "utf8");
+	const startMarker = "            // BEGIN release-compatibility-contract";
+	const endMarker = "            // END release-compatibility-contract";
+	const start = workflow.indexOf(startMarker);
+	const end = workflow.indexOf(endMarker, start);
+	expect(
+		start,
+		`${workflowPath} must define the release-compatibility contract`,
+	).toBeGreaterThanOrEqual(0);
+	expect(end, `${workflowPath} must close the release-compatibility contract`).toBeGreaterThan(
+		start,
+	);
+	const source = workflow.slice(start + startMarker.length, end).replace(/^ {12}/gm, "");
+	return runInNewContext(
+		`(() => {
+			${source}
+			return { validateCompatibilityTransition, assertReleasedHistoryUnchanged };
+		})()`,
+		{ isDeepStrictEqual },
+	) as ReleaseCompatibilityContract;
 }
 
 describe.each(WORKFLOW_PATHS)("%s release merge-subject contract", (workflowPath) => {
@@ -194,5 +234,88 @@ describe("release tag visibility contract", () => {
 		expect(workflow).toContain("const tagSha = await createOrResolveReleaseTag({");
 		expect(workflow).toContain("create: () => github.rest.git.createRef({");
 		expect(workflow).toContain("assertExpectedReleaseTag(tagSha, releaseSha, version);");
+	});
+});
+
+describe("release compatibility transition contract", () => {
+	const transition = {
+		baseManifest: { minAppVersion: "1.11.4" },
+		baseVersion: "2.18.2",
+		baseVersions: { "2.18.2": "0.15.9" },
+		nextManifest: { minAppVersion: "1.11.4" },
+		nextVersion: "2.19.0",
+		nextVersions: { "2.18.2": "0.15.9", "2.19.0": "1.11.4" },
+	};
+
+	it("accepts a pending compatibility floor without rewriting the released version", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() => contract.validateCompatibilityTransition(transition)).not.toThrow();
+	});
+
+	it("rejects a missing released compatibility record", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() =>
+			contract.validateCompatibilityTransition({ ...transition, baseVersions: {} }),
+		).toThrow("Released version 2.18.2 has no compatibility record");
+	});
+
+	it("rejects a new release that is not mapped to its manifest floor", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() =>
+			contract.validateCompatibilityTransition({
+				...transition,
+				nextVersions: { ...transition.nextVersions, "2.19.0": "0.15.9" },
+			}),
+		).toThrow("New release compatibility does not match its manifest");
+	});
+
+	it("rejects empty pending compatibility values", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() =>
+			contract.validateCompatibilityTransition({
+				...transition,
+				baseManifest: { minAppVersion: "" },
+			}),
+		).toThrow("Manifest compatibility versions must be stable semantic versions");
+	});
+
+	it("rejects invalid or lowered pending compatibility floors", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() =>
+			contract.validateCompatibilityTransition({
+				...transition,
+				baseManifest: { minAppVersion: "latest" },
+			}),
+		).toThrow("Manifest compatibility versions must be stable semantic versions");
+		expect(() =>
+			contract.validateCompatibilityTransition({
+				...transition,
+				baseManifest: { minAppVersion: "0.14.0" },
+			}),
+		).toThrow("Pending manifest compatibility must increase the released floor");
+	});
+
+	it("requires released history to match the previous stable tag exactly", async () => {
+		const contract = await readReleaseCompatibilityContract();
+		expect(() =>
+			contract.assertReleasedHistoryUnchanged(
+				transition.baseVersions,
+				structuredClone(transition.baseVersions),
+			),
+		).not.toThrow();
+		expect(() =>
+			contract.assertReleasedHistoryUnchanged(transition.baseVersions, {
+				"2.18.2": "1.11.4",
+			}),
+		).toThrow("Released compatibility history changed after the previous tag");
+	});
+
+	it("wires both compatibility checks into the fetched release provenance path", async () => {
+		const workflow = await fs.readFile(
+			path.resolve(".github/workflows/release-trigger.yml"),
+			"utf8",
+		);
+		expect(workflow).toContain("validateCompatibilityTransition({");
+		expect(workflow).toContain("assertReleasedHistoryUnchanged(baseVersions, tagVersions);");
 	});
 });


### PR DESCRIPTION
## Summary

- Allow a feature commit to raise manifest.minAppVersion without rewriting the compatibility mapping of the currently published version.
- Require pending compatibility floors to be stable semantic versions and equal to or strictly greater than the released floor.
- Prove released versions.json history exactly matches the previous stable tag in normal planning, automatic release triggering, and manual recovery.
- Record the new floor only under the next machine-generated release version.

## Why

PodNotes must require Obsidian 1.11.4 before using SecretStorage. The current release contract required manifest.minAppVersion to equal versions.json for the already published package version, which forced either a failed release plan or an incorrect rewrite of 2.18.2 compatibility history.

## Validation

- Release contract, planner, and extracted workflow contract tests: 67 passed
- Full Vitest suite: 75 files, 1,002 tests passed
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm run test: accessibility 0 errors and 0 warnings
- MkDocs build via uv
- Parsed all six workflow YAML files
- git diff --check
- Actual SecretStorage branch probe: 2.18.2 remains mapped to 0.15.9, planner selects 2.19.0, and materialization maps only 2.19.0 to 1.11.4
- Adversarial review found no remaining issues

Obsidian runtime verification was not performed because this change only affects release metadata validation and workflow orchestration.