### PR TITLE
ci(release): bump toolkit pin for merge-subject fix + add validate recovery dispatch

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@68068d2b847ff8c870c0cea4b31ec9f16452a573 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
     with:
       plugin-name: podnotes
       package-manager: npm
@@ -50,7 +50,7 @@ jobs:
       target-sha: ${{ github.event.workflow_run.head_sha || inputs.targetSha }}
       release-bot-app-slug: podnotes-release-bot
       app-id: ${{ vars.RELEASE_APP_ID }}
-      workflows-ref: 68068d2b847ff8c870c0cea4b31ec9f16452a573 # v3
+      workflows-ref: d7dad49d7e0f147d484a05d1049354406169fd97 # v3
       # dry-run: true   # plan only; skip opening the PR (smoke test)
     secrets:
       release-app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -12,6 +12,16 @@ name: Trigger release
 on:
   pull_request_target:
     types: [closed]
+  # Recovery path: re-run forensic validation for an already-merged release PR
+  # (e.g. after a toolkit pin bump fixes a validation bug). The reusable
+  # workflow re-derives everything from the PR number and fails closed, so a
+  # bad number cannot dispatch a release.
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Merged release PR number to re-validate"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -22,16 +32,17 @@ concurrency:
 jobs:
   validate:
     if: >-
-      github.event.pull_request.merged == true &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'master' &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      startsWith(github.event.pull_request.head.ref, 'release/'))
     permissions:
       actions: write
       contents: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@68068d2b847ff8c870c0cea4b31ec9f16452a573 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
     with:
-      pr-number: ${{ github.event.pull_request.number }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
       plugin-name: podnotes
       package-manager: npm
       default-branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@68068d2b847ff8c870c0cea4b31ec9f16452a573 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
     with:
       release-pr: ${{ inputs.releasePr }}
       plugin-name: podnotes
@@ -48,7 +48,7 @@ jobs:
       setup-python: true
       python-version: "3.x"
       docs-requirements: docs/requirements.txt
-      workflows-ref: 68068d2b847ff8c870c0cea4b31ec9f16452a573 # v3
+      workflows-ref: d7dad49d7e0f147d484a05d1049354406169fd97 # v3
     secrets:
       # Optional: unset secrets resolve to '' and the notify job skips them.
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Two things to recover release 2.19.3 (PR #291, merged but failed post-merge validation):

1. **Pin bump** to `obsidian-plugin-workflows@d7dad49` (v3), restoring the bare-generated-title acceptance this repo already had at 2.18.1 (b2a1ea6) and lost in the shared-pipeline extraction. Upstream fix: chhoumann/obsidian-plugin-workflows#8.
2. **Recovery dispatch** on the trigger stub: `workflow_dispatch` with a `pr-number` input, so the already-merged #291 can be re-validated. The reusable validate workflow re-derives all provenance from the PR number and fails closed, so this adds no authority a merged-PR event didn't have.

After merge: `gh workflow run release-trigger.yml -f pr-number=291` resumes 2.19.3.