### PR TITLE
refactor: add sealed capability recovery records

### DIFF
--- a/src/security/base64Url.test.ts
+++ b/src/security/base64Url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { decodeBase64Url, encodeBase64Url } from "./base64Url";
+
+describe("base64url", () => {
+	it.each([
+		[[], ""],
+		[[0], "AA"],
+		[[0, 1], "AAE"],
+		[[0, 1, 2], "AAEC"],
+		[[251, 255, 239], "-__v"],
+	] as const)("round-trips canonical unpadded bytes %#", (bytes, encoded) => {
+		const value = Uint8Array.from(bytes);
+		expect(encodeBase64Url(value)).toBe(encoded);
+		expect(decodeBase64Url(encoded, value.length, value.length)).toEqual(value);
+	});
+
+	it.each(["A", "AA=", "AA==", "AA+", "AA/", "AA\n", " A", "A A", "å"])(
+		"rejects noncanonical text %j",
+		(value) => {
+			expect(decodeBase64Url(value, 8)).toBeNull();
+		},
+	);
+
+	it("checks encoded and decoded bounds before returning bytes", () => {
+		expect(decodeBase64Url("AAE", 1)).toBeNull();
+		expect(decodeBase64Url("AAE", 2, 1)).toBeNull();
+		expect(decodeBase64Url("AAE", 2, 2)).toEqual(Uint8Array.from([0, 1]));
+		expect(decodeBase64Url("A".repeat(10_000), 32)).toBeNull();
+	});
+
+	it("handles values large enough to require chunked browser encoding", () => {
+		const value = new Uint8Array(150_000);
+		for (let index = 0; index < value.length; index += 1) value[index] = index % 251;
+		const encoded = encodeBase64Url(value);
+		expect(decodeBase64Url(encoded, value.length, value.length)).toEqual(value);
+	});
+});

--- a/src/security/base64Url.ts
+++ b/src/security/base64Url.ts
@@ -1,0 +1,50 @@
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]*$/;
+
+function maximumEncodedCharacters(maximumBytes: number): number {
+	return Math.ceil((maximumBytes * 4) / 3);
+}
+
+export function encodeBase64Url(value: Uint8Array): string {
+	let binary = "";
+	const chunkSize = 0x8000;
+	for (let offset = 0; offset < value.length; offset += chunkSize) {
+		binary += String.fromCharCode(...value.subarray(offset, offset + chunkSize));
+	}
+	return btoa(binary).replace(/\+/gu, "-").replace(/\//gu, "_").replace(/=+$/u, "");
+}
+
+/** Decode only canonical, unpadded base64url within an allocation bound. */
+export function decodeBase64Url(
+	value: unknown,
+	maximumBytes: number,
+	exactBytes?: number,
+): Uint8Array<ArrayBuffer> | null {
+	if (
+		typeof value !== "string" ||
+		!Number.isSafeInteger(maximumBytes) ||
+		maximumBytes < 0 ||
+		value.length > maximumEncodedCharacters(maximumBytes) ||
+		value.length % 4 === 1 ||
+		!BASE64URL_PATTERN.test(value)
+	) {
+		return null;
+	}
+
+	try {
+		const padding = "=".repeat((4 - (value.length % 4)) % 4);
+		const binary = atob(value.replace(/-/gu, "+").replace(/_/gu, "/") + padding);
+		if (
+			binary.length > maximumBytes ||
+			(exactBytes !== undefined && binary.length !== exactBytes)
+		) {
+			return null;
+		}
+		const decoded = new Uint8Array(binary.length);
+		for (let index = 0; index < binary.length; index += 1) {
+			decoded[index] = binary.charCodeAt(index);
+		}
+		return encodeBase64Url(decoded) === value ? decoded : null;
+	} catch {
+		return null;
+	}
+}

--- a/src/security/capabilityVaultKey.test.ts
+++ b/src/security/capabilityVaultKey.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+	CAPABILITY_VAULT_ALGORITHM,
+	CAPABILITY_VAULT_KEY_SCHEMA_VERSION,
+	CapabilityVaultCryptoError,
+	capabilityVaultKeyFingerprint,
+	createCapabilityVaultKey,
+	decodeCapabilityVaultRecoveryCode,
+	decodeLocalCapabilityVaultKey,
+	encodeCapabilityVaultRecoveryCode,
+	encodeLocalCapabilityVaultKey,
+	importCapabilityVaultKey,
+	isImportedCapabilityVaultKey,
+	type CapabilityVaultRandomFill,
+} from "./capabilityVaultKey";
+
+const EXPECTED_LOCAL_KEY = {
+	schemaVersion: CAPABILITY_VAULT_KEY_SCHEMA_VERSION,
+	kind: "capability-vault-key",
+	algorithm: CAPABILITY_VAULT_ALGORITHM,
+	vaultId: "pncv-000102030405060708090a0b0c0d0e0f",
+	keyId: "pnck-2ff6e1446606feeacee35215d553a56f",
+	keyMaterial: "EBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8",
+} as const;
+const EXPECTED_RECOVERY_CODE =
+	"PNCV1.000102030405060708090a0b0c0d0e0f.2ff6e1446606feeacee35215d553a56f.EBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8.ea0da65e52509b65";
+
+function sequentialFill(): CapabilityVaultRandomFill {
+	let next = 0;
+	return (bytes) => {
+		for (let index = 0; index < bytes.length; index += 1) bytes[index] = next++;
+	};
+}
+
+describe("capability vault keys", () => {
+	it("creates the fixed HKDF vector as a non-extractable AES-256-GCM key", async () => {
+		const created = await createCapabilityVaultKey(sequentialFill());
+
+		expect(created.localKey).toEqual(EXPECTED_LOCAL_KEY);
+		expect(created.recoveryCode).toBe(EXPECTED_RECOVERY_CODE);
+		expect(created.recoveryCode).toHaveLength(132);
+		expect(created.importedKey.cryptoKey.algorithm).toEqual({ name: "AES-GCM", length: 256 });
+		expect(created.importedKey.cryptoKey.extractable).toBe(false);
+		expect(created.importedKey.cryptoKey.usages).toEqual(["encrypt", "decrypt"]);
+		expect(created.importedKey.keyCheckCryptoKey.algorithm).toEqual({
+			name: "AES-GCM",
+			length: 256,
+		});
+		expect(created.importedKey.keyCheckCryptoKey.extractable).toBe(false);
+		expect(created.importedKey.keyCheckCryptoKey).not.toBe(created.importedKey.cryptoKey);
+		expect(isImportedCapabilityVaultKey(created.importedKey)).toBe(true);
+		expect(JSON.stringify(created.importedKey)).not.toContain(EXPECTED_LOCAL_KEY.keyMaterial);
+		expect(capabilityVaultKeyFingerprint(created.importedKey.keyId)).toBe(
+			"2FF6E1446606FEEACEE3",
+		);
+	});
+
+	it("round-trips only canonical local SecretStorage JSON", async () => {
+		const created = await createCapabilityVaultKey(sequentialFill());
+		const serialized = encodeLocalCapabilityVaultKey(created.localKey)!;
+
+		expect(decodeLocalCapabilityVaultKey(serialized)).toEqual(EXPECTED_LOCAL_KEY);
+		expect(
+			await importCapabilityVaultKey(decodeLocalCapabilityVaultKey(serialized)),
+		).not.toBeNull();
+		expect(decodeLocalCapabilityVaultKey(` ${serialized}`)).toBeNull();
+		expect(decodeLocalCapabilityVaultKey(`${serialized}\n`)).toBeNull();
+		expect(
+			decodeLocalCapabilityVaultKey(
+				JSON.stringify({
+					keyMaterial: EXPECTED_LOCAL_KEY.keyMaterial,
+					schemaVersion: EXPECTED_LOCAL_KEY.schemaVersion,
+					kind: EXPECTED_LOCAL_KEY.kind,
+					algorithm: EXPECTED_LOCAL_KEY.algorithm,
+					vaultId: EXPECTED_LOCAL_KEY.vaultId,
+					keyId: EXPECTED_LOCAL_KEY.keyId,
+				}),
+			),
+		).toBeNull();
+	});
+
+	it("round-trips the sensitive recovery code and rejects transcription changes", async () => {
+		const decoded = await decodeCapabilityVaultRecoveryCode(EXPECTED_RECOVERY_CODE);
+		expect(decoded?.localKey).toEqual(EXPECTED_LOCAL_KEY);
+		expect(decoded && isImportedCapabilityVaultKey(decoded.importedKey)).toBe(true);
+		expect(await encodeCapabilityVaultRecoveryCode(decoded?.localKey)).toBe(
+			EXPECTED_RECOVERY_CODE,
+		);
+
+		const changedChecksum = `${EXPECTED_RECOVERY_CODE.slice(0, -1)}4`;
+		const changedKey = EXPECTED_RECOVERY_CODE.replace(
+			EXPECTED_LOCAL_KEY.keyMaterial,
+			`A${EXPECTED_LOCAL_KEY.keyMaterial.slice(1)}`,
+		);
+		expect(await decodeCapabilityVaultRecoveryCode(changedChecksum)).toBeNull();
+		expect(await decodeCapabilityVaultRecoveryCode(changedKey)).toBeNull();
+		expect(
+			await decodeCapabilityVaultRecoveryCode(EXPECTED_RECOVERY_CODE.toLowerCase()),
+		).toBeNull();
+		expect(await decodeCapabilityVaultRecoveryCode(` ${EXPECTED_RECOVERY_CODE}`)).toBeNull();
+	});
+
+	it("rejects a structurally valid local envelope whose key ID does not derive from the key", async () => {
+		const mismatched = {
+			...EXPECTED_LOCAL_KEY,
+			keyId: "pnck-00000000000000000000000000000000",
+		};
+		expect(encodeLocalCapabilityVaultKey(mismatched)).not.toBeNull();
+		expect(await importCapabilityVaultKey(mismatched)).toBeNull();
+		expect(await encodeCapabilityVaultRecoveryCode(mismatched)).toBeNull();
+	});
+
+	it.each([
+		{ ...EXPECTED_LOCAL_KEY, extra: true },
+		{ ...EXPECTED_LOCAL_KEY, schemaVersion: 2 },
+		{ ...EXPECTED_LOCAL_KEY, algorithm: "AES-GCM" },
+		{ ...EXPECTED_LOCAL_KEY, vaultId: EXPECTED_LOCAL_KEY.vaultId.toUpperCase() },
+		{ ...EXPECTED_LOCAL_KEY, keyId: "pnck-00" },
+		{ ...EXPECTED_LOCAL_KEY, keyMaterial: `${EXPECTED_LOCAL_KEY.keyMaterial}=` },
+	])("rejects a hostile local key envelope %#", async (value) => {
+		expect(encodeLocalCapabilityVaultKey(value)).toBeNull();
+		expect(await importCapabilityVaultKey(value)).toBeNull();
+	});
+
+	it("does not invoke accessors while validating local key material", async () => {
+		let accessed = false;
+		const value = Object.defineProperty({ ...EXPECTED_LOCAL_KEY }, "keyMaterial", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return EXPECTED_LOCAL_KEY.keyMaterial;
+			},
+		});
+		expect(encodeLocalCapabilityVaultKey(value)).toBeNull();
+		expect(await importCapabilityVaultKey(value)).toBeNull();
+		expect(accessed).toBe(false);
+	});
+
+	it("sanitizes random-source failures", async () => {
+		await expect(
+			createCapabilityVaultKey(() => {
+				throw new Error("sensitive random source detail");
+			}),
+		).rejects.toEqual(new CapabilityVaultCryptoError());
+	});
+
+	it("creates independent vault and key identities", async () => {
+		const first = await createCapabilityVaultKey(sequentialFill());
+		let value = 91;
+		const second = await createCapabilityVaultKey((bytes) => {
+			for (let index = 0; index < bytes.length; index += 1) bytes[index] = value++;
+		});
+		expect(second.localKey.vaultId).not.toBe(first.localKey.vaultId);
+		expect(second.localKey.keyId).not.toBe(first.localKey.keyId);
+		expect(second.recoveryCode).not.toBe(first.recoveryCode);
+	});
+});

