### PR TITLE
ci: retry transient release API reads

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -40,7 +40,10 @@ jobs:
               throw new Error('Release event has an invalid PR number.');
             }
 
-            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pullNumber });
+            const { data: pull } = await readGitHubApi(
+              `release PR #${pullNumber}`,
+              () => github.rest.pulls.get({ owner, repo, pull_number: pullNumber }),
+            );
             if (!pull.merged || pull.state !== 'closed' || !pull.merged_at || !pull.merge_commit_sha) {
               throw new Error(`PR #${pullNumber} is not merged.`);
             }
@@ -73,18 +76,24 @@ jobs:
             if (!marker) throw new Error(`PR #${pullNumber} is missing valid release provenance.`);
             const baseSha = marker[1];
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner,
-              repo,
-              pull_number: pullNumber,
-              per_page: 100,
-            });
+            const files = await readGitHubApi(
+              `files for release PR #${pullNumber}`,
+              () => github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              }),
+            );
             const changedFiles = files.map((file) => file.filename).sort();
             if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
               throw new Error(`PR #${pullNumber} must change exactly the synchronized version files.`);
             }
 
-            const headCommit = await github.rest.git.getCommit({ owner, repo, commit_sha: pull.head.sha });
+            const headCommit = await readGitHubApi(
+              `release PR #${pullNumber} head commit`,
+              () => github.rest.git.getCommit({ owner, repo, commit_sha: pull.head.sha }),
+            );
             if (headCommit.data.parents.length !== 1 || headCommit.data.parents[0].sha !== baseSha) {
               throw new Error(`PR #${pullNumber} head does not descend directly from its recorded base.`);
             }
@@ -94,7 +103,10 @@ jobs:
             }
 
             const releaseSha = pull.merge_commit_sha;
-            const releaseCommit = await github.rest.git.getCommit({ owner, repo, commit_sha: releaseSha });
+            const releaseCommit = await readGitHubApi(
+              `release PR #${pullNumber} merge commit`,
+              () => github.rest.git.getCommit({ owner, repo, commit_sha: releaseSha }),
+            );
             if (releaseCommit.data.parents.length !== 1 || releaseCommit.data.parents[0].sha !== baseSha) {
               throw new Error(`PR #${pullNumber} was not squash-merged directly onto its recorded base.`);
             }
@@ -206,8 +218,49 @@ jobs:
             }
             // END release-compatibility-contract
 
+            // BEGIN transient-read-retry-contract
+            function isTransientGitHubReadError(error) {
+              return typeof error === 'object' && error !== null &&
+                Number.isInteger(error.status) && error.status >= 500 && error.status <= 599;
+            }
+
+            async function retryTransientGitHubRead({
+              read,
+              sleep,
+              retryDelays = [500, 1500, 4000],
+              onRetry = () => undefined,
+            }) {
+              for (let attempt = 0; ; attempt += 1) {
+                try {
+                  return await read();
+                } catch (error) {
+                  const delayMs = retryDelays[attempt];
+                  if (!isTransientGitHubReadError(error) || delayMs === undefined) {
+                    throw error;
+                  }
+                  onRetry({ attempt: attempt + 1, delayMs, status: error.status });
+                  await sleep(delayMs);
+                }
+              }
+            }
+            // END transient-read-retry-contract
+
+            async function readGitHubApi(description, read) {
+              return retryTransientGitHubRead({
+                read,
+                sleep: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+                onRetry: ({ attempt, delayMs, status }) => core.warning(
+                  `GitHub API returned ${status} while reading ${description}; ` +
+                  `retry ${attempt} starts in ${delayMs}ms.`,
+                ),
+              });
+            }
+
             async function readJsonAt(ref, file) {
-              const response = await github.rest.repos.getContent({ owner, repo, path: file, ref });
+              const response = await readGitHubApi(
+                `${file} at ${ref}`,
+                () => github.rest.repos.getContent({ owner, repo, path: file, ref }),
+              );
               const data = response.data;
               if (Array.isArray(data) || data.type !== 'file' || data.encoding !== 'base64' ||
                   typeof data.content !== 'string') {
@@ -283,12 +336,18 @@ jobs:
               throw new Error('versions.json changed outside the new release entry.');
             }
 
-            const master = await github.rest.git.getRef({ owner, repo, ref: 'heads/master' });
-            const comparison = await github.rest.repos.compareCommitsWithBasehead({
-              owner,
-              repo,
-              basehead: `${releaseSha}...${master.data.object.sha}`,
-            });
+            const master = await readGitHubApi(
+              'master branch',
+              () => github.rest.git.getRef({ owner, repo, ref: 'heads/master' }),
+            );
+            const comparison = await readGitHubApi(
+              `master ancestry from ${releaseSha}`,
+              () => github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${releaseSha}...${master.data.object.sha}`,
+              }),
+            );
             if (!['ahead', 'identical'].includes(comparison.data.status) ||
                 comparison.data.merge_base_commit.sha !== releaseSha) {
               throw new Error(`Release commit ${releaseSha} is not on current master.`);
@@ -297,14 +356,20 @@ jobs:
             async function resolveTagCommit(tag) {
               let reference;
               try {
-                reference = await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+                reference = await readGitHubApi(
+                  `tag ${tag}`,
+                  () => github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` }),
+                );
               } catch (error) {
                 if (error.status === 404) return null;
                 throw error;
               }
               let object = reference.data.object;
               for (let depth = 0; object.type === 'tag' && depth < 5; depth += 1) {
-                const annotated = await github.rest.git.getTag({ owner, repo, tag_sha: object.sha });
+                const annotated = await readGitHubApi(
+                  `annotated tag object ${object.sha}`,
+                  () => github.rest.git.getTag({ owner, repo, tag_sha: object.sha }),
+                );
                 object = annotated.data.object;
               }
               if (object.type !== 'commit') {
@@ -330,11 +395,14 @@ jobs:
               throw new Error(`Previous release tag ${baseVersion} has invalid version metadata.`);
             }
             assertReleasedHistoryUnchanged(baseVersions, tagVersions);
