### PR TITLE
ci(release): bump shared pipeline to v4

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
     with:
       plugin-name: podnotes
       package-manager: npm

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -40,7 +40,7 @@ jobs:
       actions: write
       contents: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
     with:
       pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
       plugin-name: podnotes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
-    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@69b85e58a8158cacf55e3f1ac8e2790e4e33c8c0 # v4
+    uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
     with:
       release-pr: ${{ inputs.releasePr }}
       plugin-name: podnotes


### PR DESCRIPTION
Bumps the three release stubs to obsidian-plugin-workflows `ebcf84b80dc48ba15e0eec1f3575d41519a78ed5` (current `v4`).

Picks up chhoumann/obsidian-plugin-workflows#21: the standing release PR body now embeds the digest-verified release notes above the provenance marker (with commit-derived HTML escaped), and marker extraction in validate/release requires exactly one match. No inputs or secrets changed.