--- a/src/security/capabilityVaultKey.ts
+++ b/src/security/capabilityVaultKey.ts
@@ -1,0 +1,347 @@
+import { decodeBase64Url, encodeBase64Url } from "./base64Url";
+import { snapshotStrictDataRecord, utf8ByteLength } from "./strictData";
+
+export const CAPABILITY_VAULT_KEY_SCHEMA_VERSION = 1;
+export const CAPABILITY_VAULT_ALGORITHM = "A256GCM";
+export const CAPABILITY_VAULT_RECOVERY_FORMAT = "PNCV1";
+export const MAX_LOCAL_CAPABILITY_VAULT_KEY_BYTES = 512;
+
+const VAULT_ID_PATTERN = /^pncv-[0-9a-f]{32}$/;
+const KEY_ID_PATTERN = /^pnck-[0-9a-f]{32}$/;
+const RECOVERY_CODE_PATTERN =
+	/^PNCV1\.([0-9a-f]{32})\.([0-9a-f]{32})\.([A-Za-z0-9_-]{43})\.([0-9a-f]{16})$/;
+const RECOVERY_CHECKSUM_DOMAIN = "podnotes-capability-vault-recovery-v1";
+const KEY_ID_INFO = "podnotes/capability-vault/v1/key-id";
+const ENCRYPTION_KEY_INFO = "podnotes/capability-vault/v1/feed-capabilities";
+const KEY_CHECK_KEY_INFO = "podnotes/capability-vault/v1/key-check";
+const VAULT_ID_BYTES = 16;
+const ROOT_KEY_BYTES = 32;
+const RECOVERY_CODE_LENGTH = 132;
+const textEncoder = new TextEncoder();
+const authenticImportedKeys = new WeakSet<object>();
+
+declare const capabilityVaultIdBrand: unique symbol;
+declare const capabilityVaultKeyIdBrand: unique symbol;
+
+export type CapabilityVaultId = string & { readonly [capabilityVaultIdBrand]: true };
+export type CapabilityVaultKeyId = string & { readonly [capabilityVaultKeyIdBrand]: true };
+export type CapabilityVaultRandomFill = (bytes: Uint8Array) => void;
+
+export interface LocalCapabilityVaultKeyV1 {
+	readonly schemaVersion: typeof CAPABILITY_VAULT_KEY_SCHEMA_VERSION;
+	readonly kind: "capability-vault-key";
+	readonly algorithm: typeof CAPABILITY_VAULT_ALGORITHM;
+	readonly vaultId: CapabilityVaultId;
+	readonly keyId: CapabilityVaultKeyId;
+	readonly keyMaterial: string;
+}
+
+export interface ImportedCapabilityVaultKey {
+	readonly vaultId: CapabilityVaultId;
+	readonly keyId: CapabilityVaultKeyId;
+	readonly cryptoKey: CryptoKey;
+	readonly keyCheckCryptoKey: CryptoKey;
+}
+
+export interface CreatedCapabilityVaultKey {
+	readonly localKey: LocalCapabilityVaultKeyV1;
+	readonly importedKey: ImportedCapabilityVaultKey;
+	/** Sensitive copy/paste recovery material. Never persist or log this string. */
+	readonly recoveryCode: string;
+}
+
+export class CapabilityVaultCryptoError extends Error {
+	constructor() {
+		super("Capability vault cryptography is unavailable.");
+		this.name = "CapabilityVaultCryptoError";
+	}
+}
+
+function fillWithWebCrypto(bytes: Uint8Array): void {
+	// oxlint-disable-next-line obsidianmd/no-global-this -- Web Crypto is the shared desktop/mobile runtime primitive.
+	const crypto = globalThis.crypto;
+	if (!crypto || typeof crypto.getRandomValues !== "function")
+		throw new CapabilityVaultCryptoError();
+	crypto.getRandomValues(bytes as Uint8Array<ArrayBuffer>);
+}
+
+function getSubtle(): SubtleCrypto {
+	// oxlint-disable-next-line obsidianmd/no-global-this -- Web Crypto is the shared desktop/mobile runtime primitive.
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) throw new CapabilityVaultCryptoError();
+	return subtle;
+}
+
+function encodeHex(bytes: Uint8Array): string {
+	let result = "";
+	for (const byte of bytes) result += byte.toString(16).padStart(2, "0");
+	return result;
+}
+
+function decodeHex(value: string, expectedBytes: number): Uint8Array<ArrayBuffer> | null {
+	if (value.length !== expectedBytes * 2 || !/^[0-9a-f]+$/.test(value)) return null;
+	const bytes = new Uint8Array(expectedBytes);
+	for (let index = 0; index < expectedBytes; index += 1) {
+		bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+	}
+	return bytes;
+}
+
+function vaultIdBytes(vaultId: CapabilityVaultId): Uint8Array<ArrayBuffer> | null {
+	return decodeHex(vaultId.slice("pncv-".length), VAULT_ID_BYTES);
+}
+
+function normalizeLocalCapabilityVaultKey(value: unknown): LocalCapabilityVaultKeyV1 | null {
+	const record = snapshotStrictDataRecord(value, [
+		"schemaVersion",
+		"kind",
+		"algorithm",
+		"vaultId",
+		"keyId",
+		"keyMaterial",
+	]);
+	if (
+		!record ||
+		record.schemaVersion !== CAPABILITY_VAULT_KEY_SCHEMA_VERSION ||
+		record.kind !== "capability-vault-key" ||
+		record.algorithm !== CAPABILITY_VAULT_ALGORITHM ||
+		typeof record.vaultId !== "string" ||
+		!VAULT_ID_PATTERN.test(record.vaultId) ||
+		typeof record.keyId !== "string" ||
+		!KEY_ID_PATTERN.test(record.keyId) ||
+		typeof record.keyMaterial !== "string"
+	) {
+		return null;
+	}
+	const decodedKeyMaterial = decodeBase64Url(record.keyMaterial, ROOT_KEY_BYTES, ROOT_KEY_BYTES);
+	if (!decodedKeyMaterial) return null;
+	decodedKeyMaterial.fill(0);
+
+	return {
+		schemaVersion: CAPABILITY_VAULT_KEY_SCHEMA_VERSION,
+		kind: "capability-vault-key",
+		algorithm: CAPABILITY_VAULT_ALGORITHM,
+		vaultId: record.vaultId as CapabilityVaultId,
+		keyId: record.keyId as CapabilityVaultKeyId,
+		keyMaterial: record.keyMaterial,
+	};
+}
+
+async function deriveImportedKey(
+	localKey: LocalCapabilityVaultKeyV1,
+): Promise<ImportedCapabilityVaultKey | null> {
+	const rootKey = decodeBase64Url(localKey.keyMaterial, ROOT_KEY_BYTES, ROOT_KEY_BYTES);
+	const salt = vaultIdBytes(localKey.vaultId);
+	if (!rootKey || !salt) return null;
+
+	try {
+		const subtle = getSubtle();
+		const hkdfKey = await subtle.importKey("raw", rootKey, "HKDF", false, [
+			"deriveBits",
+			"deriveKey",
+		]);
+		const keyIdBits = await subtle.deriveBits(
+			{
+				name: "HKDF",
+				hash: "SHA-256",
+				salt,
+				info: textEncoder.encode(KEY_ID_INFO),
+			},
+			hkdfKey,
+			128,
+		);
+		const derivedKeyId = `pnck-${encodeHex(new Uint8Array(keyIdBits))}`;
+		if (derivedKeyId !== localKey.keyId) return null;
+
+		const cryptoKey = await subtle.deriveKey(
+			{
+				name: "HKDF",
+				hash: "SHA-256",
+				salt,
+				info: textEncoder.encode(ENCRYPTION_KEY_INFO),
+			},
+			hkdfKey,
+			{ name: "AES-GCM", length: 256 },
+			false,
+			["encrypt", "decrypt"],
+		);
+		const keyCheckCryptoKey = await subtle.deriveKey(
+			{
+				name: "HKDF",
+				hash: "SHA-256",
+				salt,
+				info: textEncoder.encode(KEY_CHECK_KEY_INFO),
+			},
+			hkdfKey,
+			{ name: "AES-GCM", length: 256 },
+			false,
+			["encrypt", "decrypt"],
+		);
+		const imported = Object.freeze({
+			vaultId: localKey.vaultId,
+			keyId: localKey.keyId,
+			cryptoKey,
+			keyCheckCryptoKey,
+		});
+		authenticImportedKeys.add(imported);
+		return imported;
+	} catch (error) {
+		if (error instanceof CapabilityVaultCryptoError) throw error;
+		throw new CapabilityVaultCryptoError();
+	} finally {
+		rootKey.fill(0);
+	}
+}
+
+async function recoveryChecksum(
+	vaultPayload: string,
+	keyPayload: string,
+	keyMaterial: string,
+): Promise<string> {
+	const message = `${RECOVERY_CHECKSUM_DOMAIN}\0${vaultPayload}\0${keyPayload}\0${keyMaterial}`;
+	try {
+		const digest = await getSubtle().digest("SHA-256", textEncoder.encode(message));
+		return encodeHex(new Uint8Array(digest).subarray(0, 8));
+	} catch (error) {
+		if (error instanceof CapabilityVaultCryptoError) throw error;
+		throw new CapabilityVaultCryptoError();
+	}
+}
+
+function constantTimeTextEqual(left: string, right: string): boolean {
+	if (left.length !== right.length) return false;
+	let difference = 0;
+	for (let index = 0; index < left.length; index += 1) {
+		difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+	}
+	return difference === 0;
+}
+
+export function isCapabilityVaultId(value: unknown): value is CapabilityVaultId {
+	return typeof value === "string" && VAULT_ID_PATTERN.test(value);
+}
+
+export function isCapabilityVaultKeyId(value: unknown): value is CapabilityVaultKeyId {
+	return typeof value === "string" && KEY_ID_PATTERN.test(value);
+}
+
+export function capabilityVaultKeyFingerprint(keyId: CapabilityVaultKeyId): string {
+	return keyId.slice("pnck-".length, "pnck-".length + 20).toUpperCase();
+}
+
+export function isImportedCapabilityVaultKey(value: unknown): value is ImportedCapabilityVaultKey {
+	return typeof value === "object" && value !== null && authenticImportedKeys.has(value);
+}
+
+export function encodeLocalCapabilityVaultKey(value: unknown): string | null {
+	const normalized = normalizeLocalCapabilityVaultKey(value);
+	if (!normalized) return null;
+	const serialized = JSON.stringify(normalized);
+	return utf8ByteLength(serialized) <= MAX_LOCAL_CAPABILITY_VAULT_KEY_BYTES ? serialized : null;
+}
+
+export function decodeLocalCapabilityVaultKey(
+	serialized: unknown,
+): LocalCapabilityVaultKeyV1 | null {
+	if (
+		typeof serialized !== "string" ||
+		serialized.length === 0 ||
+		serialized.length > MAX_LOCAL_CAPABILITY_VAULT_KEY_BYTES ||
+		utf8ByteLength(serialized) > MAX_LOCAL_CAPABILITY_VAULT_KEY_BYTES
+	) {
+		return null;
+	}
+	try {
+		const normalized = normalizeLocalCapabilityVaultKey(JSON.parse(serialized));
+		return normalized && JSON.stringify(normalized) === serialized ? normalized : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function importCapabilityVaultKey(
+	value: unknown,
+): Promise<ImportedCapabilityVaultKey | null> {
+	const localKey = normalizeLocalCapabilityVaultKey(value);
+	return localKey ? deriveImportedKey(localKey) : null;
+}
+
+export async function encodeCapabilityVaultRecoveryCode(value: unknown): Promise<string | null> {
+	const localKey = normalizeLocalCapabilityVaultKey(value);
+	if (!localKey || !(await deriveImportedKey(localKey))) return null;
+	const vaultPayload = localKey.vaultId.slice("pncv-".length);
+	const keyPayload = localKey.keyId.slice("pnck-".length);
+	const checksum = await recoveryChecksum(vaultPayload, keyPayload, localKey.keyMaterial);
+	return `${CAPABILITY_VAULT_RECOVERY_FORMAT}.${vaultPayload}.${keyPayload}.${localKey.keyMaterial}.${checksum}`;
+}
+
+export async function decodeCapabilityVaultRecoveryCode(value: unknown): Promise<{
+	localKey: LocalCapabilityVaultKeyV1;
+	importedKey: ImportedCapabilityVaultKey;
+} | null> {
+	if (typeof value !== "string" || value.length !== RECOVERY_CODE_LENGTH) return null;
+	const match = RECOVERY_CODE_PATTERN.exec(value);
+	if (!match) return null;
+	const [, vaultPayload, keyPayload, keyMaterial, suppliedChecksum] = match;
+	const expectedChecksum = await recoveryChecksum(vaultPayload, keyPayload, keyMaterial);
+	if (!constantTimeTextEqual(suppliedChecksum, expectedChecksum)) return null;
+
+	const localKey = normalizeLocalCapabilityVaultKey({
+		schemaVersion: CAPABILITY_VAULT_KEY_SCHEMA_VERSION,
+		kind: "capability-vault-key",
+		algorithm: CAPABILITY_VAULT_ALGORITHM,
+		vaultId: `pncv-${vaultPayload}`,
+		keyId: `pnck-${keyPayload}`,
+		keyMaterial,
+	});
+	if (!localKey) return null;
+	const importedKey = await deriveImportedKey(localKey);
+	return importedKey ? { localKey, importedKey } : null;
+}
+
+export async function createCapabilityVaultKey(
+	fillRandom: CapabilityVaultRandomFill = fillWithWebCrypto,
+): Promise<CreatedCapabilityVaultKey> {
+	const rootBytes = new Uint8Array(ROOT_KEY_BYTES);
+	try {
+		const vaultBytes = new Uint8Array(VAULT_ID_BYTES);
+		fillRandom(vaultBytes);
+		fillRandom(rootBytes);
+		const vaultId = `pncv-${encodeHex(vaultBytes)}` as CapabilityVaultId;
+		const provisional: LocalCapabilityVaultKeyV1 = {
+			schemaVersion: CAPABILITY_VAULT_KEY_SCHEMA_VERSION,
+			kind: "capability-vault-key",
+			algorithm: CAPABILITY_VAULT_ALGORITHM,
+			vaultId,
+			keyId: "pnck-00000000000000000000000000000000" as CapabilityVaultKeyId,
+			keyMaterial: encodeBase64Url(rootBytes),
+		};
+
+		const subtle = getSubtle();
+		const hkdfKey = await subtle.importKey("raw", rootBytes, "HKDF", false, ["deriveBits"]);
+		const keyIdBits = await subtle.deriveBits(
+			{
+				name: "HKDF",
+				hash: "SHA-256",
+				salt: vaultBytes,
+				info: textEncoder.encode(KEY_ID_INFO),
+			},
+			hkdfKey,
+			128,
+		);
+		const localKey: LocalCapabilityVaultKeyV1 = Object.freeze({
+			...provisional,
+			keyId: `pnck-${encodeHex(new Uint8Array(keyIdBits))}` as CapabilityVaultKeyId,
+		});
+		const importedKey = await deriveImportedKey(localKey);
+		if (!importedKey) throw new CapabilityVaultCryptoError();
+		const recoveryCode = await encodeCapabilityVaultRecoveryCode(localKey);
+		if (!recoveryCode) throw new CapabilityVaultCryptoError();
+		return Object.freeze({ localKey, importedKey, recoveryCode });
+	} catch (error) {
+		if (error instanceof CapabilityVaultCryptoError) throw error;
+		throw new CapabilityVaultCryptoError();
+	} finally {
+		rootBytes.fill(0);
+	}
+}

--- a/src/security/capabilityVaultMetadata.test.ts
+++ b/src/security/capabilityVaultMetadata.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createCapabilityVaultKey } from "./capabilityVaultKey";
+import {
+	CAPABILITY_VAULT_METADATA_SCHEMA_VERSION,
+	decodeCapabilityVaultMetadata,
+	encodeCapabilityVaultMetadata,
+	validateCapabilityVaultMetadata,
+} from "./capabilityVaultMetadata";
+import { createCapabilityVaultKeyCheck } from "./sealedCapabilityRecord";
+
+async function fixture(start = 0) {
+	let next = start;
+	const key = await createCapabilityVaultKey((bytes) => {
+		for (let index = 0; index < bytes.length; index += 1) bytes[index] = next++;
+	});
+	const keyCheck = await createCapabilityVaultKeyCheck(key.importedKey, (bytes) => {
+		for (let index = 0; index < bytes.length; index += 1) bytes[index] = next++;
+	});
+	return {
+		schemaVersion: CAPABILITY_VAULT_METADATA_SCHEMA_VERSION,
+		kind: "capability-vault-metadata" as const,
+		algorithm: "A256GCM" as const,
+		recoveryFormat: "PNCV1" as const,
+		vaultId: key.importedKey.vaultId,
+		keyId: key.importedKey.keyId,
+		keyCheck,
+	};
+}
+
+describe("capability vault metadata", () => {
+	it("round-trips a target-free canonical key-check manifest", async () => {
+		const value = await fixture();
+		const serialized = encodeCapabilityVaultMetadata(value)!;
+
+		expect(decodeCapabilityVaultMetadata(serialized)).toEqual(value);
+		expect(serialized).not.toMatch(/https?:|token|guid|hostname/i);
+	});
+
+	it("rejects mismatched key-check authority", async () => {
+		const value = await fixture();
+		const other = await fixture(90);
+		expect(validateCapabilityVaultMetadata({ ...value, keyCheck: other.keyCheck })).toBeNull();
+	});
+
+	it.each([
+		{ extra: true },
+		{ schemaVersion: 2 },
+		{ kind: "synced-capability-vault" },
+		{ algorithm: "AES-GCM" },
+		{ recoveryFormat: "PNCV2" },
+	])("rejects an invalid metadata mutation %#", async (mutation) => {
+		const value = await fixture();
+		expect(validateCapabilityVaultMetadata({ ...value, ...mutation })).toBeNull();
+	});
+
+	it("rejects noncanonical or oversized serialized input", async () => {
+		const value = await fixture();
+		const serialized = encodeCapabilityVaultMetadata(value)!;
+		expect(decodeCapabilityVaultMetadata(` ${serialized}`)).toBeNull();
+		expect(decodeCapabilityVaultMetadata(`${serialized}\n`)).toBeNull();
+		expect(decodeCapabilityVaultMetadata(JSON.stringify({ ...value, extra: true }))).toBeNull();
+		expect(decodeCapabilityVaultMetadata("A".repeat(2049))).toBeNull();
+	});
+});

--- a/src/security/capabilityVaultMetadata.ts
+++ b/src/security/capabilityVaultMetadata.ts
@@ -1,0 +1,90 @@
+import {
+	CAPABILITY_VAULT_ALGORITHM,
+	CAPABILITY_VAULT_RECOVERY_FORMAT,
+	isCapabilityVaultId,
+	isCapabilityVaultKeyId,
+	type CapabilityVaultId,
+	type CapabilityVaultKeyId,
+} from "./capabilityVaultKey";
+import {
+	validateCapabilityVaultKeyCheck,
+	type CapabilityVaultKeyCheckV1,
+} from "./sealedCapabilityRecord";
+import { snapshotStrictDataRecord, utf8ByteLength } from "./strictData";
+
+export const CAPABILITY_VAULT_METADATA_SCHEMA_VERSION = 1;
+export const MAX_CAPABILITY_VAULT_METADATA_BYTES = 2 * 1024;
+
+/** Target-free key identity only. Immutable feed records live outside this metadata. */
+export interface CapabilityVaultMetadataV1 {
+	readonly schemaVersion: typeof CAPABILITY_VAULT_METADATA_SCHEMA_VERSION;
+	readonly kind: "capability-vault-metadata";
+	readonly algorithm: typeof CAPABILITY_VAULT_ALGORITHM;
+	readonly recoveryFormat: typeof CAPABILITY_VAULT_RECOVERY_FORMAT;
+	readonly vaultId: CapabilityVaultId;
+	readonly keyId: CapabilityVaultKeyId;
+	readonly keyCheck: CapabilityVaultKeyCheckV1;
+}
+
+export function validateCapabilityVaultMetadata(value: unknown): CapabilityVaultMetadataV1 | null {
+	const record = snapshotStrictDataRecord(value, [
+		"schemaVersion",
+		"kind",
+		"algorithm",
+		"recoveryFormat",
+		"vaultId",
+		"keyId",
+		"keyCheck",
+	]);
+	if (
+		!record ||
+		record.schemaVersion !== CAPABILITY_VAULT_METADATA_SCHEMA_VERSION ||
+		record.kind !== "capability-vault-metadata" ||
+		record.algorithm !== CAPABILITY_VAULT_ALGORITHM ||
+		record.recoveryFormat !== CAPABILITY_VAULT_RECOVERY_FORMAT ||
+		!isCapabilityVaultId(record.vaultId) ||
+		!isCapabilityVaultKeyId(record.keyId)
+	) {
+		return null;
+	}
+	const keyCheck = validateCapabilityVaultKeyCheck(record.keyCheck);
+	if (!keyCheck || keyCheck.vaultId !== record.vaultId || keyCheck.keyId !== record.keyId) {
+		return null;
+	}
+	const normalized: CapabilityVaultMetadataV1 = {
+		schemaVersion: CAPABILITY_VAULT_METADATA_SCHEMA_VERSION,
+		kind: "capability-vault-metadata",
+		algorithm: CAPABILITY_VAULT_ALGORITHM,
+		recoveryFormat: CAPABILITY_VAULT_RECOVERY_FORMAT,
+		vaultId: record.vaultId,
+		keyId: record.keyId,
+		keyCheck,
+	};
+	return utf8ByteLength(JSON.stringify(normalized)) <= MAX_CAPABILITY_VAULT_METADATA_BYTES
+		? normalized
+		: null;
+}
+
+export function encodeCapabilityVaultMetadata(value: unknown): string | null {
+	const normalized = validateCapabilityVaultMetadata(value);
+	return normalized ? JSON.stringify(normalized) : null;
+}
+
+export function decodeCapabilityVaultMetadata(
+	serialized: unknown,
+): CapabilityVaultMetadataV1 | null {
+	if (
+		typeof serialized !== "string" ||
+		serialized.length === 0 ||
+		serialized.length > MAX_CAPABILITY_VAULT_METADATA_BYTES ||
+		utf8ByteLength(serialized) > MAX_CAPABILITY_VAULT_METADATA_BYTES
+	) {
+		return null;
+	}
+	try {
+		const normalized = validateCapabilityVaultMetadata(JSON.parse(serialized));
+		return normalized && JSON.stringify(normalized) === serialized ? normalized : null;
+	} catch {
+		return null;
+	}
+}

--- a/src/security/sealedCapabilityRecord.test.ts
+++ b/src/security/sealedCapabilityRecord.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import { createCapabilityVaultKey, type CapabilityVaultRandomFill } from "./capabilityVaultKey";
+import { feedCapabilityReferenceForAttempt } from "./feedCapabilityReferences";
+import type { EpisodeHandle, FeedHandle } from "./resourceHandles";
+import {
+	FeedCapabilitySealingError,
+	MAX_SEALED_CAPABILITY_RECORD_BYTES,
+	createCapabilityVaultKeyCheck,
+	decodeCapabilityVaultKeyCheck,
+	decodeSealedFeedCapabilityRecord,
+	encodeCapabilityVaultKeyCheck,
+	encodeSealedFeedCapabilityRecord,
+	openSealedFeedCapabilityEnvelope,
+	sealFeedCapabilityEnvelope,
+	verifyCapabilityVaultKey,
+} from "./sealedCapabilityRecord";
+import type { FeedCapabilityEnvelope } from "./targetEnvelopes";
+
+const feedId = `podnotes-feed-${"11".repeat(32)}` as FeedHandle;
+const otherFeedId = `podnotes-feed-${"22".repeat(32)}` as FeedHandle;
+const episodeId = `podnotes-episode-${"33".repeat(32)}` as EpisodeHandle;
+const capabilityRef = feedCapabilityReferenceForAttempt(feedId, 1)!;
+const otherCapabilityRef = feedCapabilityReferenceForAttempt(otherFeedId, 1)!;
+const bundle: FeedCapabilityEnvelope = {
+	schemaVersion: 1,
+	kind: "feed-capability-bundle",
+	feedId,
+	subscriptionUrl: "https://secret.example/feed%2fmain.xml?token=signed-value",
+	artworkUrl: "https://secret.example/private-artwork.jpg?token=artwork-value",
+	guid: "private-feed-guid",
+	privateGrants: {
+		subscription: ["https://secret.example"],
+	},
+	episodeResources: {
+		[episodeId]: {
+			schemaVersion: 1,
+			kind: "episode-resources",
+			feedId,
+			episodeId,
+			streamUrl: "https://media.example/private.mp3?signature=episode-value",
+			guid: "private-episode-guid",
+		},
+	},
+};
+
+function sequentialFill(start = 0): CapabilityVaultRandomFill {
+	let next = start;
+	return (bytes) => {
+		for (let index = 0; index < bytes.length; index += 1) bytes[index] = next++ % 256;
+	};
+}
+
+async function fixture() {
+	const key = await createCapabilityVaultKey(sequentialFill());
+	const record = await sealFeedCapabilityEnvelope(bundle, {
+		key: key.importedKey,
+		feedId,
+		capabilityRef,
+		fillRandom: sequentialFill(64),
+	});
+	return { key, record };
+}
+
+describe("sealed feed capability records", () => {
+	it("seals and opens a fixed immutable record without clear targets", async () => {
+		const { key, record } = await fixture();
+		const serialized = encodeSealedFeedCapabilityRecord(record)!;
+
+		expect(record.recordId).toBe("pncr-404142434445464748494a4b4c4d4e4f");
+		expect(record.nonce).toBe("UFFSU1RVVldYWVpb");
+		expect(decodeSealedFeedCapabilityRecord(serialized)).toEqual(record);
+		expect(await openSealedFeedCapabilityEnvelope(record, key.importedKey)).toEqual({
+			status: "available",
+			value: bundle,
+		});
+		for (const targetFragment of [
+			"secret.example",
+			"media.example",
+			"signed-value",
+			"episode-value",
+			"private-feed-guid",
+		]) {
+			expect(serialized).not.toContain(targetFragment);
+		}
+	});
+
+	it("randomizes record identity, nonce, and ciphertext for the same plaintext", async () => {
+		const key = await createCapabilityVaultKey(sequentialFill());
+		const first = await sealFeedCapabilityEnvelope(bundle, {
+			key: key.importedKey,
+			feedId,
+			capabilityRef,
+			fillRandom: sequentialFill(64),
+		});
+		const second = await sealFeedCapabilityEnvelope(bundle, {
+			key: key.importedKey,
+			feedId,
+			capabilityRef,
+			fillRandom: sequentialFill(96),
+		});
+
+		expect(second.recordId).not.toBe(first.recordId);
+		expect(second.nonce).not.toBe(first.nonce);
+		expect(second.ciphertext).not.toBe(first.ciphertext);
+	});
+
+	it("seals a stable descriptor snapshot without rereading hostile proxy getters", async () => {
+		const key = await createCapabilityVaultKey(sequentialFill());
+		let guidReads = 0;
+		const changing = new Proxy(bundle, {
+			get(target, property, receiver) {
+				if (property === "guid") {
+					guidReads += 1;
+					return "x".repeat(9_000);
+				}
+				return Reflect.get(target, property, receiver);
+			},
+		});
+
+		const record = await sealFeedCapabilityEnvelope(changing, {
+			key: key.importedKey,
+			feedId,
+			capabilityRef,
+			fillRandom: sequentialFill(64),
+		});
+		expect(guidReads).toBe(0);
+		expect(await openSealedFeedCapabilityEnvelope(record, key.importedKey)).toEqual({
+			status: "available",
+			value: bundle,
+		});
+	});
+
+	it("authenticates every mutable clear binding", async () => {
+		const { key, record } = await fixture();
+		const otherRecordId = `pncr-${"aa".repeat(16)}`;
+		const parentRecordId = `pncr-${"bb".repeat(16)}`;
+		const suffixReference = feedCapabilityReferenceForAttempt(feedId, 2)!;
+		const changedNonce = record.nonce.startsWith("A")
+			? `B${record.nonce.slice(1)}`
+			: `A${record.nonce.slice(1)}`;
+		const variants = [
+			{ ...record, recordId: otherRecordId },
+			{ ...record, capabilityRef: suffixReference },
+			{ ...record, feedId: otherFeedId, capabilityRef: otherCapabilityRef },
+			{ ...record, generation: 2, parentRecordId },
+			{ ...record, nonce: changedNonce },
+		] as const;
+
+		for (const variant of variants) {
+			expect(await openSealedFeedCapabilityEnvelope(variant, key.importedKey)).toEqual({
+				status: "invalid",
+			});
+		}
+	});
+
+	it("rejects wrong keys, ciphertext swaps, bit changes, truncation, and extension", async () => {
+		const { key, record } = await fixture();
+		const wrongKey = await createCapabilityVaultKey(sequentialFill(150));
+		const other = await sealFeedCapabilityEnvelope(bundle, {
+			key: key.importedKey,
+			feedId,
+			capabilityRef,
+			fillRandom: sequentialFill(180),
+		});
+		const changed = `${record.ciphertext.startsWith("A") ? "B" : "A"}${record.ciphertext.slice(1)}`;
+		const variants = [
+			{ ...record, ciphertext: other.ciphertext },
+			{ ...record, ciphertext: changed },
+			{ ...record, ciphertext: record.ciphertext.slice(0, -1) },
+			{ ...record, ciphertext: `${record.ciphertext}A` },
+		];
+
+		expect(await openSealedFeedCapabilityEnvelope(record, wrongKey.importedKey)).toEqual({
+			status: "invalid",
+		});
+		for (const variant of variants) {
+			expect(await openSealedFeedCapabilityEnvelope(variant, key.importedKey)).toEqual({
+				status: "invalid",
+			});
+		}
+	});
+
+	it("requires a parent exactly when the immutable generation advances", async () => {
+		const { key, record } = await fixture();
+		const second = await sealFeedCapabilityEnvelope(bundle, {
+			key: key.importedKey,
+			feedId,
+			capabilityRef,
+			parentRecord: record,
+			fillRandom: sequentialFill(96),
+		});
+		expect(second.parentRecordId).toBe(record.recordId);
+		expect(second.generation).toBe(2);
+		expect(await openSealedFeedCapabilityEnvelope(second, key.importedKey, record)).toEqual({
+			status: "available",
+			value: bundle,
+		});
+		expect(await openSealedFeedCapabilityEnvelope(second, key.importedKey)).toEqual({
+			status: "invalid",
+		});
+
+		const otherFeedParent = await sealFeedCapabilityEnvelope(
+			{
+				schemaVersion: 1,
+				kind: "feed-capability-bundle",
+				feedId: otherFeedId,
+				subscriptionUrl: "https://other.example/feed.xml",
+				episodeResources: {},
+			},
+			{
+				key: key.importedKey,
+				feedId: otherFeedId,
+				capabilityRef: otherCapabilityRef,
+				fillRandom: sequentialFill(120),
+			},
+		);
+		const otherKey = await createCapabilityVaultKey(sequentialFill(150));
+		const otherKeyParent = await sealFeedCapabilityEnvelope(bundle, {
+			key: otherKey.importedKey,
+			feedId,
+			capabilityRef,
+			fillRandom: sequentialFill(190),
+		});
+		for (const parentRecord of [otherFeedParent, otherKeyParent]) {
+			await expect(
+				sealFeedCapabilityEnvelope(bundle, {
+					key: key.importedKey,
+					feedId,
+					capabilityRef,
+					parentRecord,
+					fillRandom: sequentialFill(220),
+				}),
+			).rejects.toEqual(new FeedCapabilitySealingError());
+		}
+	});
+
+	it("uses an authenticated key check even when the vault has no feed records", async () => {
+		const key = await createCapabilityVaultKey(sequentialFill());
+		const check = await createCapabilityVaultKeyCheck(key.importedKey, sequentialFill(200));
+		const serialized = encodeCapabilityVaultKeyCheck(check)!;
+
+		expect(check.ciphertext).toHaveLength(72);
+		expect(decodeCapabilityVaultKeyCheck(serialized)).toEqual(check);
+		expect(await verifyCapabilityVaultKey(check, key.importedKey)).toEqual({
+			status: "available",
+		});
+
+		const wrongKey = await createCapabilityVaultKey(sequentialFill(30));
+		expect(await verifyCapabilityVaultKey(check, wrongKey.importedKey)).toEqual({
+			status: "invalid",
+		});
+		const changedCiphertext = `${check.ciphertext.startsWith("A") ? "B" : "A"}${check.ciphertext.slice(1)}`;
+		expect(
+			await verifyCapabilityVaultKey(
+				{ ...check, ciphertext: changedCiphertext },
+				key.importedKey,
+			),
+		).toEqual({ status: "invalid" });
+	});
+
+	it("accepts only strict canonical record and key-check JSON", async () => {
+		const { key, record } = await fixture();
+		const check = await createCapabilityVaultKeyCheck(key.importedKey, sequentialFill(200));
+		const recordJson = encodeSealedFeedCapabilityRecord(record)!;
+		const checkJson = encodeCapabilityVaultKeyCheck(check)!;
+
+		expect(decodeSealedFeedCapabilityRecord(` ${recordJson}`)).toBeNull();
+		expect(decodeSealedFeedCapabilityRecord(`${recordJson}\n`)).toBeNull();
+		expect(
+			decodeSealedFeedCapabilityRecord(JSON.stringify({ ...record, extra: true })),
+		).toBeNull();
+		expect(decodeCapabilityVaultKeyCheck(` ${checkJson}`)).toBeNull();
+		expect(decodeCapabilityVaultKeyCheck(JSON.stringify({ ...check, extra: true }))).toBeNull();
+		expect(
+			decodeSealedFeedCapabilityRecord("A".repeat(MAX_SEALED_CAPABILITY_RECORD_BYTES + 1)),
+		).toBeNull();
+	});
+
+	it("does not invoke ciphertext accessors and sanitizes invalid envelope errors", async () => {
+		const { key, record } = await fixture();
+		let accessed = false;
+		const hostile = Object.defineProperty({ ...record }, "ciphertext", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return record.ciphertext;
+			},
+		});
+		expect(encodeSealedFeedCapabilityRecord(hostile)).toBeNull();
+		expect(accessed).toBe(false);
+
+		await expect(
+			sealFeedCapabilityEnvelope(
+				{ ...bundle, subscriptionUrl: "https://sensitive.invalid/\n" },
+				{
+					key: key.importedKey,
+					feedId,
+					capabilityRef,
+					fillRandom: sequentialFill(),
+				},
+			),
+		).rejects.toEqual(new FeedCapabilitySealingError());
+	});
+});

