### PR TITLE
fix(orca): invoke the runner via the worktree-local bin in the archive hook

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -22,7 +22,10 @@
 # - The hook needs `node` on the GUI app's PATH (Orca runs it via non-login
 #   /bin/bash). It is guarded with `command -v node` so a missing node degrades
 #   to a no-op (the reap-on-next-start safety net then handles cleanup) instead
-#   of erroring.
+#   of erroring. The runner is invoked through the worktree-local bin rather
+#   than `npm exec` because the npm shim is often absent from that GUI PATH,
+#   which would make the stop fail silently behind `|| true` and leak the
+#   instance; the bin launcher is POSIX sh and needs only node.
 scripts:
   archive: |
-    command -v node >/dev/null 2>&1 && npm exec obsidian-e2e -- stop --worktree "$ORCA_WORKTREE_PATH" || true
+    command -v node >/dev/null 2>&1 && "$ORCA_WORKTREE_PATH/node_modules/.bin/obsidian-e2e" stop --worktree "$ORCA_WORKTREE_PATH" || true


### PR DESCRIPTION
Follow-up to #283. Orca runs lifecycle hooks with a non-login GUI PATH where the npm shim is often absent, so the archive hook's `npm exec obsidian-e2e -- stop` could fail and be silently swallowed by `|| true`, leaking the worktree's Obsidian process tree and /tmp profile.

The hook now calls the worktree-local `node_modules/.bin/obsidian-e2e` directly. That launcher is POSIX sh and needs only `node`, which the existing `command -v node` guard already checks. Verified under a clean `env -i PATH=/usr/bin:/bin:<node dir>` environment: the bin resolves and performs the stop (dry-run).

Same fix already landed in quickadd (ca29a8a7) and metaedit after a Codex review flagged it there.

Housekeeping note: this commit was originally pushed to the #283 branch in a race with its merge (the push recreated the just-auto-deleted branch); that stray branch has been deleted and this PR carries the fix cleanly on master.