-            const previousComparison = await github.rest.repos.compareCommitsWithBasehead({
-              owner,
-              repo,
-              basehead: `${previousTagSha}...${baseSha}`,
-            });
+            const previousComparison = await readGitHubApi(
+              `${baseVersion} ancestry from ${previousTagSha}`,
+              () => github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${previousTagSha}...${baseSha}`,
+              }),
+            );
             if (!['ahead', 'identical'].includes(previousComparison.data.status) ||
                 previousComparison.data.merge_base_commit.sha !== previousTagSha) {
               throw new Error(`Previous release tag ${baseVersion} is not an ancestor of the base.`);
@@ -348,7 +416,10 @@ jobs:
             const runBranch = `release-run/${version}`;
             let runRef;
             try {
-              runRef = await github.rest.git.getRef({ owner, repo, ref: `heads/${runBranch}` });
+              runRef = await readGitHubApi(
+                `recovery branch ${runBranch}`,
+                () => github.rest.git.getRef({ owner, repo, ref: `heads/${runBranch}` }),
+              );
             } catch (error) {
               if (error.status !== 404) throw error;
             }

--- a/scripts/release-workflow-contract.test.ts
+++ b/scripts/release-workflow-contract.test.ts
@@ -46,6 +46,14 @@ type ReleaseCompatibilityContract = {
 	): void;
 };
 
+type TransientReadRetryContract = {
+	retryTransientGitHubRead<T>(options: {
+		read: () => Promise<T>;
+		sleep: (delayMs: number) => Promise<unknown>;
+		retryDelays?: number[];
+	}): Promise<T>;
+};
+
 async function readMergeSubjectValidator(workflowPath: string) {
 	const workflow = await fs.readFile(path.resolve(workflowPath), "utf8");
 	const functionStart = workflow.indexOf("            function isAllowedReleaseMergeSubject");
@@ -104,6 +112,119 @@ async function readReleaseCompatibilityContract() {
 		{ isDeepStrictEqual },
 	) as ReleaseCompatibilityContract;
 }
+
+async function readTransientReadRetryContract() {
+	const workflowPath = ".github/workflows/release-trigger.yml";
+	const workflow = await fs.readFile(path.resolve(workflowPath), "utf8");
+	const startMarker = "            // BEGIN transient-read-retry-contract";
+	const endMarker = "            // END transient-read-retry-contract";
+	const start = workflow.indexOf(startMarker);
+	const end = workflow.indexOf(endMarker, start);
+	expect(
+		start,
+		`${workflowPath} must define the transient-read retry contract`,
+	).toBeGreaterThanOrEqual(0);
+	expect(end, `${workflowPath} must close the transient-read retry contract`).toBeGreaterThan(
+		start,
+	);
+	const source = workflow.slice(start + startMarker.length, end).replace(/^ {12}/gm, "");
+	return runInNewContext(`(() => {
+		${source}
+		return { retryTransientGitHubRead };
+	})()`) as TransientReadRetryContract;
+}
+
+describe("release-trigger transient read retry contract", () => {
+	it("retries transient GitHub 5xx responses with the bounded schedule", async () => {
+		const contract = await readTransientReadRetryContract();
+		const responses: Array<string | { status: number }> = [
+			{ status: 502 },
+			{ status: 503 },
+			"ok",
+		];
+		const sleeps: number[] = [];
+
+		await expect(
+			contract.retryTransientGitHubRead({
+				read: async () => {
+					const response = responses.shift();
+					if (typeof response === "string") return response;
+					throw response ?? new Error("unexpected extra read");
+				},
+				sleep: async (delayMs) => {
+					sleeps.push(delayMs);
+				},
+				retryDelays: [10, 20, 30],
+			}),
+		).resolves.toBe("ok");
+		expect(sleeps).toEqual([10, 20]);
+	});
+
+	it.each([{ status: 404 }, { status: 600 }, new Error("connection failed")])(
+		"does not retry a non-5xx failure %#",
+		async (failure) => {
+			const contract = await readTransientReadRetryContract();
+			let reads = 0;
+			const sleeps: number[] = [];
+
+			await expect(
+				contract.retryTransientGitHubRead({
+					read: async () => {
+						reads += 1;
+						throw failure;
+					},
+					sleep: async (delayMs) => {
+						sleeps.push(delayMs);
+					},
+					retryDelays: [10, 20],
+				}),
+			).rejects.toBe(failure);
+			expect(reads).toBe(1);
+			expect(sleeps).toEqual([]);
+		},
+	);
+
+	it("rethrows the last transient failure after exhausting the schedule", async () => {
+		const contract = await readTransientReadRetryContract();
+		const failures = [{ status: 500 }, { status: 502 }, { status: 503 }, { status: 504 }];
+		let reads = 0;
+		const sleeps: number[] = [];
+
+		await expect(
+			contract.retryTransientGitHubRead({
+				read: async () => {
+					const failure = failures[reads];
+					reads += 1;
+					throw failure;
+				},
+				sleep: async (delayMs) => {
+					sleeps.push(delayMs);
+				},
+			}),
+		).rejects.toBe(failures[3]);
+		expect(reads).toBe(4);
+		expect(sleeps).toEqual([500, 1500, 4000]);
+	});
+
+	it("wraps every read-only API boundary while leaving mutations unwrapped", async () => {
+		const workflow = await fs.readFile(
+			path.resolve(".github/workflows/release-trigger.yml"),
+			"utf8",
+		);
+		expect(workflow).toContain("return retryTransientGitHubRead({");
+		expect(workflow).toContain(
+			"() => github.rest.repos.getContent({ owner, repo, path: file, ref })",
+		);
+		expect(workflow.match(/await readGitHubApi\(/gu)).toHaveLength(11);
+		expect(workflow.match(/await github\.rest\.[^(]+\(/gu)).toEqual([
+			"await github.rest.git.createRef(",
+			"await github.rest.actions.createWorkflowDispatch(",
+		]);
+		expect(workflow).not.toContain("() => github.rest.git.createRef(");
+		expect(workflow).not.toContain("() => github.rest.actions.createWorkflowDispatch(");
+		expect(workflow).not.toMatch(/^\s+retries:/mu);
+	});
+});
 
 describe.each(WORKFLOW_PATHS)("%s release merge-subject contract", (workflowPath) => {
 	it.each([


### PR DESCRIPTION
## Summary

- retry transient GitHub 5xx responses at every read-only API boundary in the release trigger
- use a bounded 500ms, 1.5s, and 4s backoff with visible retry warnings
- keep recovery-branch creation and release dispatch outside the retry wrapper so ambiguous mutations are never replayed
- add executable workflow-contract tests for recovery, fail-fast behavior, bounded exhaustion, complete read coverage, and mutation isolation

## Why

[Trigger release run 29093286755](https://github.com/chhoumann/PodNotes/actions/runs/29093286755) failed on its first attempt when GitHub returned a transient HTTP 502 while reading `manifest.json` from the previous 2.18.4 tag. The exact rerun passed and safely published 2.19.0, confirming that the release provenance contract was sound and the API read was the only failure.

## Verification

- fail-first workflow-contract test reproduced the missing retry behavior
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run` - 76 files, 1,061 tests
- pinned MkDocs build through `uv`
- `git diff --check`
- independent release-safety review: no findings after both requested corrections

Obsidian runtime verification was not run because this changes only a no-checkout GitHub Actions workflow and its contract tests.
