### PR TITLE
ci(release): bump shared pipeline to v4 (#20)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@b209e4363280e632c36da5e58939a20ebe39784d # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
     with:
       plugin-name: podnotes
       package-manager: npm

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -40,7 +40,7 @@ jobs:
       actions: write
       contents: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@b209e4363280e632c36da5e58939a20ebe39784d # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
     with:
       pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
       plugin-name: podnotes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@b209e4363280e632c36da5e58939a20ebe39784d # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
     with:
       release-pr: ${{ inputs.releasePr }}
       plugin-name: podnotes


### PR DESCRIPTION
## What

Bumps the three release caller stubs (`release-prepare.yml`, `release-trigger.yml`, `release.yml`) from the toolkit pin `b209e43` (#18) to `69b85e5`, the current `v4` tag. SHA pinning with the `# v4` marker is preserved.

## Why

The shared toolkit `chhoumann/obsidian-plugin-workflows` advanced the `v4` tag to `69b85e5`. PodNotes was two commits behind and missing:

- **#20 `fix(release): close superseded old-version release PRs`** - stage-1 `release-prepare` now supersedes any old-version bot-authored release PR it replaces (comments `Superseded by release PR #N`, closes it, and deletes its `release/<version>` branch). It warns-and-skips non-bot PRs in the `release/*` namespace and fails the run loudly if a bot release branch's tip commit is not machine-generated.
- **#19 `fix(templates): scope dependabot npm commits for the release policy`**.

## Notes

- No change to the pinned `release-policy` or any per-repo input (`plugin-name`, `package-manager`, `default-branch`, `release-bot-app-slug`, CI workflow name `Test`).
- Diff is three one-line pin changes.

Draft; do not merge without maintainer review.