--- a/src/security/sealedCapabilityRecord.ts
+++ b/src/security/sealedCapabilityRecord.ts
@@ -1,0 +1,578 @@
+import {
+	CAPABILITY_VAULT_ALGORITHM,
+	CapabilityVaultCryptoError,
+	isCapabilityVaultId,
+	isCapabilityVaultKeyId,
+	isImportedCapabilityVaultKey,
+	type CapabilityVaultId,
+	type CapabilityVaultKeyId,
+	type CapabilityVaultRandomFill,
+	type ImportedCapabilityVaultKey,
+} from "./capabilityVaultKey";
+import { decodeBase64Url, encodeBase64Url } from "./base64Url";
+import {
+	isFeedCapabilityReferenceFor,
+	type FeedCapabilityReference,
+} from "./feedCapabilityReferences";
+import { isFeedHandle, type FeedHandle } from "./resourceHandles";
+import { snapshotStrictDataRecord, utf8ByteLength } from "./strictData";
+import {
+	MAX_FEED_CAPABILITY_ENVELOPE_BYTES,
+	TARGET_ENVELOPE_SCHEMA_VERSION,
+	validateFeedCapabilityEnvelope,
+	type FeedCapabilityEnvelope,
+} from "./targetEnvelopes";
+
+/**
+ * Pure, storage-agnostic recovery primitives. Persist each sealed record as an
+ * immutable revision and retain divergent heads. A mutable last-writer-wins map
+ * is not a safe storage implementation for this format.
+ */
+
+export const SEALED_CAPABILITY_RECORD_SCHEMA_VERSION = 1;
+export const CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION = 1;
+export const MAX_SEALED_CAPABILITY_RECORD_BYTES = 2 * 1024 * 1024;
+export const MAX_SEALED_CAPABILITY_CIPHERTEXT_BYTES = MAX_FEED_CAPABILITY_ENVELOPE_BYTES + 16;
+export const MAX_CAPABILITY_RECORD_GENERATION = Number.MAX_SAFE_INTEGER;
+
+const RECORD_ID_PATTERN = /^pncr-[0-9a-f]{32}$/;
+const NONCE_BYTES = 12;
+const RECORD_ID_BYTES = 16;
+const GCM_TAG_BYTES = 16;
+const KEY_CHECK_PLAINTEXT = "podnotes-capability-vault-key-check-v1";
+const KEY_CHECK_PLAINTEXT_BYTES = 38;
+const KEY_CHECK_CIPHERTEXT_BYTES = KEY_CHECK_PLAINTEXT_BYTES + GCM_TAG_BYTES;
+const RECORD_AAD_DOMAIN = "podnotes/feed-capability";
+const KEY_CHECK_AAD_DOMAIN = "podnotes/capability-vault/key-check";
+const textEncoder = new TextEncoder();
+const fatalTextDecoder = new TextDecoder("utf-8", { fatal: true });
+
+declare const sealedCapabilityRecordIdBrand: unique symbol;
+export type SealedCapabilityRecordId = string & {
+	readonly [sealedCapabilityRecordIdBrand]: true;
+};
+
+export interface SealedFeedCapabilityRecordV1 {
+	readonly schemaVersion: typeof SEALED_CAPABILITY_RECORD_SCHEMA_VERSION;
+	readonly kind: "sealed-feed-capability";
+	readonly algorithm: typeof CAPABILITY_VAULT_ALGORITHM;
+	readonly vaultId: CapabilityVaultId;
+	readonly keyId: CapabilityVaultKeyId;
+	readonly recordId: SealedCapabilityRecordId;
+	readonly feedId: FeedHandle;
+	readonly capabilityRef: FeedCapabilityReference;
+	readonly envelopeSchemaVersion: typeof TARGET_ENVELOPE_SCHEMA_VERSION;
+	readonly generation: number;
+	readonly parentRecordId?: SealedCapabilityRecordId;
+	readonly nonce: string;
+	readonly ciphertext: string;
+}
+
+export interface CapabilityVaultKeyCheckV1 {
+	readonly schemaVersion: typeof CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION;
+	readonly kind: "capability-vault-key-check";
+	readonly algorithm: typeof CAPABILITY_VAULT_ALGORITHM;
+	readonly vaultId: CapabilityVaultId;
+	readonly keyId: CapabilityVaultKeyId;
+	readonly nonce: string;
+	readonly ciphertext: string;
+}
+
+export interface SealFeedCapabilityOptions {
+	readonly key: ImportedCapabilityVaultKey;
+	readonly feedId: FeedHandle | string;
+	readonly capabilityRef: unknown;
+	readonly parentRecord?: unknown;
+	readonly fillRandom?: CapabilityVaultRandomFill;
+}
+
+export type OpenSealedFeedCapabilityResult =
+	| { readonly status: "available"; readonly value: FeedCapabilityEnvelope }
+	| { readonly status: "invalid" | "unavailable" };
+
+export type VerifyCapabilityVaultKeyResult =
+	| { readonly status: "available" }
+	| { readonly status: "invalid" | "unavailable" };
+
+export class FeedCapabilitySealingError extends Error {
+	constructor() {
+		super("Feed capabilities could not be sealed.");
+		this.name = "FeedCapabilitySealingError";
+	}
+}
+
+function fillWithWebCrypto(bytes: Uint8Array): void {
+	// oxlint-disable-next-line obsidianmd/no-global-this -- Web Crypto is the shared desktop/mobile runtime primitive.
+	const crypto = globalThis.crypto;
+	if (!crypto || typeof crypto.getRandomValues !== "function")
+		throw new CapabilityVaultCryptoError();
+	crypto.getRandomValues(bytes as Uint8Array<ArrayBuffer>);
+}
+
+function getSubtle(): SubtleCrypto {
+	// oxlint-disable-next-line obsidianmd/no-global-this -- Web Crypto is the shared desktop/mobile runtime primitive.
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) throw new CapabilityVaultCryptoError();
+	return subtle;
+}
+
+function encodeHex(bytes: Uint8Array): string {
+	let result = "";
+	for (const byte of bytes) result += byte.toString(16).padStart(2, "0");
+	return result;
+}
+
+function allocateRecordId(fillRandom: CapabilityVaultRandomFill): SealedCapabilityRecordId {
+	const bytes = new Uint8Array(RECORD_ID_BYTES);
+	fillRandom(bytes);
+	return `pncr-${encodeHex(bytes)}` as SealedCapabilityRecordId;
+}
+
+function isGeneration(value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value >= 1 &&
+		value <= MAX_CAPABILITY_RECORD_GENERATION
+	);
+}
+
+export function isSealedCapabilityRecordId(value: unknown): value is SealedCapabilityRecordId {
+	return typeof value === "string" && RECORD_ID_PATTERN.test(value);
+}
+
+function normalizeSealedRecord(value: unknown): SealedFeedCapabilityRecordV1 | null {
+	const baseKeys = [
+		"schemaVersion",
+		"kind",
+		"algorithm",
+		"vaultId",
+		"keyId",
+		"recordId",
+		"feedId",
+		"capabilityRef",
+		"envelopeSchemaVersion",
+		"generation",
+		"nonce",
+		"ciphertext",
+	] as const;
+	const withParent = snapshotStrictDataRecord(value, [...baseKeys, "parentRecordId"]);
+	const record = withParent ?? snapshotStrictDataRecord(value, baseKeys);
+	if (
+		!record ||
+		record.schemaVersion !== SEALED_CAPABILITY_RECORD_SCHEMA_VERSION ||
+		record.kind !== "sealed-feed-capability" ||
+		record.algorithm !== CAPABILITY_VAULT_ALGORITHM ||
+		!isCapabilityVaultId(record.vaultId) ||
+		!isCapabilityVaultKeyId(record.keyId) ||
+		!isSealedCapabilityRecordId(record.recordId) ||
+		!isFeedHandle(record.feedId) ||
+		!isFeedCapabilityReferenceFor(record.feedId, record.capabilityRef) ||
+		record.envelopeSchemaVersion !== TARGET_ENVELOPE_SCHEMA_VERSION ||
+		!isGeneration(record.generation) ||
+		typeof record.nonce !== "string" ||
+		!decodeBase64Url(record.nonce, NONCE_BYTES, NONCE_BYTES) ||
+		typeof record.ciphertext !== "string"
+	) {
+		return null;
+	}
+
+	const ciphertext = decodeBase64Url(record.ciphertext, MAX_SEALED_CAPABILITY_CIPHERTEXT_BYTES);
+	if (!ciphertext || ciphertext.byteLength <= GCM_TAG_BYTES) return null;
+
+	let parentRecordId: SealedCapabilityRecordId | undefined;
+	if (withParent) {
+		if (
+			!isSealedCapabilityRecordId(record.parentRecordId) ||
+			record.parentRecordId === record.recordId ||
+			record.generation === 1
+		) {
+			return null;
+		}
+		parentRecordId = record.parentRecordId;
+	} else if (record.generation !== 1) {
+		return null;
+	}
+
+	const normalized: SealedFeedCapabilityRecordV1 = {
+		schemaVersion: SEALED_CAPABILITY_RECORD_SCHEMA_VERSION,
+		kind: "sealed-feed-capability",
+		algorithm: CAPABILITY_VAULT_ALGORITHM,
+		vaultId: record.vaultId,
+		keyId: record.keyId,
+		recordId: record.recordId,
+		feedId: record.feedId,
+		capabilityRef: record.capabilityRef,
+		envelopeSchemaVersion: TARGET_ENVELOPE_SCHEMA_VERSION,
+		generation: record.generation,
+		...(parentRecordId ? { parentRecordId } : {}),
+		nonce: record.nonce,
+		ciphertext: record.ciphertext,
+	};
+	return utf8ByteLength(JSON.stringify(normalized)) <= MAX_SEALED_CAPABILITY_RECORD_BYTES
+		? normalized
+		: null;
+}
+
+function recordAad(
+	record: Omit<SealedFeedCapabilityRecordV1, "ciphertext">,
+): Uint8Array<ArrayBuffer> {
+	return textEncoder.encode(
+		JSON.stringify({
+			domain: RECORD_AAD_DOMAIN,
+			version: SEALED_CAPABILITY_RECORD_SCHEMA_VERSION,
+			algorithm: record.algorithm,
+			vaultId: record.vaultId,
+			keyId: record.keyId,
+			recordId: record.recordId,
+			feedId: record.feedId,
+			capabilityRef: record.capabilityRef,
+			envelopeSchemaVersion: record.envelopeSchemaVersion,
+			generation: record.generation,
+			parentRecordId: record.parentRecordId ?? null,
+			nonce: record.nonce,
+		}),
+	) as Uint8Array<ArrayBuffer>;
+}
+
+function normalizeKeyCheck(value: unknown): CapabilityVaultKeyCheckV1 | null {
+	const record = snapshotStrictDataRecord(value, [
+		"schemaVersion",
+		"kind",
+		"algorithm",
+		"vaultId",
+		"keyId",
+		"nonce",
+		"ciphertext",
+	]);
+	if (
+		!record ||
+		record.schemaVersion !== CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION ||
+		record.kind !== "capability-vault-key-check" ||
+		record.algorithm !== CAPABILITY_VAULT_ALGORITHM ||
+		!isCapabilityVaultId(record.vaultId) ||
+		!isCapabilityVaultKeyId(record.keyId) ||
+		typeof record.nonce !== "string" ||
+		!decodeBase64Url(record.nonce, NONCE_BYTES, NONCE_BYTES) ||
+		typeof record.ciphertext !== "string" ||
+		!decodeBase64Url(record.ciphertext, KEY_CHECK_CIPHERTEXT_BYTES, KEY_CHECK_CIPHERTEXT_BYTES)
+	) {
+		return null;
+	}
+	return {
+		schemaVersion: CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION,
+		kind: "capability-vault-key-check",
+		algorithm: CAPABILITY_VAULT_ALGORITHM,
+		vaultId: record.vaultId,
+		keyId: record.keyId,
+		nonce: record.nonce,
+		ciphertext: record.ciphertext,
+	};
+}
+
+function keyCheckAad(
+	value: Pick<CapabilityVaultKeyCheckV1, "vaultId" | "keyId" | "nonce">,
+): Uint8Array<ArrayBuffer> {
+	return textEncoder.encode(
+		JSON.stringify({
+			domain: KEY_CHECK_AAD_DOMAIN,
+			version: CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION,
+			algorithm: CAPABILITY_VAULT_ALGORITHM,
+			vaultId: value.vaultId,
+			keyId: value.keyId,
+			nonce: value.nonce,
+		}),
+	) as Uint8Array<ArrayBuffer>;
+}
+
+function directParentMatches(
+	record: SealedFeedCapabilityRecordV1,
+	parent: SealedFeedCapabilityRecordV1,
+): boolean {
+	return (
+		record.generation === parent.generation + 1 &&
+		record.parentRecordId === parent.recordId &&
+		record.vaultId === parent.vaultId &&
+		record.keyId === parent.keyId &&
+		record.feedId === parent.feedId &&
+		record.capabilityRef === parent.capabilityRef
+	);
+}
+
+async function decryptNormalizedRecord(
+	record: SealedFeedCapabilityRecordV1,
+	key: ImportedCapabilityVaultKey,
+): Promise<OpenSealedFeedCapabilityResult> {
+	const nonce = decodeBase64Url(record.nonce, NONCE_BYTES, NONCE_BYTES);
+	const ciphertext = decodeBase64Url(record.ciphertext, MAX_SEALED_CAPABILITY_CIPHERTEXT_BYTES);
+	if (!nonce || !ciphertext) return { status: "invalid" };
+
+	let plaintextBytes: ArrayBuffer;
+	try {
+		plaintextBytes = await getSubtle().decrypt(
+			{
+				name: "AES-GCM",
+				iv: nonce,
+				additionalData: recordAad(record),
+				tagLength: 128,
+			},
+			key.cryptoKey,
+			ciphertext,
+		);
+	} catch (error) {
+		return error instanceof CapabilityVaultCryptoError
+			? { status: "unavailable" }
+			: { status: "invalid" };
+	}
+
+	try {
+		const plaintext = fatalTextDecoder.decode(plaintextBytes);
+		if (utf8ByteLength(plaintext) > MAX_FEED_CAPABILITY_ENVELOPE_BYTES) {
+			return { status: "invalid" };
+		}
+		const envelope = validateFeedCapabilityEnvelope(JSON.parse(plaintext), record.feedId);
+		return envelope && JSON.stringify(envelope) === plaintext
+			? { status: "available", value: envelope }
+			: { status: "invalid" };
+	} catch {
+		return { status: "invalid" };
+	}
+}
+
+export function encodeSealedFeedCapabilityRecord(value: unknown): string | null {
+	const normalized = normalizeSealedRecord(value);
+	return normalized ? JSON.stringify(normalized) : null;
+}
+
+export function validateSealedFeedCapabilityRecord(
+	value: unknown,
+): SealedFeedCapabilityRecordV1 | null {
+	return normalizeSealedRecord(value);
+}
+
+export function decodeSealedFeedCapabilityRecord(
+	serialized: unknown,
+): SealedFeedCapabilityRecordV1 | null {
+	if (
+		typeof serialized !== "string" ||
+		serialized.length === 0 ||
+		serialized.length > MAX_SEALED_CAPABILITY_RECORD_BYTES ||
+		utf8ByteLength(serialized) > MAX_SEALED_CAPABILITY_RECORD_BYTES
+	) {
+		return null;
+	}
+	try {
+		const normalized = normalizeSealedRecord(JSON.parse(serialized));
+		return normalized && JSON.stringify(normalized) === serialized ? normalized : null;
+	} catch {
+		return null;
+	}
+}
+
+export function encodeCapabilityVaultKeyCheck(value: unknown): string | null {
+	const normalized = normalizeKeyCheck(value);
+	return normalized ? JSON.stringify(normalized) : null;
+}
+
+export function validateCapabilityVaultKeyCheck(value: unknown): CapabilityVaultKeyCheckV1 | null {
+	return normalizeKeyCheck(value);
+}
+
+export function decodeCapabilityVaultKeyCheck(
+	serialized: unknown,
+): CapabilityVaultKeyCheckV1 | null {
+	if (typeof serialized !== "string" || serialized.length === 0 || serialized.length > 1024) {
+		return null;
+	}
+	try {
+		const normalized = normalizeKeyCheck(JSON.parse(serialized));
+		return normalized && JSON.stringify(normalized) === serialized ? normalized : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function sealFeedCapabilityEnvelope(
+	value: unknown,
+	options: SealFeedCapabilityOptions,
+): Promise<SealedFeedCapabilityRecordV1> {
+	try {
+		const key = options.key;
+		const feedId = options.feedId;
+		const capabilityRef = options.capabilityRef;
+		const parentRecordValue = options.parentRecord;
+		const configuredFillRandom = options.fillRandom;
+		if (
+			!isImportedCapabilityVaultKey(key) ||
+			!isFeedHandle(feedId) ||
+			!isFeedCapabilityReferenceFor(feedId, capabilityRef)
+		) {
+			throw new FeedCapabilitySealingError();
+		}
+		const envelope = validateFeedCapabilityEnvelope(value, feedId);
+		if (!envelope) throw new FeedCapabilitySealingError();
+		const parentRecord =
+			parentRecordValue === undefined ? undefined : normalizeSealedRecord(parentRecordValue);
+		if (
+			parentRecordValue !== undefined &&
+			(!parentRecord ||
+				parentRecord.vaultId !== key.vaultId ||
+				parentRecord.keyId !== key.keyId ||
+				parentRecord.feedId !== feedId ||
+				parentRecord.capabilityRef !== capabilityRef ||
+				parentRecord.generation >= MAX_CAPABILITY_RECORD_GENERATION)
+		) {
+			throw new FeedCapabilitySealingError();
+		}
+		if (parentRecord) {
+			const openedParent = await decryptNormalizedRecord(parentRecord, key);
+			if (openedParent.status !== "available") throw new FeedCapabilitySealingError();
+		}
+		const generation = parentRecord ? parentRecord.generation + 1 : 1;
+
+		const fillRandom = configuredFillRandom ?? fillWithWebCrypto;
+		const nonceBytes = new Uint8Array(NONCE_BYTES);
+		const recordId = allocateRecordId(fillRandom);
+		fillRandom(nonceBytes);
+		const clearRecord: Omit<SealedFeedCapabilityRecordV1, "ciphertext"> = {
+			schemaVersion: SEALED_CAPABILITY_RECORD_SCHEMA_VERSION,
+			kind: "sealed-feed-capability" as const,
+			algorithm: CAPABILITY_VAULT_ALGORITHM,
+			vaultId: key.vaultId,
+			keyId: key.keyId,
+			recordId,
+			feedId,
+			capabilityRef,
+			envelopeSchemaVersion: TARGET_ENVELOPE_SCHEMA_VERSION,
+			generation,
+			...(parentRecord ? { parentRecordId: parentRecord.recordId } : {}),
+			nonce: encodeBase64Url(nonceBytes),
+		};
+		const plaintext = textEncoder.encode(JSON.stringify(envelope));
+		const ciphertext = await getSubtle().encrypt(
+			{
+				name: "AES-GCM",
+				iv: nonceBytes,
+				additionalData: recordAad(clearRecord),
+				tagLength: 128,
+			},
+			key.cryptoKey,
+			plaintext,
+		);
+		const record = normalizeSealedRecord({
+			...clearRecord,
+			ciphertext: encodeBase64Url(new Uint8Array(ciphertext)),
+		});
+		if (!record) throw new FeedCapabilitySealingError();
+		return record;
+	} catch (error) {
+		if (error instanceof FeedCapabilitySealingError) throw error;
+		throw new FeedCapabilitySealingError();
+	}
+}
+
+export async function openSealedFeedCapabilityEnvelope(
+	value: unknown,
+	key: ImportedCapabilityVaultKey,
+	parentValue?: unknown,
+): Promise<OpenSealedFeedCapabilityResult> {
+	const record = normalizeSealedRecord(value);
+	if (
+		!record ||
+		!isImportedCapabilityVaultKey(key) ||
+		record.vaultId !== key.vaultId ||
+		record.keyId !== key.keyId
+	) {
+		return { status: "invalid" };
+	}
+
+	if (record.generation === 1) {
+		if (parentValue !== undefined) return { status: "invalid" };
+	} else {
+		const parent = normalizeSealedRecord(parentValue);
+		if (!parent || !directParentMatches(record, parent)) return { status: "invalid" };
+		const openedParent = await decryptNormalizedRecord(parent, key);
+		if (openedParent.status !== "available") return openedParent;
+	}
+
+	return decryptNormalizedRecord(record, key);
+}
+
+export async function createCapabilityVaultKeyCheck(
+	key: ImportedCapabilityVaultKey,
+	fillRandom: CapabilityVaultRandomFill = fillWithWebCrypto,
+): Promise<CapabilityVaultKeyCheckV1> {
+	try {
+		if (!isImportedCapabilityVaultKey(key)) throw new CapabilityVaultCryptoError();
+		const nonceBytes = new Uint8Array(NONCE_BYTES);
+		fillRandom(nonceBytes);
+		const clear = {
+			vaultId: key.vaultId,
+			keyId: key.keyId,
+			nonce: encodeBase64Url(nonceBytes),
+		};
+		const ciphertext = await getSubtle().encrypt(
+			{
+				name: "AES-GCM",
+				iv: nonceBytes,
+				additionalData: keyCheckAad(clear),
+				tagLength: 128,
+			},
+			key.keyCheckCryptoKey,
+			textEncoder.encode(KEY_CHECK_PLAINTEXT),
+		);
+		const result = normalizeKeyCheck({
+			schemaVersion: CAPABILITY_VAULT_KEY_CHECK_SCHEMA_VERSION,
+			kind: "capability-vault-key-check",
+			algorithm: CAPABILITY_VAULT_ALGORITHM,
+			...clear,
+			ciphertext: encodeBase64Url(new Uint8Array(ciphertext)),
+		});
+		if (!result) throw new CapabilityVaultCryptoError();
+		return result;
+	} catch {
+		throw new CapabilityVaultCryptoError();
+	}
+}
+
+export async function verifyCapabilityVaultKey(
+	value: unknown,
+	key: ImportedCapabilityVaultKey,
+): Promise<VerifyCapabilityVaultKeyResult> {
+	const check = normalizeKeyCheck(value);
+	if (
+		!check ||
+		!isImportedCapabilityVaultKey(key) ||
+		check.vaultId !== key.vaultId ||
+		check.keyId !== key.keyId
+	) {
+		return { status: "invalid" };
+	}
+	const nonce = decodeBase64Url(check.nonce, NONCE_BYTES, NONCE_BYTES);
+	const ciphertext = decodeBase64Url(
+		check.ciphertext,
+		KEY_CHECK_CIPHERTEXT_BYTES,
+		KEY_CHECK_CIPHERTEXT_BYTES,
+	);
+	if (!nonce || !ciphertext) return { status: "invalid" };
+
+	try {
+		const plaintext = await getSubtle().decrypt(
+			{
+				name: "AES-GCM",
+				iv: nonce,
+				additionalData: keyCheckAad(check),
+				tagLength: 128,
+			},
+			key.keyCheckCryptoKey,
+			ciphertext,
+		);
+		return fatalTextDecoder.decode(plaintext) === KEY_CHECK_PLAINTEXT
+			? { status: "available" }
+			: { status: "invalid" };
+	} catch (error) {
+		return error instanceof CapabilityVaultCryptoError
+			? { status: "unavailable" }
+			: { status: "invalid" };
+	}
+}

--- a/src/security/strictData.test.ts
+++ b/src/security/strictData.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+	snapshotAllowedDataRecord,
+	snapshotDenseDataArray,
+	snapshotPlainDataRecord,
+	snapshotStrictDataRecord,
+} from "./strictData";
+
+describe("snapshotStrictDataRecord", () => {
+	it("copies exact Object and null-prototype data records", () => {
+		const value = Object.assign(Object.create(null), { alpha: 1, beta: "two" });
+		const result = snapshotStrictDataRecord(value, ["alpha", "beta"]);
+		expect(result).toEqual({ alpha: 1, beta: "two" });
+		expect(Object.getPrototypeOf(result!)).toBeNull();
+	});
+
+	it.each([
+		null,
+		[],
+		new Date(),
+		{ alpha: 1 },
+		{ alpha: 1, beta: 2, extra: 3 },
+		Object.assign(Object.create(null), { __proto__: "value", beta: 2 }),
+	])("rejects a non-exact record %#", (value) => {
+		expect(snapshotStrictDataRecord(value, ["alpha", "beta"])).toBeNull();
+	});
+
+	it("rejects accessors and symbols without invoking them", () => {
+		let accessed = false;
+		const value = Object.defineProperty({ beta: 2 }, "alpha", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return 1;
+			},
+		});
+		Object.defineProperty(value, Symbol("hidden"), { enumerable: true, value: 3 });
+
+		expect(snapshotStrictDataRecord(value, ["alpha", "beta"])).toBeNull();
+		expect(accessed).toBe(false);
+	});
+
+	it("fails closed when a proxy trap throws", () => {
+		const value = new Proxy(
+			{},
+			{
+				ownKeys() {
+					throw new Error("hostile proxy");
+				},
+			},
+		);
+		expect(snapshotStrictDataRecord(value, [])).toBeNull();
+	});
+
+	it("snapshots bounded and allowlisted records without rereading proxy getters", () => {
+		let reads = 0;
+		const value = new Proxy(
+			{ alpha: 1, beta: 2 },
+			{
+				get(target, key, receiver) {
+					reads += 1;
+					return Reflect.get(target, key, receiver);
+				},
+			},
+		);
+		expect(snapshotPlainDataRecord(value, 2)).toEqual({ alpha: 1, beta: 2 });
+		expect(snapshotAllowedDataRecord(value, new Set(["alpha", "beta"]))).toEqual({
+			alpha: 1,
+			beta: 2,
+		});
+		expect(snapshotPlainDataRecord(value, 1)).toBeNull();
+		expect(snapshotAllowedDataRecord(value, new Set(["alpha"]))).toBeNull();
+		expect(reads).toBe(0);
+	});
+
+	it("rejects dangerous data keys explicitly", () => {
+		const value = Object.create(null) as Record<string, unknown>;
+		Object.defineProperty(value, "__proto__", { enumerable: true, value: "poison" });
+		expect(snapshotPlainDataRecord(value)).toBeNull();
+	});
+
+	it("snapshots only dense data arrays", () => {
+		const value = ["one", "two"];
+		expect(snapshotDenseDataArray(value, 2)).toEqual(value);
+		expect(snapshotDenseDataArray(value, 1)).toBeNull();
+		const sparse: string[] = [];
+		sparse.length = 1;
+		expect(snapshotDenseDataArray(sparse, 2)).toBeNull();
+		const extra = ["one"] as string[] & { extra?: boolean };
+		extra.extra = true;
+		expect(snapshotDenseDataArray(extra, 2)).toBeNull();
+	});
+
+	it("does not invoke dense-array accessors", () => {
+		let accessed = false;
+		const value = ["one"];
+		Object.defineProperty(value, "0", {
+			enumerable: true,
+			get() {
+				accessed = true;
+				return "one";
+			},
+		});
+		expect(snapshotDenseDataArray(value, 1)).toBeNull();
+		expect(accessed).toBe(false);
+	});
+});

