### PR TITLE
ci(release): bump shared pipeline to v3

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@8471ad7827fcee306ac2b8c10e984e57aeefe7df # v3
     with:
       plugin-name: podnotes
       package-manager: npm
@@ -50,7 +50,7 @@ jobs:
       target-sha: ${{ github.event.workflow_run.head_sha || inputs.targetSha }}
       release-bot-app-slug: podnotes-release-bot
       app-id: ${{ vars.RELEASE_APP_ID }}
-      workflows-ref: d7dad49d7e0f147d484a05d1049354406169fd97 # v3
+      workflows-ref: 8471ad7827fcee306ac2b8c10e984e57aeefe7df # v3
       # dry-run: true   # plan only; skip opening the PR (smoke test)
     secrets:
       release-app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -40,7 +40,7 @@ jobs:
       actions: write
       contents: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@8471ad7827fcee306ac2b8c10e984e57aeefe7df # v3
     with:
       pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
       plugin-name: podnotes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@d7dad49d7e0f147d484a05d1049354406169fd97 # v3
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@8471ad7827fcee306ac2b8c10e984e57aeefe7df # v3
     with:
       release-pr: ${{ inputs.releasePr }}
       plugin-name: podnotes
@@ -48,7 +48,7 @@ jobs:
       setup-python: true
       python-version: "3.x"
       docs-requirements: docs/requirements.txt
-      workflows-ref: d7dad49d7e0f147d484a05d1049354406169fd97 # v3
+      workflows-ref: 8471ad7827fcee306ac2b8c10e984e57aeefe7df # v3
     secrets:
       # Optional: unset secrets resolve to '' and the notify job skips them.
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Bumps the shared release-pipeline SHA pins in the three release stubs
(`release-prepare.yml`, `release-trigger.yml`, `release.yml`) from
`d7dad49d7e0f147d484a05d1049354406169fd97` to
`8471ad7827fcee306ac2b8c10e984e57aeefe7df`, the commit behind the new `v3` tag of
[`chhoumann/obsidian-plugin-workflows`](https://github.com/chhoumann/obsidian-plugin-workflows).
The `# v3` trailing comments are preserved. SHA-pinning is deliberate here and is
kept intact (every `uses:` and `workflows-ref:` occurrence).

## Why - what v3 brings

- **feat!**: stop cutting releases for chore-only commits
- **fix**: handle bare release merge subjects
- **fix**: retry the tag-verify read after `createRef`, closing the tag-verify
  replication race that hit 2 of the first 3 production releases

## Behavior change

A commit range containing only `chore` commits will no longer produce a standing
release PR. This is intended - see
[chhoumann/obsidian-plugin-workflows#4](https://github.com/chhoumann/obsidian-plugin-workflows/issues/4).

## Validation

- YAML parses (PyYAML `safe_load`)
- `actionlint` clean on all three stubs