--- a/src/security/strictData.ts
+++ b/src/security/strictData.ts
@@ -1,0 +1,117 @@
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const textEncoder = new TextEncoder();
+
+export type StrictDataRecord = Record<string, unknown>;
+
+function snapshotDataRecordInternal(
+	value: unknown,
+	allowedKeys?: ReadonlySet<string>,
+	maximumKeys = Number.MAX_SAFE_INTEGER,
+): StrictDataRecord | null {
+	try {
+		if (
+			typeof value !== "object" ||
+			value === null ||
+			Array.isArray(value) ||
+			!Number.isSafeInteger(maximumKeys) ||
+			maximumKeys < 0
+		) {
+			return null;
+		}
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) return null;
+
+		const ownKeys = Reflect.ownKeys(value);
+		if (ownKeys.length > maximumKeys) return null;
+		const snapshot = Object.create(null) as StrictDataRecord;
+		for (const key of ownKeys) {
+			if (
+				typeof key !== "string" ||
+				DANGEROUS_KEYS.has(key) ||
+				(allowedKeys && !allowedKeys.has(key))
+			) {
+				return null;
+			}
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor?.enumerable || !("value" in descriptor)) return null;
+			snapshot[key] = descriptor.value;
+		}
+		return snapshot;
+	} catch {
+		return null;
+	}
+}
+
+/** Snapshot any bounded plain-data record once, including proxy descriptors. */
+export function snapshotPlainDataRecord(
+	value: unknown,
+	maximumKeys = Number.MAX_SAFE_INTEGER,
+): StrictDataRecord | null {
+	return snapshotDataRecordInternal(value, undefined, maximumKeys);
+}
+
+/** Snapshot a plain-data record whose keys must be drawn from the allowlist. */
+export function snapshotAllowedDataRecord(
+	value: unknown,
+	allowedKeys: ReadonlySet<string>,
+): StrictDataRecord | null {
+	return snapshotDataRecordInternal(value, allowedKeys, allowedKeys.size);
+}
+
+/**
+ * Copy an exact plain-data object without invoking accessors or retaining a
+ * hostile proxy/object reference. Every expected key must exist exactly once.
+ */
+export function snapshotStrictDataRecord(
+	value: unknown,
+	expectedKeys: readonly string[],
+): StrictDataRecord | null {
+	const expected = new Set(expectedKeys);
+	if (expected.size !== expectedKeys.length) return null;
+	const snapshot = snapshotDataRecordInternal(value, expected, expected.size);
+	return snapshot &&
+		expectedKeys.every((key) => Object.prototype.hasOwnProperty.call(snapshot, key))
+		? snapshot
+		: null;
+}
+
+/** Snapshot a dense data-only array without retaining a proxy or invoking getters. */
+export function snapshotDenseDataArray(value: unknown, maximumLength: number): unknown[] | null {
+	try {
+		if (!Array.isArray(value) || !Number.isSafeInteger(maximumLength) || maximumLength < 0) {
+			return null;
+		}
+		const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+		if (!lengthDescriptor || !("value" in lengthDescriptor)) return null;
+		const length = lengthDescriptor.value;
+		if (!Number.isSafeInteger(length) || length < 0 || length > maximumLength) return null;
+		const ownKeys = Reflect.ownKeys(value);
+		const ownKeySet = new Set(ownKeys);
+		if (ownKeySet.size !== length + 1 || !ownKeySet.has("length")) return null;
+
+		const snapshot: unknown[] = [];
+		for (let index = 0; index < length; index += 1) {
+			const key = String(index);
+			if (!ownKeySet.has(key)) return null;
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (!descriptor?.enumerable || !("value" in descriptor)) return null;
+			snapshot.push(descriptor.value);
+		}
+		return snapshot;
+	} catch {
+		return null;
+	}
+}
+
+export function utf8ByteLength(value: string): number {
+	return textEncoder.encode(value).byteLength;
+}
+
+export function serializedValueFits(value: unknown, maximumBytes: number): boolean {
+	try {
+		const serialized = JSON.stringify(value);
+		return typeof serialized === "string" && utf8ByteLength(serialized) <= maximumBytes;
+	} catch {
+		return false;
+	}
+}

--- a/src/security/targetEnvelopes.test.ts
+++ b/src/security/targetEnvelopes.test.ts
@@ -106,13 +106,56 @@ describe("feed capability bundles", () => {
 
 	it("fails closed for unsupported versions and hostile objects", () => {
 		const hostile = new Proxy(feedBundle(), {
-			get() {
-				throw new Error("hostile getter");
+			ownKeys() {
+				throw new Error("hostile ownKeys trap");
 			},
 		});
 
 		expect(validateFeedCapabilityEnvelope({ ...feedBundle(), schemaVersion: 2 })).toBeNull();
 		expect(validateFeedCapabilityEnvelope(hostile)).toBeNull();
+	});
+
+	it("snapshots proxy data descriptors once instead of rereading changing getters", () => {
+		let rootGuidReads = 0;
+		let episodeGuidReads = 0;
+		const episode = new Proxy(
+			{ ...episodeResources(), guid: "stable-episode-guid" },
+			{
+				get(target, key, receiver) {
+					if (key === "guid") {
+						episodeGuidReads += 1;
+						return "x".repeat(9_000);
+					}
+					return Reflect.get(target, key, receiver);
+				},
+			},
+		);
+		const value = new Proxy(
+			{
+				...feedBundle(),
+				guid: "stable-feed-guid",
+				episodeResources: { [episodeId]: episode },
+			},
+			{
+				get(target, key, receiver) {
+					if (key === "guid") {
+						rootGuidReads += 1;
+						return "x".repeat(9_000);
+					}
+					return Reflect.get(target, key, receiver);
+				},
+			},
+		);
+
+		expect(validateFeedCapabilityEnvelope(value)).toEqual({
+			...feedBundle(),
+			guid: "stable-feed-guid",
+			episodeResources: {
+				[episodeId]: { ...episodeResources(), guid: "stable-episode-guid" },
+			},
+		});
+		expect(rootGuidReads).toBe(0);
+		expect(episodeGuidReads).toBe(0);
 	});
 
 	it("preserves bounded channel GUID evidence without imposing uniqueness", () => {
@@ -271,8 +314,8 @@ describe("episode resource envelopes", () => {
 
 	it("fails closed for unsupported versions and hostile objects", () => {
 		const hostile = new Proxy(episodeResources(), {
-			get() {
-				throw new Error("hostile getter");
+			getOwnPropertyDescriptor() {
+				throw new Error("hostile descriptor trap");
 			},
 		});
 

--- a/src/security/targetEnvelopes.ts
+++ b/src/security/targetEnvelopes.ts
@@ -4,6 +4,12 @@ import {
 	type EpisodeHandle,
 	type FeedHandle,
 } from "./resourceHandles";
+import {
+	snapshotAllowedDataRecord,
+	snapshotDenseDataArray,
+	snapshotPlainDataRecord,
+	type StrictDataRecord,
+} from "./strictData";
 
 export const TARGET_ENVELOPE_SCHEMA_VERSION = 1;
 export const MAX_TARGET_URL_BYTES = 16 * 1024;
@@ -80,24 +86,7 @@ const EPISODE_KEYS = new Set([
 ]);
 const PRIVATE_GRANT_KEYS = new Set<string>(PRIVATE_TARGET_GRANT_KINDS);
 
-type UnknownRecord = Record<string, unknown>;
-
-function isPlainDataRecord(value: unknown): value is UnknownRecord {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const prototype = Object.getPrototypeOf(value);
-	if (prototype !== Object.prototype && prototype !== null) return false;
-
-	for (const key of Reflect.ownKeys(value)) {
-		if (typeof key !== "string") return false;
-		const descriptor = Object.getOwnPropertyDescriptor(value, key);
-		if (!descriptor?.enumerable || !("value" in descriptor)) return false;
-	}
-	return true;
-}
-
-function isStrictRecord(value: unknown, allowedKeys: ReadonlySet<string>): value is UnknownRecord {
-	return isPlainDataRecord(value) && Object.keys(value).every((key) => allowedKeys.has(key));
-}
+type UnknownRecord = StrictDataRecord;
 
 function hasUnsafeUnicode(value: string): boolean {
 	for (let index = 0; index < value.length; index += 1) {
@@ -157,22 +146,14 @@ function normalizePrivateOrigin(value: unknown): string | undefined {
 
 function normalizePrivateGrants(value: unknown): PrivateTargetGrants | null | undefined {
 	if (value === undefined) return undefined;
-	if (!isStrictRecord(value, PRIVATE_GRANT_KEYS)) return null;
+	const record = snapshotAllowedDataRecord(value, PRIVATE_GRANT_KEYS);
+	if (!record) return null;
 
 	const normalized: PrivateTargetGrants = {};
 	for (const kind of PRIVATE_TARGET_GRANT_KINDS) {
-		if (!Object.prototype.hasOwnProperty.call(value, kind)) continue;
-		const grants = value[kind];
-		if (
-			!Array.isArray(grants) ||
-			grants.length === 0 ||
-			grants.length > MAX_PRIVATE_GRANTS_PER_KIND
-		) {
-			return null;
-		}
-		for (let index = 0; index < grants.length; index += 1) {
-			if (!Object.prototype.hasOwnProperty.call(grants, index)) return null;
-		}
+		if (!Object.prototype.hasOwnProperty.call(record, kind)) continue;
+		const grants = snapshotDenseDataArray(record[kind], MAX_PRIVATE_GRANTS_PER_KIND);
+		if (!grants || grants.length === 0) return null;
 		const origins = grants.map(normalizePrivateOrigin);
 		if (origins.some((origin) => origin === undefined)) return null;
 		const concrete = origins as string[];
@@ -200,45 +181,46 @@ function validateEpisodeResourcesEnvelopeUnchecked(
 	expectedFeedId?: unknown,
 	expectedEpisodeId?: unknown,
 ): EpisodeResourcesEnvelope | null {
-	if (!isStrictRecord(value, EPISODE_KEYS)) return null;
+	const record = snapshotAllowedDataRecord(value, EPISODE_KEYS);
+	if (!record) return null;
 	if (
-		value.schemaVersion !== TARGET_ENVELOPE_SCHEMA_VERSION ||
-		value.kind !== "episode-resources" ||
-		!isFeedHandle(value.feedId) ||
-		!isEpisodeHandle(value.episodeId) ||
-		(expectedFeedId !== undefined && value.feedId !== expectedFeedId) ||
-		(expectedEpisodeId !== undefined && value.episodeId !== expectedEpisodeId)
+		record.schemaVersion !== TARGET_ENVELOPE_SCHEMA_VERSION ||
+		record.kind !== "episode-resources" ||
+		!isFeedHandle(record.feedId) ||
+		!isEpisodeHandle(record.episodeId) ||
+		(expectedFeedId !== undefined && record.feedId !== expectedFeedId) ||
+		(expectedEpisodeId !== undefined && record.episodeId !== expectedEpisodeId)
 	) {
 		return null;
 	}
 
-	const streamUrl = readOptionalTarget(value, "streamUrl");
-	const chaptersUrl = readOptionalTarget(value, "chaptersUrl");
-	const artworkUrl = readOptionalTarget(value, "artworkUrl");
-	const itemLink = readOptionalTarget(value, "itemLink");
+	const streamUrl = readOptionalTarget(record, "streamUrl");
+	const chaptersUrl = readOptionalTarget(record, "chaptersUrl");
+	const artworkUrl = readOptionalTarget(record, "artworkUrl");
+	const itemLink = readOptionalTarget(record, "itemLink");
 	if (streamUrl === null || chaptersUrl === null || artworkUrl === null || itemLink === null) {
 		return null;
 	}
 	if (
-		Object.prototype.hasOwnProperty.call(value, "guid") &&
-		!isBoundedString(value.guid, MAX_GUID_BYTES)
+		Object.prototype.hasOwnProperty.call(record, "guid") &&
+		!isBoundedString(record.guid, MAX_GUID_BYTES)
 	) {
 		return null;
 	}
-	if (!streamUrl && !chaptersUrl && !artworkUrl && !itemLink && typeof value.guid !== "string") {
+	if (!streamUrl && !chaptersUrl && !artworkUrl && !itemLink && typeof record.guid !== "string") {
 		return null;
 	}
 
 	const normalized: EpisodeResourcesEnvelope = {
 		schemaVersion: TARGET_ENVELOPE_SCHEMA_VERSION,
 		kind: "episode-resources",
-		feedId: value.feedId,
-		episodeId: value.episodeId,
+		feedId: record.feedId,
+		episodeId: record.episodeId,
 		...(streamUrl ? { streamUrl } : {}),
 		...(chaptersUrl ? { chaptersUrl } : {}),
 		...(artworkUrl ? { artworkUrl } : {}),
 		...(itemLink ? { itemLink } : {}),
-		...(typeof value.guid === "string" ? { guid: value.guid } : {}),
+		...(typeof record.guid === "string" ? { guid: record.guid } : {}),
 	};
 	return serializedFits(normalized, MAX_EPISODE_RESOURCES_ENVELOPE_BYTES) ? normalized : null;
 }
@@ -259,41 +241,46 @@ function validateFeedCapabilityEnvelopeUnchecked(
 	value: unknown,
 	expectedFeedId?: unknown,
 ): FeedCapabilityEnvelope | null {
-	if (!isStrictRecord(value, FEED_CAPABILITY_KEYS)) return null;
+	const record = snapshotAllowedDataRecord(value, FEED_CAPABILITY_KEYS);
+	if (!record) return null;
+	const episodeResourcesRecord = snapshotPlainDataRecord(
+		record.episodeResources,
+		MAX_EPISODE_RESOURCES_PER_FEED,
+	);
 	if (
-		value.schemaVersion !== TARGET_ENVELOPE_SCHEMA_VERSION ||
-		value.kind !== "feed-capability-bundle" ||
-		!isFeedHandle(value.feedId) ||
-		(expectedFeedId !== undefined && value.feedId !== expectedFeedId) ||
-		!isPlainDataRecord(value.episodeResources)
+		record.schemaVersion !== TARGET_ENVELOPE_SCHEMA_VERSION ||
+		record.kind !== "feed-capability-bundle" ||
+		!isFeedHandle(record.feedId) ||
+		(expectedFeedId !== undefined && record.feedId !== expectedFeedId) ||
+		!episodeResourcesRecord
 	) {
 		return null;
 	}
 
-	const episodeIds = Object.keys(value.episodeResources);
+	const episodeIds = Object.keys(episodeResourcesRecord);
 	if (episodeIds.length > MAX_EPISODE_RESOURCES_PER_FEED) return null;
 
-	const subscriptionUrl = normalizeHttpTarget(value.subscriptionUrl);
-	const artworkUrl = readOptionalTarget(value, "artworkUrl");
-	const siteUrl = readOptionalTarget(value, "siteUrl");
-	const privateGrants = normalizePrivateGrants(value.privateGrants);
+	const subscriptionUrl = normalizeHttpTarget(record.subscriptionUrl);
+	const artworkUrl = readOptionalTarget(record, "artworkUrl");
+	const siteUrl = readOptionalTarget(record, "siteUrl");
+	const privateGrants = normalizePrivateGrants(record.privateGrants);
 	if (!subscriptionUrl || artworkUrl === null || siteUrl === null || privateGrants === null) {
 		return null;
 	}
 	if (
-		Object.prototype.hasOwnProperty.call(value, "guid") &&
-		!isBoundedString(value.guid, MAX_GUID_BYTES)
+		Object.prototype.hasOwnProperty.call(record, "guid") &&
+		!isBoundedString(record.guid, MAX_GUID_BYTES)
 	) {
 		return null;
 	}
 	const normalizedMetadata: Omit<FeedCapabilityEnvelope, "episodeResources"> = {
 		schemaVersion: TARGET_ENVELOPE_SCHEMA_VERSION,
 		kind: "feed-capability-bundle" as const,
-		feedId: value.feedId,
+		feedId: record.feedId,
 		subscriptionUrl,
 		...(artworkUrl ? { artworkUrl } : {}),
 		...(siteUrl ? { siteUrl } : {}),
-		...(typeof value.guid === "string" ? { guid: value.guid } : {}),
+		...(typeof record.guid === "string" ? { guid: record.guid } : {}),
 		...(privateGrants ? { privateGrants } : {}),
 	};
 	if (!serializedFits(normalizedMetadata, MAX_FEED_CAPABILITY_METADATA_BYTES)) return null;
@@ -302,8 +289,8 @@ function validateFeedCapabilityEnvelopeUnchecked(
 	for (const episodeId of episodeIds.sort()) {
 		if (!isEpisodeHandle(episodeId)) return null;
 		const entry = validateEpisodeResourcesEnvelope(
-			value.episodeResources[episodeId],
-			value.feedId,
+			episodeResourcesRecord[episodeId],
+			record.feedId,
 			episodeId,
 		);
 		if (!entry) return null;


### PR DESCRIPTION
## Summary

- add browser-native, bounded, canonical base64url and strict data-snapshot primitives
- add a local-only capability vault key envelope plus an explicit `PNCV1` recovery code
- derive separate non-extractable AES-256-GCM keys for feed records and empty-vault key verification with HKDF-SHA-256
- add immutable sealed feed-capability records with authenticated vault, key, record, feed, exact reference, lineage, and nonce metadata
- add target-free capability vault metadata containing only key identity and an authenticated key check
- harden existing target-envelope validation against proxy time-of-check/time-of-use mutation

## Cross-device contract

Obsidian SecretStorage is treated as device-local. A 256-bit recovery root remains local and can be transferred explicitly with the sensitive recovery code. Synced recovery material can contain immutable ciphertext records, but no URL, hostname, GUID, key bytes, device ID, or target-derived digest.

This PR intentionally does not choose or activate a synced storage location. Future storage must retain immutable divergent heads rather than putting records in a last-writer-wins map. Schema v2 remains authoritative until desktop and mobile Sync behavior, conflict retention, recovery import, and lossless migration are proven.

## Security properties

- 128-bit random vault and record identities
- vault-salted HKDF with distinct info labels for key identity, feed encryption, and key checking
- AES-256-GCM with random 96-bit nonces and 128-bit tags
- fixed-order canonical AAD authenticating every clear record binding
- fatal UTF-8 decode plus byte-for-byte canonical envelope verification after decryption
- direct-parent authentication with generation and parent ID derived by the sealer
- strict bounds before base64 decode, JSON parse, or ciphertext allocation
- canonical JSON, exact key sets, dense arrays, no accessors, symbols, dangerous keys, or hostile object retention
- sanitized cryptographic errors with no target or key material

## Validation

- focused security suite: 75 tests
- full suite: 96 files and 1,564 tests
- Svelte accessibility checks: 0 errors and 0 warnings
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `uv run --with-requirements docs/requirements.txt mkdocs build -f docs/mkdocs.yml -d site`
- three independent P1/P2 reviews after fixes, all clean

## Real Obsidian verification

Verified in Obsidian 1.12.7 on macOS with the isolated worktree vault:

- PodNotes loaded successfully
- HKDF-SHA-256 derived a non-extractable AES-256-GCM key
- encrypt/decrypt round-trip succeeded with a 16-byte GCM tag
- browser base64 and fatal UTF-8 decoding succeeded
- the Obsidian error log remained clean
- the isolated process tree and profile were removed afterward

## Review-driven root fixes

- sealing now derives adjacent lineage from a decrypted same-vault, same-key, same-feed, same-reference parent
- target, episode, episode-map, private-grant, and dense-array validators snapshot descriptors once, preventing changing proxies from poisoning a record that cannot later open

## Release impact

- no user-facing setting, persisted-data migration, network caller, or runtime cutover is activated
- the sealed modules remain storage-agnostic and unused by production composition
- the shared target validator is stricter but preserves all valid canonical envelopes
